### PR TITLE
feat: notebook new and noun-verb dispatcher

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -9,12 +9,62 @@ import (
 var newCmd = &cobra.Command{
 	Use:   "new <name>",
 	Short: "Create a new notebook",
-	Args:  cobra.ExactArgs(1),
+	Long: `Create a new notebook.
+
+Examples:
+  notebook new "Work"              Create a notebook called Work
+  notebook new "Personal Journal"  Create a notebook with spaces in the name`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Implementation in issue #4
-		fmt.Printf("  ✓ Created \"%s\"\n", args[0])
+		name := args[0]
+		if !validName(name) {
+			return invalidNameError(name)
+		}
+
+		store, err := getStore()
+		if err != nil {
+			return err
+		}
+
+		if store.NotebookExists(name) {
+			return fmt.Errorf("notebook %q already exists", name)
+		}
+
+		if err := store.CreateNotebook(name); err != nil {
+			return err
+		}
+
+		fmt.Printf("  ✓ Created \"%s\"\n", name)
 		return nil
 	},
+}
+
+// newNoteCmd handles: notebook <book> new <note-title>
+// This is registered dynamically by the notebook subcommand dispatcher.
+func runNewNote(book string, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("usage: notebook %s new <note-title>", book)
+	}
+	name := args[0]
+	if !validName(name) {
+		return invalidNameError(name)
+	}
+
+	store, err := getStore()
+	if err != nil {
+		return err
+	}
+
+	if store.NoteExists(book, name) {
+		return fmt.Errorf("note %q already exists in %q", name, book)
+	}
+
+	if err := store.CreateNote(book, name, ""); err != nil {
+		return err
+	}
+
+	fmt.Printf("  ✓ Created \"%s\" in %s\n", name, book)
+	return nil
 }
 
 func init() {

--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func setupTestDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	storageDir = dir
+	return dir
+}
+
+func TestNewNotebook(t *testing.T) {
+	dir := setupTestDir(t)
+	rootCmd.SetArgs([]string{"new", "work"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("new notebook: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "work")); err != nil {
+		t.Error("expected work directory to exist")
+	}
+}
+
+func TestNewNotebookAlreadyExists(t *testing.T) {
+	setupTestDir(t)
+	rootCmd.SetArgs([]string{"new", "work"})
+	_ = rootCmd.Execute()
+
+	rootCmd.SetArgs([]string{"new", "work"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("expected error for duplicate notebook")
+	}
+}
+
+func TestNewNotebookInvalidName(t *testing.T) {
+	setupTestDir(t)
+	rootCmd.SetArgs([]string{"new", "../escape"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("expected error for invalid name")
+	}
+}
+
+func TestNewNoteViaNounVerb(t *testing.T) {
+	dir := setupTestDir(t)
+	// First create the notebook
+	rootCmd.SetArgs([]string{"new", "ideas"})
+	_ = rootCmd.Execute()
+
+	// Then create a note via noun-verb: notebook ideas new "shower thought"
+	rootCmd.SetArgs([]string{"ideas", "new", "shower thought"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("new note via noun-verb: %v", err)
+	}
+	path := filepath.Join(dir, "ideas", "shower thought.md")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected note file at %s", path)
+	}
+}
+
+func TestNewNoteAutoCreatesNotebook(t *testing.T) {
+	dir := setupTestDir(t)
+	// Create note in non-existent notebook
+	rootCmd.SetArgs([]string{"fresh-book", "new", "first note"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("new note with auto-create: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "fresh-book")); err != nil {
+		t.Error("expected auto-created notebook directory")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "fresh-book", "first note.md")); err != nil {
+		t.Error("expected note file to exist")
+	}
+}

--- a/cmd/notebook_cmd.go
+++ b/cmd/notebook_cmd.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// notebookSubcommands maps verb names to handler functions.
+// Each handler receives the book name and remaining args.
+var notebookSubcommands = map[string]func(book string, args []string) error{
+	"new": runNewNote,
+	// "list", "delete", "search" handlers added in their respective files
+}
+
+// registerNotebookVerb registers a verb that can be used in the
+// `notebook <book> <verb> [args]` pattern.
+func registerNotebookVerb(verb string, fn func(book string, args []string) error) {
+	notebookSubcommands[verb] = fn
+}
+
+// knownSubcommands returns the set of top-level subcommand names
+// so the dispatcher can distinguish `notebook list` from `notebook mybook`.
+func knownSubcommands() map[string]bool {
+	names := make(map[string]bool)
+	for _, c := range rootCmd.Commands() {
+		names[c.Name()] = true
+		for _, alias := range c.Aliases {
+			names[alias] = true
+		}
+	}
+	// Also include built-in names
+	names["help"] = true
+	names["completion"] = true
+	return names
+}
+
+func init() {
+	// Override the root command's RunE to handle dynamic book routing.
+	// When args don't match a known subcommand, treat the first arg as a
+	// notebook name and dispatch based on subsequent args.
+	rootCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return cmd.Help()
+		}
+
+		book := args[0]
+		known := knownSubcommands()
+		if known[book] {
+			// This shouldn't happen — Cobra routes known subcommands.
+			// But just in case, show help.
+			return cmd.Help()
+		}
+
+		if !validName(book) {
+			return invalidNameError(book)
+		}
+
+		// notebook <book> — with no verb, view/browse the notebook
+		if len(args) == 1 {
+			// For now, show notes in the notebook (list behavior)
+			return runNotebookList(book)
+		}
+
+		// notebook <book> <verb> [args...]
+		verb := args[1]
+		if handler, ok := notebookSubcommands[verb]; ok {
+			return handler(book, args[2:])
+		}
+
+		// notebook <book> <note> [verb] — two-level resource
+		note := args[1]
+		if !validName(note) {
+			return invalidNameError(note)
+		}
+
+		if len(args) == 2 {
+			// notebook <book> <note> — view the note
+			return runViewNote(book, note)
+		}
+
+		// notebook <book> <note> <verb>
+		noteVerb := args[2]
+		switch noteVerb {
+		case "edit":
+			return fmt.Errorf("editor not yet implemented (coming in Phase 3)")
+		case "delete", "rm":
+			return runDeleteNote(book, note)
+		case "copy":
+			return fmt.Errorf("clipboard copy not yet implemented (coming in Phase 5)")
+		default:
+			return fmt.Errorf("unknown command %q — try: edit, delete, copy", noteVerb)
+		}
+	}
+
+	// Allow arbitrary args on root for the dynamic routing
+	rootCmd.Args = cobra.ArbitraryArgs
+
+	// Disable Cobra's built-in subcommand suggestions for the root
+	// so it doesn't confuse book names with typos of subcommands
+	rootCmd.DisableSuggestions = true
+}
+
+// runNotebookList lists notes in a notebook. Stub until issue #5.
+func runNotebookList(book string) error {
+	store, err := getStore()
+	if err != nil {
+		return err
+	}
+	if !store.NotebookExists(book) {
+		return fmt.Errorf("notebook %q not found", book)
+	}
+	notes, err := store.ListNotes(book)
+	if err != nil {
+		return err
+	}
+	if len(notes) == 0 {
+		fmt.Println("  No notes yet.")
+		fmt.Println()
+		fmt.Printf("  Create one with:  notebook %s new \"My First Note\"\n", book)
+		return nil
+	}
+	for _, n := range notes {
+		fmt.Printf("  %s\n", n)
+	}
+	return nil
+}
+
+// runViewNote views a note. Stub until issue #6.
+func runViewNote(book, note string) error {
+	store, err := getStore()
+	if err != nil {
+		return err
+	}
+	n, err := store.GetNote(book, note)
+	if err != nil {
+		return fmt.Errorf("note %q not found in %q", note, book)
+	}
+	fmt.Print(n.Content)
+	if len(n.Content) > 0 && !strings.HasSuffix(n.Content, "\n") {
+		fmt.Println()
+	}
+	return nil
+}
+
+// runDeleteNote deletes a note. Stub until issue #7.
+func runDeleteNote(book, note string) error {
+	store, err := getStore()
+	if err != nil {
+		return err
+	}
+	if !store.NoteExists(book, note) {
+		return fmt.Errorf("note %q not found in %q", note, book)
+	}
+	if err := store.DeleteNote(book, note); err != nil {
+		return err
+	}
+	fmt.Printf("  ✓ Deleted \"%s\" from %s\n", note, book)
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+	"regexp"
+
 	"github.com/oobagi/notebook/internal/storage"
 	"github.com/spf13/cobra"
 )
@@ -17,6 +20,22 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&storageDir, "dir", storage.DefaultRoot(), "storage directory for notebooks")
+}
+
+// getStore creates a Store using the configured storage directory.
+func getStore() (*storage.Store, error) {
+	return storage.New(storageDir)
+}
+
+// validName checks that a name contains only safe characters.
+var validNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9 _-]*$`)
+
+func validName(name string) bool {
+	return validNamePattern.MatchString(name)
+}
+
+func invalidNameError(name string) error {
+	return fmt.Errorf("invalid name %q — use letters, numbers, hyphens, underscores, or spaces", name)
 }
 
 // Execute runs the root command.


### PR DESCRIPTION
## Summary
- `notebook new <name>` creates a notebook with name validation
- `notebook <book> new <note>` creates a note, auto-creates the notebook
- Dynamic dispatcher on root command routes noun-verb patterns (`notebook <book> <verb>`)
- Stubs wired for `<book>` (list notes), `<book> <note>` (view), `<note> delete`
- 5 tests covering create flows, duplicate detection, invalid names, auto-creation

Closes #4

## Test plan
- [x] `go test ./cmd/...` — 10 tests pass
- [x] `go vet ./...` clean
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)