### PR TITLE
feat: CLI framework with noun-verb dispatcher

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Show current configuration",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Fprintln(cmd.OutOrStdout(), "config: not implemented yet")
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete <name>",
+	Short: "Delete a notebook",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		if err := store.DeleteNotebook(name); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Deleted %q\n", name)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(deleteCmd)
+}

--- a/cmd/dispatcher.go
+++ b/cmd/dispatcher.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+// dispatch handles the noun-verb routing for commands like:
+//
+//	notebook <book>                    -> list notes in book
+//	notebook <book> list               -> list notes in book
+//	notebook <book> new "Title"        -> create note in book
+//	notebook <book> delete "Title"     -> delete note from book
+//	notebook <book> search "query"     -> search within book (stub)
+//	notebook <book> <note>             -> view note (stub)
+//	notebook <book> <note> edit        -> edit note (stub)
+//	notebook <book> <note> delete      -> delete note
+//	notebook <book> <note> copy        -> copy note (stub)
+func dispatch(cmd *cobra.Command, args []string) error {
+	w := cmd.OutOrStdout()
+	book := args[0]
+	rest := args[1:]
+
+	// notebook <book> — no further args: list notes in the book
+	if len(rest) == 0 {
+		return listNotesInBook(w, book)
+	}
+
+	// notebook <book> <verb> [args...]
+	second := rest[0]
+	switch second {
+	case "list":
+		return listNotesInBook(w, book)
+	case "new":
+		if len(rest) < 2 {
+			return fmt.Errorf("usage: notebook %s new <title>", book)
+		}
+		return createNoteInBook(w, book, rest[1])
+	case "delete":
+		if len(rest) < 2 {
+			return fmt.Errorf("usage: notebook %s delete <title>", book)
+		}
+		return deleteNoteFromBook(w, book, rest[1])
+	case "search":
+		if len(rest) < 2 {
+			return fmt.Errorf("usage: notebook %s search <query>", book)
+		}
+		return searchInBook(w, book, rest[1])
+	}
+
+	// second arg is not a book-level verb, so treat it as a note name
+	note := second
+	noteRest := rest[1:]
+
+	// notebook <book> <note> — no verb: view the note
+	if len(noteRest) == 0 {
+		return viewNote(w, book, note)
+	}
+
+	// notebook <book> <note> <verb>
+	verb := noteRest[0]
+	trailing := noteRest[1:]
+	switch verb {
+	case "edit", "delete", "copy":
+		if len(trailing) > 0 {
+			return fmt.Errorf("unexpected arguments after %q", verb)
+		}
+	}
+	switch verb {
+	case "edit":
+		return editNote(w, book, note)
+	case "delete":
+		return deleteNoteFromBook(w, book, note)
+	case "copy":
+		return copyNote(w, book, note)
+	default:
+		return fmt.Errorf("unknown command %q for note %q in %q", verb, note, book)
+	}
+}
+
+// --- Book-scoped operations ---
+
+func listNotesInBook(w io.Writer, book string) error {
+	notes, err := store.ListNotes(book)
+	if err != nil {
+		return fmt.Errorf("list notes in %q: %w", book, err)
+	}
+	for _, n := range notes {
+		fmt.Fprintln(w, n.Name)
+	}
+	return nil
+}
+
+func createNoteInBook(w io.Writer, book, title string) error {
+	if err := store.CreateNote(book, title, ""); err != nil {
+		return err
+	}
+	fmt.Fprintf(w, "Created %q in %s\n", title, book)
+	return nil
+}
+
+func deleteNoteFromBook(w io.Writer, book, note string) error {
+	if err := store.DeleteNote(book, note); err != nil {
+		return err
+	}
+	fmt.Fprintf(w, "Deleted %q from %s\n", note, book)
+	return nil
+}
+
+func searchInBook(w io.Writer, book, query string) error {
+	fmt.Fprintln(w, "search: not implemented yet")
+	return nil
+}
+
+// --- Note-scoped operations ---
+
+func viewNote(w io.Writer, book, note string) error {
+	fmt.Fprintln(w, "view: not implemented yet")
+	return nil
+}
+
+func editNote(w io.Writer, book, note string) error {
+	fmt.Fprintln(w, "edit: not implemented yet")
+	return nil
+}
+
+func copyNote(w io.Writer, book, note string) error {
+	fmt.Fprintln(w, "copy: not implemented yet")
+	return nil
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all notebooks",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		notebooks, err := store.ListNotebooks()
+		if err != nil {
+			return err
+		}
+		w := cmd.OutOrStdout()
+		for _, name := range notebooks {
+			fmt.Fprintln(w, name)
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var newCmd = &cobra.Command{
+	Use:   "new <name>",
+	Short: "Create a new notebook",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		if err := store.CreateNotebook(name); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Created %q\n", name)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(newCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,14 +1,49 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/oobagi/notebook/internal/storage"
 	"github.com/spf13/cobra"
+)
+
+var (
+	store   *storage.Store
+	dirFlag string
 )
 
 var rootCmd = &cobra.Command{
 	SilenceErrors: true,
-	Use:   "notebook",
-	Short: "A dead-simple CLI note manager with live markdown preview",
-	Long:  "Notebook is a CLI tool for managing markdown notes organized into notebooks, with a live-preview editor mode right in your terminal.",
+	SilenceUsage:  true,
+	Use:           "notebook",
+	Short:         "A dead-simple CLI note manager with live markdown preview",
+	Long:          "Notebook is a CLI tool for managing markdown notes organized into notebooks, with a live-preview editor mode right in your terminal.",
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		root := dirFlag
+		if root == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("resolve home directory: %w", err)
+			}
+			root = filepath.Join(home, ".notebook")
+		}
+		store = storage.NewStore(root)
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return cmd.Help()
+		}
+		return dispatch(cmd, args)
+	},
+	// Accept arbitrary args so the dispatcher can handle noun-verb routing.
+	Args: cobra.ArbitraryArgs,
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&dirFlag, "dir", "", "root directory for notebook storage (default ~/.notebook)")
 }
 
 // Execute runs the root command.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,7 +1,12 @@
 package cmd
 
 import (
+	"bytes"
+	"os"
+	"strings"
 	"testing"
+
+	"github.com/oobagi/notebook/internal/storage"
 )
 
 func TestRootCommandUseField(t *testing.T) {
@@ -16,8 +21,342 @@ func TestRootCommandSilenceErrors(t *testing.T) {
 	}
 }
 
