### PR TITLE
feat: notebook delete with confirmation

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,10 +1,15 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
+
+var forceFlag bool
 
 var deleteCmd = &cobra.Command{
 	Use:   "delete <name>",
@@ -13,15 +18,56 @@ var deleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		w := cmd.OutOrStdout()
 		name := args[0]
+
+		// Check if notebook exists.
+		dir := store.NotebookDir(name)
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			printError(w, fmt.Sprintf("Notebook %q not found", name))
+			return nil
+		}
+
+		// Count notes for the confirmation message.
+		count, err := store.NoteCount(name)
+		if err != nil {
+			printError(w, err.Error())
+			return nil
+		}
+
+		if !forceFlag {
+			// Show confirmation prompt.
+			if count > 0 {
+				fmt.Fprintf(w, "  Delete %q and %s? This cannot be undone. [y/N] ",
+					name, pluralize(count, "note", "notes"))
+			} else {
+				fmt.Fprintf(w, "  Delete %q? This cannot be undone. [y/N] ", name)
+			}
+
+			scanner := bufio.NewScanner(cmd.InOrStdin())
+			if !scanner.Scan() {
+				return nil
+			}
+			answer := strings.TrimSpace(scanner.Text())
+			if answer != "y" && answer != "Y" {
+				printInfo(w, "Cancelled")
+				return nil
+			}
+		}
+
 		if err := store.DeleteNotebook(name); err != nil {
 			printError(w, err.Error())
 			return nil
 		}
