### PR TITLE
feat: notebook new with design-doc output

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -11,11 +11,13 @@ var deleteCmd = &cobra.Command{
 	Short: "Delete a notebook",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		w := cmd.OutOrStdout()
 		name := args[0]
 		if err := store.DeleteNotebook(name); err != nil {
-			return err
+			printError(w, err.Error())
+			return nil
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "Deleted %q\n", name)
+		printSuccess(w, fmt.Sprintf("Deleted %q", name))
 		return nil
 	},
 }

--- a/cmd/dispatcher.go
+++ b/cmd/dispatcher.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -88,24 +89,31 @@ func listNotesInBook(w io.Writer, book string) error {
 		return fmt.Errorf("list notes in %q: %w", book, err)
 	}
 	for _, n := range notes {
-		fmt.Fprintln(w, n.Name)
+		fmt.Fprintf(w, "  %s\n", n.Name)
 	}
 	return nil
 }
 
 func createNoteInBook(w io.Writer, book, title string) error {
 	if err := store.CreateNote(book, title, ""); err != nil {
-		return err
+		// Check for "already exists" from the storage layer.
+		if strings.Contains(err.Error(), "already exists") {
+			printError(w, fmt.Sprintf("Note %q already exists in %q", title, book))
+			return nil
+		}
+		printError(w, err.Error())
+		return nil
 	}
-	fmt.Fprintf(w, "Created %q in %s\n", title, book)
+	printSuccess(w, fmt.Sprintf("Created %q in %s", title, book))
 	return nil
 }
 
 func deleteNoteFromBook(w io.Writer, book, note string) error {
 	if err := store.DeleteNote(book, note); err != nil {
-		return err
+		printError(w, err.Error())
+		return nil
 	}
-	fmt.Fprintf(w, "Deleted %q from %s\n", note, book)
+	printSuccess(w, fmt.Sprintf("Deleted %q from %s", note, book))
 	return nil
 }
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -17,7 +17,7 @@ var listCmd = &cobra.Command{
 		}
 		w := cmd.OutOrStdout()
 		for _, name := range notebooks {
-			fmt.Fprintln(w, name)
+			fmt.Fprintf(w, "  %s\n", name)
 		}
 		return nil
 	},

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -11,11 +12,21 @@ var newCmd = &cobra.Command{
 	Short: "Create a new notebook",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		w := cmd.OutOrStdout()
 		name := args[0]
-		if err := store.CreateNotebook(name); err != nil {
-			return err
+
+		// Check if the notebook already exists before creating.
+		dir := store.NotebookDir(name)
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			printError(w, fmt.Sprintf("Notebook %q already exists", name))
+			return nil
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "Created %q\n", name)
+
+		if err := store.CreateNotebook(name); err != nil {
+			printError(w, err.Error())
+			return nil
+		}
+		printSuccess(w, fmt.Sprintf("Created %q", name))
 		return nil
 	},
 }

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+)
+
+func printSuccess(w io.Writer, msg string) {
+	fmt.Fprintf(w, "  \u2713 %s\n", msg)
+}
+
+func printError(w io.Writer, msg string) {
+	fmt.Fprintf(w, "  \u2717 %s\n", msg)
+}
+
+func printInfo(w io.Writer, msg string) {
+	fmt.Fprintf(w, "  \u2192 %s\n", msg)
+}
+
+func printWarning(w io.Writer, msg string) {
+	fmt.Fprintf(w, "  ! %s\n", msg)
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -93,8 +93,8 @@ func TestDispatchBookWithNoArgs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(out, "spark") {
-		t.Errorf("expected output to contain %q, got %q", "spark", out)
+	if !strings.Contains(out, "  spark\n") {
+		t.Errorf("expected indented %q in output, got %q", "  spark", out)
 	}
 }
 
@@ -109,11 +109,11 @@ func TestDispatchBookList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(out, "todo") {
-		t.Errorf("expected %q in output, got %q", "todo", out)
+	if !strings.Contains(out, "  todo\n") {
+		t.Errorf("expected indented %q in output, got %q", "  todo", out)
 	}
-	if !strings.Contains(out, "meeting") {
-		t.Errorf("expected %q in output, got %q", "meeting", out)
+	if !strings.Contains(out, "  meeting\n") {
+		t.Errorf("expected indented %q in output, got %q", "  meeting", out)
 	}
 }
 
@@ -124,8 +124,9 @@ func TestDispatchBookNew(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(out, "Created") {
-		t.Errorf("expected 'Created' in output, got %q", out)
+	want := "  \u2713 Created \"day1\" in journal\n"
+	if out != want {
+		t.Errorf("output = %q, want %q", out, want)
 	}
 
 	// Verify the note was actually created.
@@ -148,8 +149,9 @@ func TestDispatchBookDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(out, "Deleted") {
-		t.Errorf("expected 'Deleted' in output, got %q", out)
+	want := "  \u2713 Deleted \"temp\" from work\n"
+	if out != want {
+		t.Errorf("output = %q, want %q", out, want)
 	}
 
 	// Verify the note is gone.
@@ -206,8 +208,9 @@ func TestDispatchNoteDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(out, "Deleted") {
-		t.Errorf("expected 'Deleted' in output, got %q", out)
+	want := "  \u2713 Deleted \"doomed\" from work\n"
+	if out != want {
+		t.Errorf("output = %q, want %q", out, want)
 	}
 
 	_, err = st.GetNote("work", "doomed")
@@ -270,11 +273,11 @@ func TestTopLevelList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(out, "alpha") {
-		t.Errorf("expected %q in output, got %q", "alpha", out)
+	if !strings.Contains(out, "  alpha\n") {
+		t.Errorf("expected indented %q in output, got %q", "  alpha", out)
 	}
-	if !strings.Contains(out, "beta") {
-		t.Errorf("expected %q in output, got %q", "beta", out)
+	if !strings.Contains(out, "  beta\n") {
+		t.Errorf("expected indented %q in output, got %q", "  beta", out)
 	}
 }
 
@@ -285,8 +288,9 @@ func TestTopLevelNew(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(out, "Created") {
-		t.Errorf("expected 'Created' in output, got %q", out)
+	want := "  \u2713 Created \"Projects\"\n"
+	if out != want {
+		t.Errorf("output = %q, want %q", out, want)
 	}
 
 	st := storage.NewStore(dir)
@@ -311,8 +315,9 @@ func TestTopLevelDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(out, "Deleted") {
-		t.Errorf("expected 'Deleted' in output, got %q", out)
+	want := "  \u2713 Deleted \"trash\"\n"
+	if out != want {
+		t.Errorf("output = %q, want %q", out, want)
 	}
 
 	nbs, _ := st.ListNotebooks()
@@ -358,5 +363,123 @@ func TestNoArgsPrintsHelp(t *testing.T) {
 	}
 	if !strings.Contains(out, "notebook") {
 		t.Errorf("expected help output, got %q", out)
+	}
+}
+
+// --- Issue #4: notebook new output formatting ---
+
+func TestNewNotebookSuccessOutput(t *testing.T) {
+	dir := setupTestStore(t)
+
+	out, err := executeCapture([]string{"--dir", dir, "new", "test-book"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "  \u2713 Created \"test-book\"\n"
+	if out != want {
+		t.Errorf("output = %q, want %q", out, want)
+	}
+
+	// Verify the notebook was actually created.
+	st := storage.NewStore(dir)
+	nbs, _ := st.ListNotebooks()
+	found := false
+	for _, n := range nbs {
+		if n == "test-book" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("notebook 'test-book' should exist after creation")
+	}
+}
+
+func TestNewNoteInBookSuccessOutput(t *testing.T) {
+	dir := setupTestStore(t)
+
+	out, err := executeCapture([]string{"--dir", dir, "mybook", "new", "test-note"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "  \u2713 Created \"test-note\" in mybook\n"
+	if out != want {
+		t.Errorf("output = %q, want %q", out, want)
+	}
+
+	// Verify the note was actually created.
+	st := storage.NewStore(dir)
+	note, err := st.GetNote("mybook", "test-note")
+	if err != nil {
+		t.Fatalf("note should exist: %v", err)
+	}
+	if note.Name != "test-note" {
+		t.Errorf("note name = %q, want %q", note.Name, "test-note")
+	}
+}
+
+func TestNewDuplicateNotebookShowsError(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNotebook("my-notebook")
+
+	out, err := executeCapture([]string{"--dir", dir, "new", "my-notebook"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "\u2717") {
+		t.Errorf("expected error symbol in output, got %q", out)
+	}
+	if !strings.Contains(out, "already exists") {
+		t.Errorf("expected 'already exists' in output, got %q", out)
+	}
+}
+
+func TestNewNoteAutoCreatesNotebook(t *testing.T) {
+	dir := setupTestStore(t)
+
+	// "newbook" does not exist yet; creating a note should auto-create it.
+	out, err := executeCapture([]string{"--dir", dir, "newbook", "new", "first-note"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "\u2713") {
+		t.Errorf("expected success symbol in output, got %q", out)
+	}
+
+	// Verify both the notebook and note exist.
+	st := storage.NewStore(dir)
+	nbs, _ := st.ListNotebooks()
+	found := false
+	for _, n := range nbs {
+		if n == "newbook" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("notebook 'newbook' should have been auto-created")
+	}
+	note, err := st.GetNote("newbook", "first-note")
+	if err != nil {
+		t.Fatalf("note should exist: %v", err)
+	}
+	if note.Name != "first-note" {
+		t.Errorf("note name = %q, want %q", note.Name, "first-note")
+	}
+}
+
+func TestNewDuplicateNoteShowsError(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNote("my-notebook", "my-note", "content")
+
+	out, err := executeCapture([]string{"--dir", dir, "my-notebook", "new", "my-note"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "\u2717") {
+		t.Errorf("expected error symbol in output, got %q", out)
+	}
+	if !strings.Contains(out, "already exists") {
+		t.Errorf("expected 'already exists' in output, got %q", out)
 	}
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -48,6 +48,12 @@ func (s *Store) notebookPath(name string) string {
 	return filepath.Join(s.Root, name)
 }
 
+// NotebookDir returns the full filesystem path for a notebook directory.
+// This is the exported version of notebookPath for use by the command layer.
+func (s *Store) NotebookDir(name string) string {
+	return filepath.Join(s.Root, name)
+}
+
 // CreateNotebook creates a new notebook directory.
 func (s *Store) CreateNotebook(name string) error {
 	if err := validName(name); err != nil {


### PR DESCRIPTION
## Summary

- Shared output helpers (`printSuccess`, `printError`, `printInfo`, `printWarning`) with design-doc formatting
- `notebook new` detects duplicate notebooks with clear `✗` error messages
- `notebook <book> new <title>` detects duplicate notes
- All commands use two-space indent and Unicode symbols
- 5 new tests for create flows, duplicates, and auto-creation

Closes #4

## Test plan

- [x] 30 cmd tests pass (including 5 new for issue #4)
- [x] 28 storage tests pass
- [x] `go vet ./...` clean
- [x] Interactive: verified create, duplicate detection, auto-creation, path traversal rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)