### PR TITLE
feat: CLI framework with Cobra

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:     "delete <name>",
+	Aliases: []string{"rm"},
+	Short:   "Delete a notebook",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Implementation in issue #7
+		fmt.Printf("  ✗ Not implemented yet\n")
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(deleteCmd)
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all notebooks",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Implementation in issue #5
+		fmt.Println("  No books yet.")
+		fmt.Println()
+		fmt.Println("  Create one with:  notebook new \"My First Book\"")
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var newCmd = &cobra.Command{
+	Use:   "new <name>",
+	Short: "Create a new notebook",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Implementation in issue #4
+		fmt.Printf("  ✓ Created \"%s\"\n", args[0])
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(newCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,14 +1,22 @@
 package cmd
 
 import (
+	"github.com/oobagi/notebook/internal/storage"
 	"github.com/spf13/cobra"
 )
 
+var storageDir string
+
 var rootCmd = &cobra.Command{
 	SilenceErrors: true,
-	Use:   "notebook",
-	Short: "A dead-simple CLI note manager with live markdown preview",
-	Long:  "Notebook is a CLI tool for managing markdown notes organized into notebooks, with a live-preview editor mode right in your terminal.",
+	SilenceUsage:  true,
+	Use:           "notebook",
+	Short:         "A dead-simple CLI note manager with live markdown preview",
+	Long:          "Notebook is a CLI tool for managing markdown notes organized into notebooks, with a live-preview editor mode right in your terminal.",
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&storageDir, "dir", storage.DefaultRoot(), "storage directory for notebooks")
 }
 
 // Execute runs the root command.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -13,8 +14,39 @@ func TestRootCommandExists(t *testing.T) {
 	}
 }
 
+func TestRootHasSubcommands(t *testing.T) {
+	expected := []string{"version", "list", "new", "delete", "search"}
+	commands := rootCmd.Commands()
+
+	found := make(map[string]bool)
+	for _, c := range commands {
+		found[c.Name()] = true
+	}
+
+	for _, name := range expected {
+		if !found[name] {
+			t.Errorf("expected subcommand %q to be registered", name)
+		}
+	}
+}
+
+func TestDirFlagExists(t *testing.T) {
+	flag := rootCmd.PersistentFlags().Lookup("dir")
+	if flag == nil {
+		t.Fatal("expected --dir persistent flag to exist")
+	}
+}
+
+func TestVersionCommand(t *testing.T) {
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"version"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("version command error: %v", err)
+	}
+}
+
 func TestExecuteReturnsNoError(t *testing.T) {
-	// Execute with no args should print help and return nil
 	rootCmd.SetArgs([]string{})
 	if err := Execute(); err != nil {
 		t.Errorf("Execute() returned unexpected error: %v", err)

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var searchCmd = &cobra.Command{
+	Use:   "search <query>",
+	Short: "Search across all notebooks",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Implementation in issue #12
+		fmt.Printf("  ✗ Not implemented yet\n")
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(searchCmd)
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Version is set at build time via ldflags.
+var Version = "dev"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("notebook %s\n", Version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
## Summary
- Root command with `--dir` persistent flag for custom storage path
- `version` subcommand (build-time via ldflags)
- Scaffolded `list`, `new`, `delete` (aliased `rm`), `search` subcommands with stub implementations
- 5 tests for command structure

Closes #3

## Test plan
- [x] `notebook --help` shows all subcommands
- [x] `notebook version` prints version
- [x] `--dir` flag available on all subcommands
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)