### PR TITLE
feat: live split-pane markdown preview

### DIFF
--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -4,10 +4,12 @@ package editor
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/oobagi/notebook/internal/render"
 )
 
 // Config holds the configuration for the editor.
@@ -26,17 +28,33 @@ type savedMsg struct{ content string }
 // saveErrMsg is sent when a save fails.
 type saveErrMsg struct{ err error }
 
+// previewTickMsg is sent after the debounce interval to trigger preview rendering.
+// The seq field is compared against Model.previewSeq to implement true debounce:
+// only the most recent tick (matching the current seq) triggers a render.
+type previewTickMsg struct{ seq int }
+
+// previewDebounce is the delay before re-rendering the preview after a text change.
+const previewDebounce = 150 * time.Millisecond
+
+// minSplitWidth is the minimum terminal width required to show the split pane.
+// Below this, the preview is auto-hidden.
+const minSplitWidth = 40
+
 // Model is the Bubble Tea model for the editor.
 type Model struct {
-	textarea    textarea.Model
-	config      Config
-	initial     string
-	width       int
-	height      int
-	status      string
-	statusStyle statusKind
-	quitWarning bool
-	quitting    bool
+	textarea     textarea.Model
+	config       Config
+	initial      string
+	width        int
+	height       int
+	status       string
+	statusStyle  statusKind
+	quitWarning  bool
+	quitting     bool
+	showPreview  bool
+	preview      string
+	previewDirty bool
+	previewSeq   int
 }
 
 type statusKind int
@@ -56,13 +74,15 @@ func New(cfg Config) Model {
 	ta.Focus()
 
 	return Model{
-		textarea: ta,
-		config:   cfg,
-		initial:  cfg.Content,
+		textarea:    ta,
+		config:      cfg,
+		initial:     cfg.Content,
+		showPreview: true,
 	}
 }
 
 // Init returns the initial command for the editor (start cursor blinking).
+// The first preview render is triggered by the initial WindowSizeMsg.
 func (m Model) Init() tea.Cmd {
 	return textarea.Blink
 }
@@ -77,15 +97,74 @@ func (m Model) Content() string {
 	return m.textarea.Value()
 }
 
+// textareaWidth returns the width the textarea should use given the current
+// preview visibility and total terminal width.
+func (m Model) textareaWidth() int {
+	if m.showPreview && m.width >= minSplitWidth {
+		return m.width / 2
+	}
+	return m.width
+}
+
+// previewWidth returns the width available for the preview pane.
+func (m Model) previewWidth() int {
+	if !m.showPreview || m.width < minSplitWidth {
+		return 0
+	}
+	// Total width minus left pane minus 1-column border.
+	return m.width - m.width/2 - 1
+}
+
+// resizeTextarea updates the textarea dimensions for the current layout.
+func (m *Model) resizeTextarea() {
+	m.textarea.SetWidth(m.textareaWidth())
+	// Reserve 1 line for the status bar.
+	if m.height > 1 {
+		m.textarea.SetHeight(m.height - 1)
+	}
+}
+
+// renderPreview renders the current content as markdown for the preview pane.
+func (m *Model) renderPreview() {
+	pw := m.previewWidth()
+	if pw <= 0 {
+		m.preview = ""
+		return
+	}
+	content := m.textarea.Value()
+	if content == "" {
+		m.preview = ""
+		return
+	}
+	m.preview = render.RenderMarkdown(content, pw)
+	m.previewDirty = false
+}
+
+// schedulePreviewTick increments the sequence counter and returns a tick command.
+// Only the tick matching the current sequence will trigger a render, implementing
+// a true debounce (renders after the last change, not the first).
+func (m *Model) schedulePreviewTick() tea.Cmd {
+	m.previewSeq++
+	seq := m.previewSeq
+	return tea.Tick(previewDebounce, func(t time.Time) tea.Msg {
+		return previewTickMsg{seq: seq}
+	})
+}
+
 // Update handles messages and updates the model.
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		m.textarea.SetWidth(msg.Width)
-		// Reserve 1 line for the status bar.
-		m.textarea.SetHeight(msg.Height - 1)
+		m.resizeTextarea()
+		m.previewDirty = true
+		return m, m.schedulePreviewTick()
+
+	case previewTickMsg:
+		if msg.seq == m.previewSeq && m.previewDirty {
+			m.renderPreview()
+		}
 		return m, nil
 
 	case tea.KeyMsg:
