### PR TITLE
feat: filesystem storage layer

### DIFF
--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,0 +1,159 @@
+package storage
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/oobagi/notebook/internal/model"
+)
+
+// Store manages notebooks and notes on the local filesystem.
+// Notes are stored as plain .md files in notebook directories.
+type Store struct {
+	Root string
+}
+
+// New creates a Store rooted at the given directory.
+// The root directory is created if it does not exist.
+func New(root string) (*Store, error) {
+	if err := os.MkdirAll(root, 0755); err != nil {
+		return nil, fmt.Errorf("create storage root: %w", err)
+	}
+	return &Store{Root: root}, nil
+}
+
+// DefaultRoot returns the default storage path (~/.notebook).
+func DefaultRoot() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".notebook")
+}
+
+// CreateNotebook creates a new notebook directory.
+func (s *Store) CreateNotebook(name string) error {
+	path := filepath.Join(s.Root, name)
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return fmt.Errorf("create notebook %q: %w", name, err)
+	}
+	return nil
+}
+
+// CreateNote creates a new note in a notebook. The notebook directory
+// is auto-created if it does not exist.
+func (s *Store) CreateNote(notebook, name, content string) error {
+	dir := filepath.Join(s.Root, notebook)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create notebook dir %q: %w", notebook, err)
+	}
+	path := s.notePath(notebook, name)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		return fmt.Errorf("write note %q: %w", name, err)
+	}
+	return nil
+}
+
+// GetNote reads a note from disk and returns it with metadata.
+func (s *Store) GetNote(notebook, name string) (model.Note, error) {
+	path := s.notePath(notebook, name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return model.Note{}, fmt.Errorf("read note %q: %w", name, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return model.Note{}, fmt.Errorf("stat note %q: %w", name, err)
+	}
+	return model.Note{
+		Name:      name,
+		Notebook:  notebook,
+		Content:   string(data),
+		UpdatedAt: info.ModTime(),
+	}, nil
+}
+
+// UpdateNote overwrites the content of an existing note.
+func (s *Store) UpdateNote(notebook, name, content string) error {
+	path := s.notePath(notebook, name)
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("note %q not found: %w", name, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		return fmt.Errorf("write note %q: %w", name, err)
+	}
+	return nil
+}
+
+// DeleteNote removes a single note file.
+func (s *Store) DeleteNote(notebook, name string) error {
+	path := s.notePath(notebook, name)
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("delete note %q: %w", name, err)
+	}
+	return nil
+}
+
+// DeleteNotebook removes a notebook directory and all its notes.
+func (s *Store) DeleteNotebook(name string) error {
+	path := filepath.Join(s.Root, name)
+	if err := os.RemoveAll(path); err != nil {
+		return fmt.Errorf("delete notebook %q: %w", name, err)
+	}
+	return nil
+}
+
+// ListNotebooks returns the names of all notebook directories.
+func (s *Store) ListNotebooks() ([]string, error) {
+	entries, err := os.ReadDir(s.Root)
+	if err != nil {
+		return nil, fmt.Errorf("list notebooks: %w", err)
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	return names, nil
+}
+
+// ListNotes returns the names of all notes in a notebook (without .md extension).
+func (s *Store) ListNotes(notebook string) ([]string, error) {
+	dir := filepath.Join(s.Root, notebook)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("list notes in %q: %w", notebook, err)
+	}
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") {
+			names = append(names, strings.TrimSuffix(e.Name(), ".md"))
+		}
+	}
+	return names, nil
+}
+
+// NoteCount returns the number of notes in a notebook.
+func (s *Store) NoteCount(notebook string) (int, error) {
+	notes, err := s.ListNotes(notebook)
+	if err != nil {
+		return 0, err
+	}
+	return len(notes), nil
+}
+
+// NotebookExists returns true if the notebook directory exists.
+func (s *Store) NotebookExists(name string) bool {
+	info, err := os.Stat(filepath.Join(s.Root, name))
+	return err == nil && info.IsDir()
+}
+
+// NoteExists returns true if the note file exists.
+func (s *Store) NoteExists(notebook, name string) bool {
+	_, err := os.Stat(s.notePath(notebook, name))
+	return err == nil
+}
+
+func (s *Store) notePath(notebook, name string) string {
+	return filepath.Join(s.Root, notebook, name+".md")
+}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -1,0 +1,235 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	return s
+}
+
+func TestCreateAndListNotebooks(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateNotebook("work"); err != nil {
+		t.Fatalf("CreateNotebook: %v", err)
+	}
+	if err := s.CreateNotebook("personal"); err != nil {
+		t.Fatalf("CreateNotebook: %v", err)
+	}
+
+	names, err := s.ListNotebooks()
+	if err != nil {
+		t.Fatalf("ListNotebooks: %v", err)
+	}
+	if len(names) != 2 {
+		t.Fatalf("expected 2 notebooks, got %d", len(names))
+	}
+}
+
+func TestCreateNoteAutoCreatesNotebook(t *testing.T) {
+	s := newTestStore(t)
+
+	// Create a note in a notebook that doesn't exist yet
+	err := s.CreateNote("ideas", "shower-thought", "# Great Idea\n\nThis is brilliant.")
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	// Notebook should now exist
+	if !s.NotebookExists("ideas") {
+		t.Error("expected notebook 'ideas' to be auto-created")
+	}
+
+	// Note should exist as a .md file
+	path := filepath.Join(s.Root, "ideas", "shower-thought.md")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected note file to exist at %s", path)
+	}
+}
+
+func TestGetNote(t *testing.T) {
+	s := newTestStore(t)
+
+	content := "# Meeting Notes\n\nDiscussed the roadmap."
+	if err := s.CreateNote("work", "meeting", content); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	note, err := s.GetNote("work", "meeting")
+	if err != nil {
+		t.Fatalf("GetNote: %v", err)
+	}
+	if note.Name != "meeting" {
+		t.Errorf("expected Name 'meeting', got %q", note.Name)
+	}
+	if note.Notebook != "work" {
+		t.Errorf("expected Notebook 'work', got %q", note.Notebook)
+	}
+	if note.Content != content {
+		t.Errorf("content mismatch: got %q", note.Content)
+	}
+	if note.UpdatedAt.IsZero() {
+		t.Error("expected non-zero UpdatedAt")
+	}
+}
+
+func TestUpdateNote(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateNote("work", "draft", "initial"); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	if err := s.UpdateNote("work", "draft", "updated content"); err != nil {
+		t.Fatalf("UpdateNote: %v", err)
+	}
+
+	note, err := s.GetNote("work", "draft")
+	if err != nil {
+		t.Fatalf("GetNote: %v", err)
+	}
+	if note.Content != "updated content" {
+		t.Errorf("expected updated content, got %q", note.Content)
+	}
+}
+
+func TestUpdateNoteNotFound(t *testing.T) {
+	s := newTestStore(t)
+
+	err := s.UpdateNote("work", "nonexistent", "content")
+	if err == nil {
+		t.Error("expected error for nonexistent note")
+	}
+}
+
+func TestDeleteNote(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateNote("work", "temp", "temporary"); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+	if err := s.DeleteNote("work", "temp"); err != nil {
+		t.Fatalf("DeleteNote: %v", err)
+	}
+	if s.NoteExists("work", "temp") {
+		t.Error("expected note to be deleted")
+	}
+}
+
+func TestDeleteNotebook(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateNote("scratch", "note1", "content1"); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+	if err := s.CreateNote("scratch", "note2", "content2"); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+	if err := s.DeleteNotebook("scratch"); err != nil {
+		t.Fatalf("DeleteNotebook: %v", err)
+	}
+	if s.NotebookExists("scratch") {
+		t.Error("expected notebook to be deleted")
+	}
+}
+
+func TestListNotes(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateNote("journal", "day1", "Day 1"); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+	if err := s.CreateNote("journal", "day2", "Day 2"); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	notes, err := s.ListNotes("journal")
+	if err != nil {
+		t.Fatalf("ListNotes: %v", err)
+	}
+	if len(notes) != 2 {
+		t.Fatalf("expected 2 notes, got %d", len(notes))
+	}
+}
+
+func TestNoteCount(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateNotebook("empty"); err != nil {
+		t.Fatalf("CreateNotebook: %v", err)
+	}
+	count, err := s.NoteCount("empty")
+	if err != nil {
+		t.Fatalf("NoteCount: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 notes, got %d", count)
+	}
+
+	if err := s.CreateNote("empty", "first", "content"); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+	count, err = s.NoteCount("empty")
+	if err != nil {
+		t.Fatalf("NoteCount: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 note, got %d", count)
+	}
+}
+
+func TestNotebookAndNoteExist(t *testing.T) {
+	s := newTestStore(t)
+
+	if s.NotebookExists("nope") {
+		t.Error("expected notebook to not exist")
+	}
+	if s.NoteExists("nope", "nope") {
+		t.Error("expected note to not exist")
+	}
+
+	if err := s.CreateNote("real", "note", "content"); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+	if !s.NotebookExists("real") {
+		t.Error("expected notebook to exist")
+	}
+	if !s.NoteExists("real", "note") {
+		t.Error("expected note to exist")
+	}
+}
+
+func TestListNotesIgnoresNonMarkdown(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateNotebook("mixed"); err != nil {
+		t.Fatalf("CreateNotebook: %v", err)
+	}
+	// Create a .md file and a non-.md file
+	if err := s.CreateNote("mixed", "real-note", "content"); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+	nonMd := filepath.Join(s.Root, "mixed", "config.json")
+	if err := os.WriteFile(nonMd, []byte("{}"), 0644); err != nil {
+		t.Fatalf("write non-md file: %v", err)
+	}
+
+	notes, err := s.ListNotes("mixed")
+	if err != nil {
+		t.Fatalf("ListNotes: %v", err)
+	}
+	if len(notes) != 1 {
+		t.Errorf("expected 1 note (ignoring .json), got %d", len(notes))
+	}
+	if notes[0] != "real-note" {
+		t.Errorf("expected 'real-note', got %q", notes[0])
+	}
+}


### PR DESCRIPTION
## Summary
- Implement `internal/storage` package with full CRUD for notebooks and notes
- Notes stored as plain `.md` files in `~/.notebook/<book>/<note>.md`
- Auto-creates notebook directories when creating notes
- 11 tests covering all operations

Closes #2

## Test plan
- [x] `go test ./internal/storage/...` — 11 tests pass
- [x] Auto-creation of notebook dirs verified
- [x] Non-.md files ignored in ListNotes

🤖 Generated with [Claude Code](https://claude.com/claude-code)