-		printSuccess(w, fmt.Sprintf("Deleted %q", name))
+
+		if count > 0 {
+			printSuccess(w, fmt.Sprintf("Deleted %q and %s", name, pluralize(count, "note", "notes")))
+		} else {
+			printSuccess(w, fmt.Sprintf("Deleted %q", name))
+		}
 		return nil
 	},
 }
 
 func init() {
+	deleteCmd.Flags().BoolVarP(&forceFlag, "force", "f", false, "skip confirmation prompt")
 	rootCmd.AddCommand(deleteCmd)
 }

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -1,0 +1,332 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/oobagi/notebook/internal/storage"
+)
+
+// --- Notebook deletion tests ---
+
+func TestDeleteNotebookWithForceFlag(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNotebook("ideas")
+	_ = st.CreateNote("ideas", "spark", "bright idea")
+	_ = st.CreateNote("ideas", "plan", "a plan")
+
+	out, err := executeCapture([]string{"--dir", dir, "delete", "--force", "ideas"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "  \u2713 Deleted \"ideas\" and 2 notes\n"
+	if out != want {
+		t.Errorf("output =\n%q\nwant\n%q", out, want)
+	}
+
+	// Verify notebook is gone.
+	nbs, _ := st.ListNotebooks()
+	for _, n := range nbs {
+		if n == "ideas" {
+			t.Error("notebook 'ideas' should be deleted")
+		}
+	}
+}
+
+func TestDeleteNotebookWithForceShortFlag(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNotebook("temp")
+
+	out, err := executeCapture([]string{"--dir", dir, "delete", "-f", "temp"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "  \u2713 Deleted \"temp\"\n"
+	if out != want {
+		t.Errorf("output = %q, want %q", out, want)
+	}
+}
+
+func TestDeleteEmptyNotebookWithForce(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNotebook("empty")
+
+	out, err := executeCapture([]string{"--dir", dir, "delete", "--force", "empty"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "  \u2713 Deleted \"empty\"\n"
+	if out != want {
+		t.Errorf("output = %q, want %q", out, want)
+	}
+}
+
+func TestDeleteNotebookConfirmYes(t *testing.T) {
+	dir := setupTestStore(t)
+	forceFlag = false
+	st := storage.NewStore(dir)
+	_ = st.CreateNotebook("ideas")
+	_ = st.CreateNote("ideas", "note1", "content")
+	_ = st.CreateNote("ideas", "note2", "content")
+	_ = st.CreateNote("ideas", "note3", "content")
+
+	// Simulate user typing "y" at the confirmation prompt.
+	rootCmd.SetIn(strings.NewReader("y\n"))
+	defer rootCmd.SetIn(nil)
+
+	out, err := executeCapture([]string{"--dir", dir, "delete", "ideas"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, `Delete "ideas" and 3 notes?`) {
+		t.Errorf("expected confirmation prompt in output, got %q", out)
+	}
+	if !strings.Contains(out, "\u2713 Deleted \"ideas\" and 3 notes") {
+		t.Errorf("expected success message in output, got %q", out)
+	}
+
+	// Verify notebook is gone.
+	nbs, _ := st.ListNotebooks()
+	for _, n := range nbs {
+		if n == "ideas" {
+			t.Error("notebook 'ideas' should be deleted")
+		}
+	}
+}
+
+func TestDeleteNotebookConfirmUpperY(t *testing.T) {
+	dir := setupTestStore(t)
+	forceFlag = false
+	st := storage.NewStore(dir)
+	_ = st.CreateNotebook("work")
+	_ = st.CreateNote("work", "task", "do stuff")
+
+	rootCmd.SetIn(strings.NewReader("Y\n"))
+	defer rootCmd.SetIn(nil)
+
+	out, err := executeCapture([]string{"--dir", dir, "delete", "work"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "\u2713 Deleted \"work\" and 1 note\n") {
+		t.Errorf("expected success message in output, got %q", out)
+	}
+}
+
+func TestDeleteNotebookConfirmNo(t *testing.T) {
+	dir := setupTestStore(t)
+	forceFlag = false
+	st := storage.NewStore(dir)
+	_ = st.CreateNotebook("keep")
+	_ = st.CreateNote("keep", "important", "do not delete")
+
+	rootCmd.SetIn(strings.NewReader("n\n"))
+	defer rootCmd.SetIn(nil)
+
+	out, err := executeCapture([]string{"--dir", dir, "delete", "keep"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "Cancelled") {
+		t.Errorf("expected 'Cancelled' in output, got %q", out)
+	}
+
+	// Verify notebook still exists.
+	nbs, _ := st.ListNotebooks()
+	found := false
+	for _, n := range nbs {
+		if n == "keep" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("notebook 'keep' should still exist after cancelling delete")
+	}
+}
+
+func TestDeleteNotebookConfirmEmpty(t *testing.T) {
+	dir := setupTestStore(t)
+	forceFlag = false
+	st := storage.NewStore(dir)
+	_ = st.CreateNotebook("keep2")
+
+	// Pressing enter without typing anything (default is N).
+	rootCmd.SetIn(strings.NewReader("\n"))
+	defer rootCmd.SetIn(nil)
+
+	out, err := executeCapture([]string{"--dir", dir, "delete", "keep2"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "Cancelled") {
+		t.Errorf("expected 'Cancelled' in output, got %q", out)
+	}
+
+	// Verify notebook still exists.
+	nbs, _ := st.ListNotebooks()
+	found := false
+	for _, n := range nbs {
+		if n == "keep2" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("notebook 'keep2' should still exist after empty input")
+	}
+}
+
+func TestDeleteEmptyNotebookPrompt(t *testing.T) {
+	dir := setupTestStore(t)
+	forceFlag = false
+	st := storage.NewStore(dir)
+	_ = st.CreateNotebook("vacant")
+
+	rootCmd.SetIn(strings.NewReader("y\n"))
+	defer rootCmd.SetIn(nil)
+
+	out, err := executeCapture([]string{"--dir", dir, "delete", "vacant"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Empty notebook prompt should NOT mention note count.
+	if !strings.Contains(out, `Delete "vacant"? This cannot be undone. [y/N]`) {
+		t.Errorf("expected simple prompt for empty notebook, got %q", out)
+	}
+	if !strings.Contains(out, "\u2713 Deleted \"vacant\"\n") {
+		t.Errorf("expected success message, got %q", out)
+	}
+}
+
+func TestDeleteNotebookSingularNote(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNotebook("solo")
+	_ = st.CreateNote("solo", "only", "the one")
+
+	out, err := executeCapture([]string{"--dir", dir, "delete", "--force", "solo"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should say "1 note" not "1 notes".
+	want := "  \u2713 Deleted \"solo\" and 1 note\n"
+	if out != want {
+		t.Errorf("output = %q, want %q", out, want)
+	}
+}
+
+func TestDeleteNotebookPluralNotes(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNotebook("multi")
+	_ = st.CreateNote("multi", "a", "x")
+	_ = st.CreateNote("multi", "b", "y")
+	_ = st.CreateNote("multi", "c", "z")
+
+	out, err := executeCapture([]string{"--dir", dir, "delete", "--force", "multi"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "  \u2713 Deleted \"multi\" and 3 notes\n"
+	if out != want {
+		t.Errorf("output = %q, want %q", out, want)
+	}
+}
+
+// --- Not-found tests ---
+
+func TestDeleteNonExistentNotebook(t *testing.T) {
+	dir := setupTestStore(t)
+
+	out, err := executeCapture([]string{"--dir", dir, "delete", "--force", "ghost"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "\u2717") {
+		t.Errorf("expected error symbol in output, got %q", out)
+	}
+	if !strings.Contains(out, "not found") {
+		t.Errorf("expected 'not found' in output, got %q", out)
+	}
+}
+
+// --- Note deletion tests ---
+
+func TestDeleteNoteNoConfirmation(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNote("work", "temp", "throwaway")
+
+	// Delete via: notebook <book> delete <note>
+	out, err := executeCapture([]string{"--dir", dir, "work", "delete", "temp"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "  \u2713 Deleted \"temp\" from work\n"
+	if out != want {
+		t.Errorf("output = %q, want %q", out, want)
+	}
+
+	// Verify note is gone.
+	_, err = st.GetNote("work", "temp")
+	if err == nil {
+		t.Fatal("note should have been deleted")
+	}
+}
+
+func TestDeleteNoteViaVerbSuffix(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNote("journal", "entry", "dear diary")
+
+	// Delete via: notebook <book> <note> delete
+	out, err := executeCapture([]string{"--dir", dir, "journal", "entry", "delete"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "  \u2713 Deleted \"entry\" from journal\n"
+	if out != want {
+		t.Errorf("output = %q, want %q", out, want)
+	}
+
+	_, err = st.GetNote("journal", "entry")
+	if err == nil {
+		t.Fatal("note should have been deleted")
+	}
+}
+
+func TestDeleteNonExistentNote(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNotebook("work")
+
+	out, err := executeCapture([]string{"--dir", dir, "work", "delete", "ghost"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "\u2717") {
+		t.Errorf("expected error symbol in output, got %q", out)
+	}
+	if !strings.Contains(out, "not found") {
+		t.Errorf("expected 'not found' in output, got %q", out)
+	}
+}
+
+func TestDeleteNonExistentNoteViaVerbSuffix(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNotebook("work")
+
+	out, err := executeCapture([]string{"--dir", dir, "work", "phantom", "delete"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "\u2717") {
+		t.Errorf("expected error symbol in output, got %q", out)
+	}
+	if !strings.Contains(out, "not found") {
+		t.Errorf("expected 'not found' in output, got %q", out)
+	}
+}

--- a/cmd/dispatcher.go
+++ b/cmd/dispatcher.go
@@ -137,6 +137,10 @@ func createNoteInBook(w io.Writer, book, title string) error {
 
 func deleteNoteFromBook(w io.Writer, book, note string) error {
 	if err := store.DeleteNote(book, note); err != nil {
+		if strings.Contains(err.Error(), "no such file or directory") {
+			printError(w, fmt.Sprintf("Note %q not found in %q", note, book))
+			return nil
+		}
 		printError(w, err.Error())
 		return nil
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -362,7 +362,7 @@ func TestTopLevelDelete(t *testing.T) {
 	st := storage.NewStore(dir)
 	_ = st.CreateNotebook("trash")
 
-	out, err := executeCapture([]string{"--dir", dir, "delete", "trash"})
+	out, err := executeCapture([]string{"--dir", dir, "delete", "--force", "trash"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary

- `notebook delete "name"` prompts `[y/N]` with note count before deleting
- `--force` / `-f` flag skips confirmation
- `notebook <book> <note> delete` and `notebook <book> delete <note>` both work
- Not-found errors with clear `✗` messages
- 15 new tests covering force, confirmation, cancellation, and edge cases

Closes #7

## Test plan

- [x] 71 tests pass (`go test ./...`)
- [x] `go vet ./...` clean
- [x] Interactive: verified prompt, y/Y/n/empty/force, note deletion, not-found

🤖 Generated with [Claude Code](https://claude.com/claude-code)