@@ -96,6 +175,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		switch msg.String() {
+		case "ctrl+p":
+			m.showPreview = !m.showPreview
+			m.resizeTextarea()
+			if m.showPreview {
+				m.previewDirty = true
+				return m, m.schedulePreviewTick()
+			}
+			return m, nil
+
 		case "ctrl+s":
 			m.quitWarning = false
 			if m.config.Save != nil {
@@ -139,8 +227,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// Track content before the textarea processes the message so we can
+	// detect changes and schedule a preview re-render.
+	contentBefore := m.textarea.Value()
+
 	var cmd tea.Cmd
 	m.textarea, cmd = m.textarea.Update(msg)
+
+	if m.textarea.Value() != contentBefore {
+		m.previewDirty = true
+		cmd = tea.Batch(cmd, m.schedulePreviewTick())
+	}
+
 	return m, cmd
 }
 
@@ -151,7 +249,39 @@ func (m Model) View() string {
 	}
 
 	statusBar := m.renderStatusBar()
-	return m.textarea.View() + "\n" + statusBar
+
+	if !m.showPreview || m.width < minSplitWidth {
+		return m.textarea.View() + "\n" + statusBar
+	}
+
+	// Split-pane layout: editor left, border, preview right.
+	editorHeight := m.height - 1
+	if editorHeight < 1 {
+		editorHeight = 1
+	}
+
+	leftWidth := m.width / 2
+	rightWidth := m.width - leftWidth - 1 // 1 col for border
+
+	// Build the vertical border (thin dim line of │ characters).
+	borderStyle := lipgloss.NewStyle().Faint(true)
+	var borderLines []string
+	for i := 0; i < editorHeight; i++ {
+		borderLines = append(borderLines, borderStyle.Render("│"))
+	}
+	border := strings.Join(borderLines, "\n")
+
+	// Constrain the preview pane.
+	previewStyle := lipgloss.NewStyle().
+		Width(rightWidth).
+		Height(editorHeight)
+
+	leftPane := m.textarea.View()
+	rightPane := previewStyle.Render(m.preview)
+
+	split := lipgloss.JoinHorizontal(lipgloss.Top, leftPane, border, rightPane)
+
+	return split + "\n" + statusBar
 }
 
 // renderStatusBar builds the bottom status bar.