-func TestExecuteReturnsNoError(t *testing.T) {
-	if err := Execute(); err != nil {
-		t.Errorf("Execute() returned unexpected error: %v", err)
+// setupTestStore creates a temporary store and configures the package-level
+// store variable. It returns the temp dir path.
+func setupTestStore(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	store = storage.NewStore(dir)
+	return dir
+}
+
+// executeCapture runs the root command with the given args and captures stdout.
+func executeCapture(args []string) (string, error) {
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	return buf.String(), err
+}
+
+// --- Flag tests ---
+
+func TestDirFlagRegistered(t *testing.T) {
+	f := rootCmd.PersistentFlags().Lookup("dir")
+	if f == nil {
+		t.Fatal("--dir flag not registered")
+	}
+	if f.DefValue != "" {
+		t.Errorf("--dir default should be empty string, got %q", f.DefValue)
+	}
+}
+
+func TestDirFlagDefaultsToHomeNotebook(t *testing.T) {
+	// Reset dirFlag to empty to simulate no --dir passed.
+	dirFlag = ""
+	rootCmd.SetArgs([]string{"version"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	home, _ := os.UserHomeDir()
+	if store == nil {
+		t.Fatal("store should be initialized after Execute")
+	}
+	if store.Root != home+"/.notebook" {
+		t.Errorf("store.Root = %q, want %q", store.Root, home+"/.notebook")
+	}
+}
+
+func TestDirFlagCustomPath(t *testing.T) {
+	dir := t.TempDir()
+	dirFlag = dir
+	rootCmd.SetArgs([]string{"version"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if store.Root != dir {
+		t.Errorf("store.Root = %q, want %q", store.Root, dir)
+	}
+	dirFlag = "" // reset
+}
+
+// --- Dispatcher routing tests ---
+
+func TestDispatchBookWithNoArgs(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNotebook("ideas")
+	_ = st.CreateNote("ideas", "spark", "content")
+
+	out, err := executeCapture([]string{"--dir", dir, "ideas"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "spark") {
+		t.Errorf("expected output to contain %q, got %q", "spark", out)
+	}
+}
+
+func TestDispatchBookList(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNotebook("work")
+	_ = st.CreateNote("work", "todo", "stuff")
+	_ = st.CreateNote("work", "meeting", "notes")
+
+	out, err := executeCapture([]string{"--dir", dir, "work", "list"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "todo") {
+		t.Errorf("expected %q in output, got %q", "todo", out)
+	}
+	if !strings.Contains(out, "meeting") {
+		t.Errorf("expected %q in output, got %q", "meeting", out)
+	}
+}
+
+func TestDispatchBookNew(t *testing.T) {
+	dir := setupTestStore(t)
+
+	out, err := executeCapture([]string{"--dir", dir, "journal", "new", "day1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "Created") {
+		t.Errorf("expected 'Created' in output, got %q", out)
+	}
+
+	// Verify the note was actually created.
+	st := storage.NewStore(dir)
+	note, err := st.GetNote("journal", "day1")
+	if err != nil {
+		t.Fatalf("note should exist: %v", err)
+	}
+	if note.Name != "day1" {
+		t.Errorf("note name = %q, want %q", note.Name, "day1")
+	}
+}
+
+func TestDispatchBookDelete(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNote("work", "temp", "data")
+
+	out, err := executeCapture([]string{"--dir", dir, "work", "delete", "temp"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "Deleted") {
+		t.Errorf("expected 'Deleted' in output, got %q", out)
+	}
+
+	// Verify the note is gone.
+	_, err = st.GetNote("work", "temp")
+	if err == nil {
+		t.Fatal("note should have been deleted")
+	}
+}
+
+func TestDispatchBookSearch(t *testing.T) {
+	dir := setupTestStore(t)
+
+	out, err := executeCapture([]string{"--dir", dir, "work", "search", "hello"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "not implemented") {
+		t.Errorf("expected stub message, got %q", out)
+	}
+}
+
+func TestDispatchNoteView(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNote("work", "readme", "# Hello")
+
+	out, err := executeCapture([]string{"--dir", dir, "work", "readme"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "not implemented") {
+		t.Errorf("expected stub message, got %q", out)
+	}
+}
+
+func TestDispatchNoteEdit(t *testing.T) {
+	dir := setupTestStore(t)
+
+	out, err := executeCapture([]string{"--dir", dir, "work", "readme", "edit"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "not implemented") {
+		t.Errorf("expected stub message, got %q", out)
+	}
+}
+
+func TestDispatchNoteDelete(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNote("work", "doomed", "bye")
+
+	out, err := executeCapture([]string{"--dir", dir, "work", "doomed", "delete"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "Deleted") {
+		t.Errorf("expected 'Deleted' in output, got %q", out)
+	}
+
+	_, err = st.GetNote("work", "doomed")
+	if err == nil {
+		t.Fatal("note should have been deleted")
+	}
+}
+
+func TestDispatchNoteCopy(t *testing.T) {
+	dir := setupTestStore(t)
+
+	out, err := executeCapture([]string{"--dir", dir, "work", "readme", "copy"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "not implemented") {
+		t.Errorf("expected stub message, got %q", out)
+	}
+}
+
+func TestDispatchUnknownNoteVerb(t *testing.T) {
+	dir := setupTestStore(t)
+
+	_, err := executeCapture([]string{"--dir", dir, "work", "readme", "frobnicate"})
+	if err == nil {
+		t.Fatal("expected error for unknown note verb")
+	}
+	if !strings.Contains(err.Error(), "unknown command") {
+		t.Errorf("expected 'unknown command' in error, got %q", err.Error())
+	}
+}
+
+func TestDispatchBookNewMissingTitle(t *testing.T) {
+	dir := setupTestStore(t)
+
+	_, err := executeCapture([]string{"--dir", dir, "work", "new"})
+	if err == nil {
+		t.Fatal("expected error when note title is missing")
+	}
+}
+
+func TestDispatchBookDeleteMissingTitle(t *testing.T) {
+	dir := setupTestStore(t)
+
+	_, err := executeCapture([]string{"--dir", dir, "work", "delete"})
+	if err == nil {
+		t.Fatal("expected error when delete target is missing")
+	}
+}
+
+// --- Top-level command tests ---
+
+func TestTopLevelList(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNotebook("alpha")
+	_ = st.CreateNotebook("beta")
+
+	out, err := executeCapture([]string{"--dir", dir, "list"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "alpha") {
+		t.Errorf("expected %q in output, got %q", "alpha", out)
+	}
+	if !strings.Contains(out, "beta") {
+		t.Errorf("expected %q in output, got %q", "beta", out)
+	}
+}
+
+func TestTopLevelNew(t *testing.T) {
+	dir := setupTestStore(t)
+
+	out, err := executeCapture([]string{"--dir", dir, "new", "Projects"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "Created") {
+		t.Errorf("expected 'Created' in output, got %q", out)
+	}
+
+	st := storage.NewStore(dir)
+	nbs, _ := st.ListNotebooks()
+	found := false
+	for _, n := range nbs {
+		if n == "Projects" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("notebook 'Projects' should exist after creation")
+	}
+}
+
+func TestTopLevelDelete(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNotebook("trash")
+
+	out, err := executeCapture([]string{"--dir", dir, "delete", "trash"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "Deleted") {
+		t.Errorf("expected 'Deleted' in output, got %q", out)
+	}
+
+	nbs, _ := st.ListNotebooks()
+	for _, n := range nbs {
+		if n == "trash" {
+			t.Error("notebook 'trash' should be deleted")
+		}
+	}
+}
+
+func TestTopLevelSearch(t *testing.T) {
+	dir := setupTestStore(t)
+
+	out, err := executeCapture([]string{"--dir", dir, "search", "hello"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "not implemented") {
+		t.Errorf("expected stub message, got %q", out)
+	}
+}
+
+func TestTopLevelConfig(t *testing.T) {
+	dir := setupTestStore(t)
+
+	out, err := executeCapture([]string{"--dir", dir, "config"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "not implemented") {
+		t.Errorf("expected stub message, got %q", out)
+	}
+}
+
+// --- No args shows help ---
+
+func TestNoArgsPrintsHelp(t *testing.T) {
+	dir := setupTestStore(t)
+
+	out, err := executeCapture([]string{"--dir", dir})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "notebook") {
+		t.Errorf("expected help output, got %q", out)
 	}
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var searchCmd = &cobra.Command{
+	Use:   "search <query>",
+	Short: "Search across all notebooks",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Fprintln(cmd.OutOrStdout(), "search: not implemented yet")
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(searchCmd)
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Version is set at build time via ldflags.
+var Version = "dev"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version of notebook",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Fprintln(cmd.OutOrStdout(), "notebook "+Version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVersionCommand(t *testing.T) {
+	out, err := executeCapture([]string{"version"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "notebook dev") {
+		t.Errorf("expected %q in output, got %q", "notebook dev", out)
+	}
+}
+
+func TestVersionVariable(t *testing.T) {
+	if Version != "dev" {
+		t.Errorf("default Version should be %q, got %q", "dev", Version)
+	}
+}


### PR DESCRIPTION
## Summary

- Dynamic noun-verb dispatcher: `notebook <book> [<note>] [verb]` routing
- Top-level commands: `list`, `new`, `delete`, `version`, `search` (stub), `config` (stub)
- `--dir` persistent flag for custom storage root (default `~/.notebook`)
- Rejects trailing args after note-level verbs
- Dead code removed, filepath.Join for path construction

Closes #3

## Test plan

- [x] 25 cmd tests pass (dispatcher routes, flags, edge cases)
- [x] 28 storage tests pass
- [x] `go vet ./...` clean
- [x] Interactive testing: `notebook --help`, `notebook version`, `notebook --dir /tmp/x new "test"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)