### PR TITLE
feat: filesystem storage layer

### DIFF
--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,0 +1,214 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/oobagi/notebook/internal/model"
+)
+
+// ErrInvalidName is returned when a notebook or note name contains
+// path-traversal sequences or is otherwise unsafe for use as a filename.
+var ErrInvalidName = errors.New("invalid name")
+
+// validName rejects names that could escape the storage root via path
+// traversal or that are degenerate filesystem entries.
+func validName(name string) error {
+	if name == "" || name == "." {
+		return fmt.Errorf("%w: must not be empty or %q", ErrInvalidName, ".")
+	}
+	if strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
+		return fmt.Errorf("%w: %q contains path separator or traversal sequence", ErrInvalidName, name)
+	}
+	return nil
+}
+
+// Store manages notebook and note persistence on the filesystem.
+// Notes are stored as markdown files within notebook directories.
+// Layout: <root>/<notebook>/<note>.md
+type Store struct {
+	Root string
+}
+
+// NewStore creates a Store backed by the given root directory.
+func NewStore(root string) *Store {
+	return &Store{Root: root}
+}
+
+// notePath returns the full filesystem path for a note.
+func (s *Store) notePath(notebook, name string) string {
+	return filepath.Join(s.Root, notebook, name+".md")
+}
+
+// notebookPath returns the full filesystem path for a notebook directory.
+func (s *Store) notebookPath(name string) string {
+	return filepath.Join(s.Root, name)
+}
+
+// CreateNotebook creates a new notebook directory.
+func (s *Store) CreateNotebook(name string) error {
+	if err := validName(name); err != nil {
+		return err
+	}
+	dir := s.notebookPath(name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create notebook %q: %w", name, err)
+	}
+	return nil
+}
+
+// CreateNote writes a markdown file into the given notebook directory.
+// The notebook directory is created automatically if it does not exist.
+// It returns an error if a note with the same name already exists.
+func (s *Store) CreateNote(notebook, name, content string) error {
+	if err := validName(notebook); err != nil {
+		return err
+	}
+	if err := validName(name); err != nil {
+		return err
+	}
+
+	dir := s.notebookPath(notebook)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create notebook dir %q: %w", notebook, err)
+	}
+
+	p := s.notePath(notebook, name)
+	if _, err := os.Stat(p); err == nil {
+		return fmt.Errorf("note %q already exists in %q", name, notebook)
+	}
+
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("create note %q/%q: %w", notebook, name, err)
+	}
+	return nil
+}
+
+// GetNote reads a note from disk and populates all fields including
+// timestamps derived from os.Stat.
+func (s *Store) GetNote(notebook, name string) (model.Note, error) {
+	if err := validName(notebook); err != nil {
+		return model.Note{}, err
+	}
+	if err := validName(name); err != nil {
+		return model.Note{}, err
+	}
+	p := s.notePath(notebook, name)
+
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return model.Note{}, fmt.Errorf("get note %q/%q: %w", notebook, name, err)
+	}
+
+	info, err := os.Stat(p)
+	if err != nil {
+		return model.Note{}, fmt.Errorf("stat note %q/%q: %w", notebook, name, err)
+	}
+
+	return model.Note{
+		Name:      name,
+		Notebook:  notebook,
+		Content:   string(data),
+		CreatedAt: info.ModTime(), // best approximation; most filesystems lack birth time
+		UpdatedAt: info.ModTime(),
+	}, nil
+}
+
+// ListNotebooks returns the names of all notebook directories under the root.
+// If the root directory does not exist yet, it returns an empty slice.
+func (s *Store) ListNotebooks() ([]string, error) {
+	entries, err := os.ReadDir(s.Root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("list notebooks: %w", err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	return names, nil
+}
+
+// ListNotes returns all notes in a notebook with metadata populated from stat.
+func (s *Store) ListNotes(notebook string) ([]model.Note, error) {
+	if err := validName(notebook); err != nil {
+		return nil, err
+	}
+	dir := s.notebookPath(notebook)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("list notes in %q: %w", notebook, err)
+	}
+
+	var notes []model.Note
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+
+		name := strings.TrimSuffix(e.Name(), ".md")
+		note, err := s.GetNote(notebook, name)
+		if err != nil {
+			return nil, err
+		}
+		notes = append(notes, note)
+	}
+	return notes, nil
+}
+
+// DeleteNote removes a single note file.
+func (s *Store) DeleteNote(notebook, name string) error {
+	if err := validName(notebook); err != nil {
+		return err
+	}
+	if err := validName(name); err != nil {
+		return err
+	}
+	p := s.notePath(notebook, name)
+	if err := os.Remove(p); err != nil {
+		return fmt.Errorf("delete note %q/%q: %w", notebook, name, err)
+	}
+	return nil
+}
+
+// DeleteNotebook removes a notebook directory and all of its contents.
+func (s *Store) DeleteNotebook(name string) error {
+	if err := validName(name); err != nil {
+		return err
+	}
+	dir := s.notebookPath(name)
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("delete notebook %q: %w", name, err)
+	}
+	return nil
+}
+
+// UpdateNote overwrites the content of an existing note.
+func (s *Store) UpdateNote(notebook, name, content string) error {
+	if err := validName(notebook); err != nil {
+		return err
+	}
+	if err := validName(name); err != nil {
+		return err
+	}
+	p := s.notePath(notebook, name)
+
+	// Verify the file exists before overwriting.
+	if _, err := os.Stat(p); err != nil {
+		return fmt.Errorf("update note %q/%q: %w", notebook, name, err)
+	}
+
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("update note %q/%q: %w", notebook, name, err)
+	}
+	return nil
+}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -1,0 +1,451 @@
+package storage
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCreateNotebook(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	if err := store.CreateNotebook("work"); err != nil {
+		t.Fatalf("CreateNotebook: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(store.Root, "work"))
+	if err != nil {
+		t.Fatalf("notebook dir missing: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("notebook path is not a directory")
+	}
+}
+
+func TestCreateNotebookIdempotent(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	if err := store.CreateNotebook("work"); err != nil {
+		t.Fatalf("first CreateNotebook: %v", err)
+	}
+	if err := store.CreateNotebook("work"); err != nil {
+		t.Fatalf("second CreateNotebook should not fail: %v", err)
+	}
+}
+
+func TestCreateNoteAndGetNote(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	content := "# Hello\nThis is a test note."
+	if err := store.CreateNote("journal", "day1", content); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	note, err := store.GetNote("journal", "day1")
+	if err != nil {
+		t.Fatalf("GetNote: %v", err)
+	}
+
+	if note.Name != "day1" {
+		t.Errorf("Name = %q, want %q", note.Name, "day1")
+	}
+	if note.Notebook != "journal" {
+		t.Errorf("Notebook = %q, want %q", note.Notebook, "journal")
+	}
+	if note.Content != content {
+		t.Errorf("Content = %q, want %q", note.Content, content)
+	}
+	if note.CreatedAt.IsZero() {
+		t.Error("CreatedAt is zero")
+	}
+	if note.UpdatedAt.IsZero() {
+		t.Error("UpdatedAt is zero")
+	}
+}
+
+func TestCreateNoteAutoCreatesNotebook(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	// Notebook directory does not exist yet.
+	if err := store.CreateNote("ideas", "spark", "an idea"); err != nil {
+		t.Fatalf("CreateNote with auto-create: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(store.Root, "ideas"))
+	if err != nil {
+		t.Fatalf("notebook dir not auto-created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("notebook path is not a directory")
+	}
+}
+
+func TestNoteStoredAsMdFile(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	if err := store.CreateNote("work", "todo", "buy milk"); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	expected := filepath.Join(store.Root, "work", "todo.md")
+	if _, err := os.Stat(expected); err != nil {
+		t.Fatalf("expected file %q not found: %v", expected, err)
+	}
+}
+
+func TestGetNoteNotFound(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	_, err := store.GetNote("ghost", "missing")
+	if err == nil {
+		t.Fatal("expected error for non-existent note, got nil")
+	}
+}
+
+func TestListNotebooks(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		if err := store.CreateNotebook(name); err != nil {
+			t.Fatalf("CreateNotebook(%q): %v", name, err)
+		}
+	}
+
+	notebooks, err := store.ListNotebooks()
+	if err != nil {
+		t.Fatalf("ListNotebooks: %v", err)
+	}
+
+	if len(notebooks) != 3 {
+		t.Fatalf("got %d notebooks, want 3", len(notebooks))
+	}
+
+	want := map[string]bool{"alpha": true, "beta": true, "gamma": true}
+	for _, n := range notebooks {
+		if !want[n] {
+			t.Errorf("unexpected notebook %q", n)
+		}
+	}
+}
+
+func TestListNotebooksEmpty(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	notebooks, err := store.ListNotebooks()
+	if err != nil {
+		t.Fatalf("ListNotebooks: %v", err)
+	}
+	if len(notebooks) != 0 {
+		t.Fatalf("got %d notebooks, want 0", len(notebooks))
+	}
+}
+
+func TestListNotes(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	for _, name := range []string{"a", "b", "c"} {
+		if err := store.CreateNote("nb", name, "content of "+name); err != nil {
+			t.Fatalf("CreateNote(%q): %v", name, err)
+		}
+	}
+
+	notes, err := store.ListNotes("nb")
+	if err != nil {
+		t.Fatalf("ListNotes: %v", err)
+	}
+
+	if len(notes) != 3 {
+		t.Fatalf("got %d notes, want 3", len(notes))
+	}
+
+	found := map[string]bool{}
+	for _, n := range notes {
+		found[n.Name] = true
+		if n.Notebook != "nb" {
+			t.Errorf("note %q has Notebook=%q, want %q", n.Name, n.Notebook, "nb")
+		}
+	}
+	for _, name := range []string{"a", "b", "c"} {
+		if !found[name] {
+			t.Errorf("note %q not found in list", name)
+		}
+	}
+}
+
+func TestListNotesIgnoresNonMdFiles(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	if err := store.CreateNote("nb", "real", "content"); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	// Write a non-.md file directly.
+	bogus := filepath.Join(store.Root, "nb", "stray.txt")
+	if err := os.WriteFile(bogus, []byte("ignore me"), 0o644); err != nil {
+		t.Fatalf("write stray file: %v", err)
+	}
+
+	notes, err := store.ListNotes("nb")
+	if err != nil {
+		t.Fatalf("ListNotes: %v", err)
+	}
+	if len(notes) != 1 {
+		t.Fatalf("got %d notes, want 1 (non-.md should be ignored)", len(notes))
+	}
+	if notes[0].Name != "real" {
+		t.Errorf("Name = %q, want %q", notes[0].Name, "real")
+	}
+}
+
+func TestDeleteNote(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	if err := store.CreateNote("nb", "doomed", "bye"); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	if err := store.DeleteNote("nb", "doomed"); err != nil {
+		t.Fatalf("DeleteNote: %v", err)
+	}
+
+	_, err := store.GetNote("nb", "doomed")
+	if err == nil {
+		t.Fatal("expected error after delete, got nil")
+	}
+}
+
+func TestDeleteNoteNotFound(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	err := store.DeleteNote("ghost", "missing")
+	if err == nil {
+		t.Fatal("expected error for deleting non-existent note, got nil")
+	}
+}
+
+func TestDeleteNotebook(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	if err := store.CreateNote("nb", "n1", "one"); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+	if err := store.CreateNote("nb", "n2", "two"); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	if err := store.DeleteNotebook("nb"); err != nil {
+		t.Fatalf("DeleteNotebook: %v", err)
+	}
+
+	_, err := os.Stat(filepath.Join(store.Root, "nb"))
+	if !os.IsNotExist(err) {
+		t.Fatalf("notebook dir should be gone, stat err = %v", err)
+	}
+}
+
+func TestDeleteNotebookNotFound(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	// os.RemoveAll does not error on a missing path, so this should succeed.
+	if err := store.DeleteNotebook("nope"); err != nil {
+		t.Fatalf("DeleteNotebook on missing dir: %v", err)
+	}
+}
+
+func TestUpdateNote(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	if err := store.CreateNote("nb", "note", "v1"); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	if err := store.UpdateNote("nb", "note", "v2"); err != nil {
+		t.Fatalf("UpdateNote: %v", err)
+	}
+
+	note, err := store.GetNote("nb", "note")
+	if err != nil {
+		t.Fatalf("GetNote after update: %v", err)
+	}
+	if note.Content != "v2" {
+		t.Errorf("Content = %q, want %q", note.Content, "v2")
+	}
+}
+
+func TestUpdateNoteNotFound(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	err := store.UpdateNote("ghost", "missing", "data")
+	if err == nil {
+		t.Fatal("expected error updating non-existent note, got nil")
+	}
+}
+
+// --- Path traversal rejection tests ---
+
+func TestValidNameRejectsTraversal(t *testing.T) {
+	badNames := []string{
+		"",
+		".",
+		"..",
+		"../etc",
+		"foo/bar",
+		"foo\\bar",
+		"a..b",
+	}
+
+	for _, name := range badNames {
+		t.Run("name="+name, func(t *testing.T) {
+			err := validName(name)
+			if err == nil {
+				t.Fatalf("validName(%q) should have returned an error", name)
+			}
+			if !errors.Is(err, ErrInvalidName) {
+				t.Fatalf("error should wrap ErrInvalidName, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidNameAcceptsGoodNames(t *testing.T) {
+	goodNames := []string{
+		"work",
+		"my-notebook",
+		"day1",
+		"UPPER",
+		"with spaces",
+	}
+
+	for _, name := range goodNames {
+		t.Run("name="+name, func(t *testing.T) {
+			if err := validName(name); err != nil {
+				t.Fatalf("validName(%q) should succeed, got: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestCreateNotebookRejectsTraversal(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	for _, name := range []string{"..", "../escape", "a/b"} {
+		if err := store.CreateNotebook(name); err == nil {
+			t.Errorf("CreateNotebook(%q) should have failed", name)
+		}
+	}
+}
+
+func TestCreateNoteRejectsTraversal(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	// Bad notebook name
+	if err := store.CreateNote("../evil", "note", "x"); err == nil {
+		t.Error("CreateNote with traversal notebook name should fail")
+	}
+	// Bad note name
+	if err := store.CreateNote("good", "../evil", "x"); err == nil {
+		t.Error("CreateNote with traversal note name should fail")
+	}
+}
+
+func TestGetNoteRejectsTraversal(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	if _, err := store.GetNote("../evil", "note"); err == nil {
+		t.Error("GetNote with traversal notebook name should fail")
+	}
+	if _, err := store.GetNote("good", "../evil"); err == nil {
+		t.Error("GetNote with traversal note name should fail")
+	}
+}
+
+func TestDeleteNoteRejectsTraversal(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	if err := store.DeleteNote("../evil", "note"); err == nil {
+		t.Error("DeleteNote with traversal notebook name should fail")
+	}
+	if err := store.DeleteNote("good", "../evil"); err == nil {
+		t.Error("DeleteNote with traversal note name should fail")
+	}
+}
+
+func TestDeleteNotebookRejectsTraversal(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	if err := store.DeleteNotebook("../evil"); err == nil {
+		t.Error("DeleteNotebook with traversal name should fail")
+	}
+}
+
+func TestUpdateNoteRejectsTraversal(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	if err := store.UpdateNote("../evil", "note", "x"); err == nil {
+		t.Error("UpdateNote with traversal notebook name should fail")
+	}
+	if err := store.UpdateNote("good", "../evil", "x"); err == nil {
+		t.Error("UpdateNote with traversal note name should fail")
+	}
+}
+
+func TestListNotesRejectsTraversal(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	if _, err := store.ListNotes("../evil"); err == nil {
+		t.Error("ListNotes with traversal name should fail")
+	}
+}
+
+// --- Duplicate note rejection test ---
+
+func TestCreateNoteDuplicate(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	if err := store.CreateNote("nb", "dup", "first"); err != nil {
+		t.Fatalf("first CreateNote: %v", err)
+	}
+
+	err := store.CreateNote("nb", "dup", "second")
+	if err == nil {
+		t.Fatal("second CreateNote should fail for duplicate name")
+	}
+
+	// Verify original content is preserved.
+	note, err := store.GetNote("nb", "dup")
+	if err != nil {
+		t.Fatalf("GetNote after rejected duplicate: %v", err)
+	}
+	if note.Content != "first" {
+		t.Errorf("Content = %q, want %q (original should be preserved)", note.Content, "first")
+	}
+}
+
+// --- ListNotebooks with non-existent root ---
+
+func TestListNotebooksNonExistentRoot(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "does-not-exist"))
+
+	notebooks, err := store.ListNotebooks()
+	if err != nil {
+		t.Fatalf("ListNotebooks should return empty slice for missing root, got error: %v", err)
+	}
+	if notebooks == nil {
+		t.Fatal("ListNotebooks should return non-nil empty slice, got nil")
+	}
+	if len(notebooks) != 0 {
+		t.Fatalf("got %d notebooks, want 0", len(notebooks))
+	}
+}
+
+// --- ListNotes on non-existent notebook ---
+
+func TestListNotesNonExistentNotebook(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	_, err := store.ListNotes("nonexistent")
+	if err == nil {
+		t.Fatal("ListNotes on non-existent notebook should return an error")
+	}
+}


### PR DESCRIPTION
## Summary

- `Store` struct with configurable root path and full CRUD for notebooks/notes
- Auto-creates notebook directories when creating notes (`os.MkdirAll`)
- Path traversal protection — rejects names containing `/`, `\`, `..`
- `CreateNote` rejects duplicates (no silent overwrite)
- `ListNotebooks` gracefully handles missing root directory
- 28 tests covering all operations, edge cases, and security

Closes #2

## Test plan

- [x] 28 tests pass (`go test -v ./internal/storage/...`)
- [x] `go vet ./...` clean
- [x] Path traversal attacks rejected
- [x] Duplicate note creation rejected
- [x] Auto-creation verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)