@@ -172,7 +302,7 @@ func (m Model) renderStatusBar() string {
 	if m.status != "" {
 		right = m.status
 	} else {
-		right = "Ctrl+S save \u00B7 Ctrl+Q quit"
+		right = "Ctrl+S save \u00B7 Ctrl+P preview \u00B7 Ctrl+Q quit"
 	}
 
 	// Calculate gap between left and right.

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -2,6 +2,7 @@ package editor
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -248,6 +249,154 @@ func TestStatusBarContainsTitle(t *testing.T) {
 	view := m.View()
 	if !containsPlainText(view, "work \u203A notes") {
 		t.Fatal("view should contain the title in the status bar")
+	}
+}
+
+func TestPreviewVisibleByDefault(t *testing.T) {
+	m := New(Config{Title: "test", Content: "hello"})
+	if !m.showPreview {
+		t.Fatal("showPreview should be true by default")
+	}
+}
+
+func TestCtrlPTogglesPreview(t *testing.T) {
+	m := New(Config{Title: "test", Content: "hello"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	if !m.showPreview {
+		t.Fatal("preview should be visible initially")
+	}
+
+	// Toggle off.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	m = updated.(Model)
+
+	if m.showPreview {
+		t.Fatal("Ctrl+P should toggle preview off")
+	}
+
+	// Toggle back on.
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	m = updated.(Model)
+
+	if !m.showPreview {
+		t.Fatal("Ctrl+P should toggle preview back on")
+	}
+	if cmd == nil {
+		t.Fatal("toggling preview on should schedule a preview tick")
+	}
+}
+
+func TestPreviewTickRendersContent(t *testing.T) {
+	m := New(Config{Title: "test", Content: "# Hello"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Mark dirty and send tick with matching seq.
+	m.previewDirty = true
+	updated, _ = m.Update(previewTickMsg{seq: m.previewSeq})
+	m = updated.(Model)
+
+	if m.previewDirty {
+		t.Fatal("previewDirty should be false after tick renders")
+	}
+	if m.preview == "" {
+		t.Fatal("preview should contain rendered content after tick")
+	}
+}
+
+func TestPreviewTickSkipsWhenNotDirty(t *testing.T) {
+	m := New(Config{Title: "test", Content: "# Hello"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Ensure not dirty.
+	m.previewDirty = false
+	m.preview = "old"
+
+	updated, _ = m.Update(previewTickMsg{seq: m.previewSeq})
+	m = updated.(Model)
+
+	if m.preview != "old" {
+		t.Fatal("preview should not change when not dirty")
+	}
+}
+
+func TestPreviewTickSkipsStaleSeq(t *testing.T) {
+	m := New(Config{Title: "test", Content: "# Hello"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	m.previewDirty = true
+	staleSeq := m.previewSeq - 1
+
+	updated, _ = m.Update(previewTickMsg{seq: staleSeq})
+	m = updated.(Model)
+
+	if !m.previewDirty {
+		t.Fatal("stale tick should not trigger render")
+	}
+}
+
+func TestViewContainsPreviewWhenVisible(t *testing.T) {
+	m := New(Config{Title: "test", Content: "# Hello"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Trigger preview render.
+	m.previewDirty = true
+	updated, _ = m.Update(previewTickMsg{seq: m.previewSeq})
+	m = updated.(Model)
+
+	view := m.View()
+	// The view should contain the border character when preview is visible.
+	if !strings.Contains(view, "│") {
+		t.Fatal("view should contain the vertical border when preview is visible")
+	}
+}
+
+func TestViewFullWidthWhenPreviewHidden(t *testing.T) {
+	m := New(Config{Title: "test", Content: "# Hello"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Toggle preview off.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	m = updated.(Model)
+
+	view := m.View()
+	// Without preview, there should be no border character.
+	if strings.Contains(view, "│") {
+		t.Fatal("view should not contain border when preview is hidden")
+	}
+}
+
+func TestPreviewAutoHidesWhenNarrow(t *testing.T) {
+	m := New(Config{Title: "test", Content: "# Hello"})
+	// Set width below minSplitWidth.
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 30, Height: 24})
+	m = updated.(Model)
+
+	// Preview is logically on, but should not render in the view.
+	if !m.showPreview {
+		t.Fatal("showPreview should still be true (auto-hide is view-level)")
+	}
+
+	view := m.View()
+	if strings.Contains(view, "│") {
+		t.Fatal("view should not show preview border when terminal is too narrow")
+	}
+}
+
+func TestStatusBarContainsPreviewHint(t *testing.T) {
+	m := New(Config{Title: "test", Content: ""})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	view := m.View()
+	if !containsPlainText(view, "Ctrl+P preview") {
+		t.Fatal("status bar should contain Ctrl+P preview hint")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Side-by-side editor (left) and Glamour-rendered markdown preview (right)
- True debounce with sequence counter — renders 150ms after last keystroke
- Ctrl+P toggles preview visibility
- Auto-hides preview when terminal < 40 columns

Closes #10

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass (22 tests in editor package)
- [x] `go build` compiles
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)