### PR TITLE
feat: editor keybindings, help overlay, cut/paste

### DIFF
--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -28,6 +28,9 @@ type savedMsg struct{ content string }
 // saveErrMsg is sent when a save fails.
 type saveErrMsg struct{ err error }
 
+// savedQuitMsg is sent after a successful save-then-quit.
+type savedQuitMsg struct{ content string }
+
 // previewTickMsg is sent after the debounce interval to trigger preview rendering.
 // The seq field is compared against Model.previewSeq to implement true debounce:
 // only the most recent tick (matching the current seq) triggers a render.
@@ -49,9 +52,11 @@ type Model struct {
 	height       int
 	status       string
 	statusStyle  statusKind
-	quitWarning  bool
+	quitPrompt   bool
 	quitting     bool
 	showPreview  bool
+	showHelp     bool
+	clipboard    string
 	preview      string
 	previewDirty bool
 	previewSeq   int
@@ -151,6 +156,83 @@ func (m *Model) schedulePreviewTick() tea.Cmd {
 	})
 }
 
+// cursorLine returns the zero-based line index where the textarea cursor is.
+func (m Model) cursorLine() int {
+	return m.textarea.Line()
+}
+
+// cutLine removes the current line from the textarea and stores it in the
+// clipboard. It returns the cut text.
+func (m *Model) cutLine() string {
+	value := m.textarea.Value()
+	lines := strings.Split(value, "\n")
+
+	line := m.cursorLine()
+	if line < 0 || line >= len(lines) {
+		return ""
+	}
+
+	cut := lines[line]
+
+	// Remove the line.
+	newLines := make([]string, 0, len(lines)-1)
+	newLines = append(newLines, lines[:line]...)
+	newLines = append(newLines, lines[line+1:]...)
+
+	m.textarea.SetValue(strings.Join(newLines, "\n"))
+
+	// Reposition cursor: stay on the same line index, clamped to the new
+	// line count. Move to the start of the line for simplicity.
+	newLineCount := len(newLines)
+	targetLine := line
+	if targetLine >= newLineCount {
+		targetLine = newLineCount - 1
+	}
+	if targetLine < 0 {
+		targetLine = 0
+	}
+	m.textarea.SetCursor(0)
+	for m.textarea.Line() > targetLine {
+		m.textarea.CursorUp()
+	}
+	for m.textarea.Line() < targetLine {
+		m.textarea.CursorDown()
+	}
+
+	return cut
+}
+
+// pasteLine inserts the clipboard content at the current cursor line.
+func (m *Model) pasteLine() {
+	if m.clipboard == "" {
+		return
+	}
+	value := m.textarea.Value()
+	lines := strings.Split(value, "\n")
+
+	line := m.cursorLine()
+	if line < 0 {
+		line = 0
+	}
+	if line > len(lines) {
+		line = len(lines)
+	}
+
+	// Insert the clipboard as a new line before the current line.
+	newLines := make([]string, 0, len(lines)+1)
+	newLines = append(newLines, lines[:line]...)
+	newLines = append(newLines, m.clipboard)
+	newLines = append(newLines, lines[line:]...)
+
+	m.textarea.SetValue(strings.Join(newLines, "\n"))
+
+	// Position cursor on the pasted line.
+	m.textarea.SetCursor(0)
+	for m.textarea.Line() < line {
+		m.textarea.CursorDown()
+	}
+}
+
 // Update handles messages and updates the model.
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
@@ -168,13 +250,67 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
-		// Clear transient status on any keypress, unless quitting.
+		// When help overlay is showing, only Ctrl+G and Esc dismiss it.
+		if m.showHelp {
+			switch msg.String() {
+			case "ctrl+g", "esc":
+				m.showHelp = false
+			}
+			return m, nil
+		}
+
+		// When quit prompt is showing, handle the 3-option response.
+		if m.quitPrompt {
+			switch msg.String() {
+			case "y", "Y", "enter":
+				m.quitPrompt = false
+				// Save then quit.
+				if m.config.Save != nil {
+					content := m.textarea.Value()
+					return m, func() tea.Msg {
+						if err := m.config.Save(content); err != nil {
+							return saveErrMsg{err: err}
+						}
+						return savedQuitMsg{content: content}
+					}
+				}
+				// No save function configured — just quit.
+				m.quitting = true
+				return m, tea.Quit
+			case "n", "N":
+				m.quitting = true
+				return m, tea.Quit
+			case "esc":
+				m.quitPrompt = false
+				m.status = ""
+				m.statusStyle = statusNone
+				return m, nil
+			}
+			// Ignore all other keys while in the prompt.
+			return m, nil
+		}
+
+		// Clear transient status on any keypress.
 		if m.statusStyle == statusSuccess {
 			m.status = ""
 			m.statusStyle = statusNone
 		}
 
 		switch msg.String() {
+		case "ctrl+g":
+			m.showHelp = true
+			return m, nil
+
+		case "ctrl+k":
+			m.clipboard = m.cutLine()
+			m.previewDirty = true
+			return m, m.schedulePreviewTick()
+
+		case "ctrl+u":
+			m.pasteLine()
+			m.previewDirty = true
+			return m, m.schedulePreviewTick()
+
 		case "ctrl+p":
 			m.showPreview = !m.showPreview
 			m.resizeTextarea()
@@ -185,7 +321,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 
 		case "ctrl+s":
-			m.quitWarning = false
 			if m.config.Save != nil {
 				content := m.textarea.Value()
 				return m, func() tea.Msg {
@@ -198,9 +333,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 
 		case "ctrl+q":
-			if m.modified() && !m.quitWarning {
-				m.quitWarning = true
-				m.status = "Unsaved changes! Press Ctrl+Q again to quit without saving"
+			if m.modified() {
+				m.quitPrompt = true
+				m.status = "Save before quitting? [Y/n/Esc]"
 				m.statusStyle = statusWarning
 				return m, nil
 			}
@@ -212,14 +347,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 
-		// Any key other than ctrl+q resets the quit warning.
-		m.quitWarning = false
-
 	case savedMsg:
 		m.initial = msg.content
 		m.status = "Saved"
 		m.statusStyle = statusSuccess
 		return m, nil
+
+	case savedQuitMsg:
+		m.initial = msg.content
+		m.quitting = true
+		return m, tea.Quit
 
 	case saveErrMsg:
 		m.status = fmt.Sprintf("Save failed: %s", msg.err)
@@ -242,10 +379,51 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+// renderHelpOverlay builds the full-screen help panel.
+func (m Model) renderHelpOverlay() string {
+	help := `  Keybindings
+  ───────────────────────────
+
+  Ctrl+S    Save
+  Ctrl+Q    Quit
+  Ctrl+C    Force quit (no save)
+  Ctrl+P    Toggle preview
+  Ctrl+G    Toggle this help
+  Ctrl+K    Cut line
+  Ctrl+U    Paste line
+
+  Press Ctrl+G or Esc to close`
+
+	w := m.width
+	if w <= 0 {
+		w = 80
+	}
+	h := m.height
+	if h <= 0 {
+		h = 24
+	}
+
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("8")).
+		Padding(1, 2).
+		Width(36).
+		Align(lipgloss.Left)
+
+	rendered := box.Render(help)
+
+	// Center the box in the terminal.
+	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, rendered)
+}
+
 // View renders the editor UI.
 func (m Model) View() string {
 	if m.quitting {
 		return ""
+	}
+
+	if m.showHelp {
+		return m.renderHelpOverlay()
 	}
 
 	statusBar := m.renderStatusBar()
@@ -302,7 +480,7 @@ func (m Model) renderStatusBar() string {
 	if m.status != "" {
 		right = m.status
 	} else {
-		right = "Ctrl+S save \u00B7 Ctrl+P preview \u00B7 Ctrl+Q quit"
+		right = "Ctrl+S save \u00B7 Ctrl+P preview \u00B7 Ctrl+G help \u00B7 Ctrl+Q quit"
 	}
 
 	// Calculate gap between left and right.

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -40,7 +40,7 @@ func TestCtrlQQuitsWhenClean(t *testing.T) {
 	}
 }
 
-func TestCtrlQShowsWarningWhenModified(t *testing.T) {
+func TestCtrlQShowsPromptWhenModified(t *testing.T) {
 	m := New(Config{Title: "test", Content: "hello"})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = updated.(Model)
@@ -53,22 +53,76 @@ func TestCtrlQShowsWarningWhenModified(t *testing.T) {
 		t.Fatal("editor should be modified after typing")
 	}
 
-	// First Ctrl+Q should show warning, not quit.
+	// Ctrl+Q should show prompt, not quit.
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlQ})
 	m = updated.(Model)
 
 	if cmd != nil {
-		t.Fatal("first Ctrl+Q on modified content should not quit")
+		t.Fatal("Ctrl+Q on modified content should show prompt, not quit")
 	}
-	if !m.quitWarning {
-		t.Fatal("should show quit warning")
+	if !m.quitPrompt {
+		t.Fatal("should show quit prompt")
 	}
 	if m.status == "" {
-		t.Fatal("status should contain warning message")
+		t.Fatal("status should contain prompt message")
 	}
 }
 
-func TestCtrlQTwiceQuitsWhenModified(t *testing.T) {
+func TestQuitPromptSaveAndQuit(t *testing.T) {
+	saved := false
+	var savedContent string
+	saveFn := func(content string) error {
+		saved = true
+		savedContent = content
+		return nil
+	}
+
+	m := New(Config{Title: "test", Content: "hello", Save: saveFn})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Modify content.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = updated.(Model)
+
+	// Ctrl+Q: shows prompt.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlQ})
+	m = updated.(Model)
+
+	if !m.quitPrompt {
+		t.Fatal("should show quit prompt")
+	}
+
+	// Press 'y' to save and quit.
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	m = updated.(Model)
+
+	if cmd == nil {
+		t.Fatal("pressing 'y' should return a save-then-quit command")
+	}
+
+	// Execute the command to trigger save.
+	msg := cmd()
+	if !saved {
+		t.Fatal("save function should have been called")
+	}
+	if savedContent == "" {
+		t.Fatal("saved content should not be empty")
+	}
+
+	// Process the savedQuitMsg.
+	updated, quitCmd := m.Update(msg)
+	m = updated.(Model)
+
+	if !m.quitting {
+		t.Fatal("model should be in quitting state after save-then-quit")
+	}
+	if quitCmd == nil {
+		t.Fatal("should return tea.Quit command")
+	}
+}
+
+func TestQuitPromptDiscardAndQuit(t *testing.T) {
 	m := New(Config{Title: "test", Content: "hello"})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = updated.(Model)
@@ -77,19 +131,54 @@ func TestCtrlQTwiceQuitsWhenModified(t *testing.T) {
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
 	m = updated.(Model)
 
-	// First Ctrl+Q: warning.
+	// Ctrl+Q: shows prompt.
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlQ})
 	m = updated.(Model)
 
-	// Second Ctrl+Q: quit.
-	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlQ})
+	// Press 'n' to quit without saving.
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
 	m = updated.(Model)
 
 	if cmd == nil {
-		t.Fatal("second Ctrl+Q should return tea.Quit command")
+		t.Fatal("pressing 'n' should return tea.Quit command")
 	}
 	if !m.quitting {
 		t.Fatal("model should be in quitting state")
+	}
+}
+
+func TestQuitPromptCancel(t *testing.T) {
+	m := New(Config{Title: "test", Content: "hello"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Modify content.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = updated.(Model)
+
+	// Ctrl+Q: shows prompt.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlQ})
+	m = updated.(Model)
+
+	if !m.quitPrompt {
+		t.Fatal("should show quit prompt")
+	}
+
+	// Press Esc to cancel.
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+
+	if m.quitPrompt {
+		t.Fatal("quit prompt should be dismissed after Esc")
+	}
+	if m.quitting {
+		t.Fatal("should not be quitting after Esc")
+	}
+	if cmd != nil {
+		t.Fatal("Esc should not return a command")
+	}
+	if m.status != "" {
+		t.Fatal("status should be cleared after cancelling prompt")
 	}
 }
 
@@ -177,7 +266,7 @@ func TestCtrlSSaveError(t *testing.T) {
 	}
 }
 
-func TestOtherKeyResetsQuitWarning(t *testing.T) {
+func TestQuitPromptIgnoresOtherKeys(t *testing.T) {
 	m := New(Config{Title: "test", Content: "hello"})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = updated.(Model)
@@ -186,20 +275,26 @@ func TestOtherKeyResetsQuitWarning(t *testing.T) {
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
 	m = updated.(Model)
 
-	// First Ctrl+Q: warning.
+	// Ctrl+Q: shows prompt.
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlQ})
 	m = updated.(Model)
 
-	if !m.quitWarning {
-		t.Fatal("quit warning should be set")
+	if !m.quitPrompt {
+		t.Fatal("quit prompt should be set")
 	}
 
-	// Type another character — should reset the warning.
-	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	// Type an unrelated character — should stay in prompt.
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
 	m = updated.(Model)
 
-	if m.quitWarning {
-		t.Fatal("quit warning should be reset after typing")
+	if !m.quitPrompt {
+		t.Fatal("quit prompt should remain active after pressing unrelated key")
+	}
+	if m.quitting {
+		t.Fatal("should not be quitting")
+	}
+	if cmd != nil {
+		t.Fatal("unrelated key in prompt should not return a command")
 	}
 }
 
@@ -391,12 +486,186 @@ func TestPreviewAutoHidesWhenNarrow(t *testing.T) {
 
 func TestStatusBarContainsPreviewHint(t *testing.T) {
 	m := New(Config{Title: "test", Content: ""})
-	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
 	m = updated.(Model)
 
 	view := m.View()
 	if !containsPlainText(view, "Ctrl+P preview") {
 		t.Fatal("status bar should contain Ctrl+P preview hint")
+	}
+}
+
+func TestStatusBarContainsHelpHint(t *testing.T) {
+	m := New(Config{Title: "test", Content: ""})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = updated.(Model)
+
+	view := m.View()
+	if !containsPlainText(view, "Ctrl+G help") {
+		t.Fatal("status bar should contain Ctrl+G help hint")
+	}
+}
+
+func TestCtrlGTogglesHelp(t *testing.T) {
+	m := New(Config{Title: "test", Content: "hello"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	if m.showHelp {
+		t.Fatal("help should not be visible initially")
+	}
+
+	// Press Ctrl+G to show help.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlG})
+	m = updated.(Model)
+
+	if !m.showHelp {
+		t.Fatal("Ctrl+G should show help overlay")
+	}
+
+	// Press Ctrl+G again to hide help.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlG})
+	m = updated.(Model)
+
+	if m.showHelp {
+		t.Fatal("Ctrl+G should hide help overlay")
+	}
+}
+
+func TestHelpDismissedByEsc(t *testing.T) {
+	m := New(Config{Title: "test", Content: "hello"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Show help.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlG})
+	m = updated.(Model)
+
+	if !m.showHelp {
+		t.Fatal("help should be visible")
+	}
+
+	// Press Esc to dismiss.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+
+	if m.showHelp {
+		t.Fatal("Esc should dismiss help overlay")
+	}
+}
+
+func TestHelpViewContainsKeybindings(t *testing.T) {
+	m := New(Config{Title: "test", Content: "hello"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Show help.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlG})
+	m = updated.(Model)
+
+	view := m.View()
+
+	keybindings := []string{
+		"Ctrl+S", "Save",
+		"Ctrl+Q", "Quit",
+		"Ctrl+C", "Force quit",
+		"Ctrl+P", "Toggle preview",
+		"Ctrl+G", "Toggle this help",
+		"Ctrl+K", "Cut line",
+		"Ctrl+U", "Paste line",
+	}
+	for _, kb := range keybindings {
+		if !containsPlainText(view, kb) {
+			t.Fatalf("help overlay should contain %q", kb)
+		}
+	}
+}
+
+func TestHelpBlocksOtherKeys(t *testing.T) {
+	m := New(Config{Title: "test", Content: "hello"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	contentBefore := m.Content()
+
+	// Show help.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlG})
+	m = updated.(Model)
+
+	// Try to type — should be blocked.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = updated.(Model)
+
+	if m.Content() != contentBefore {
+		t.Fatal("typing should be blocked while help is showing")
+	}
+	if !m.showHelp {
+		t.Fatal("help should still be showing")
+	}
+}
+
+func TestCtrlKCutsLine(t *testing.T) {
+	m := New(Config{Title: "test", Content: "line1\nline2\nline3"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// The textarea cursor starts at the end of the content (last line).
+	// Cut the last line.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlK})
+	m = updated.(Model)
+
+	if m.clipboard != "line3" {
+		t.Fatalf("clipboard should be %q, got %q", "line3", m.clipboard)
+	}
+
+	content := m.Content()
+	if strings.Contains(content, "line3") {
+		t.Fatal("line3 should be removed from content after cut")
+	}
+	if !strings.Contains(content, "line1") || !strings.Contains(content, "line2") {
+		t.Fatal("other lines should remain after cut")
+	}
+}
+
+func TestCtrlUPastesLine(t *testing.T) {
+	m := New(Config{Title: "test", Content: "line1\nline2\nline3"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Cursor is at the end (line3). Cut it.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlK})
+	m = updated.(Model)
+
+	if m.clipboard != "line3" {
+		t.Fatalf("clipboard should be %q, got %q", "line3", m.clipboard)
+	}
+
+	// Now paste — should re-insert line3.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlU})
+	m = updated.(Model)
+
+	content := m.Content()
+	if !strings.Contains(content, "line3") {
+		t.Fatal("pasted line should appear in content")
+	}
+	if !strings.Contains(content, "line1") || !strings.Contains(content, "line2") {
+		t.Fatal("other lines should remain after paste")
+	}
+}
+
+func TestCtrlUNopWithEmptyClipboard(t *testing.T) {
+	m := New(Config{Title: "test", Content: "line1\nline2"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	contentBefore := m.Content()
+
+	// Paste with empty clipboard — should be a no-op.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlU})
+	m = updated.(Model)
+
+	if m.Content() != contentBefore {
+		t.Fatal("paste with empty clipboard should not change content")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Ctrl+G help overlay showing all keybindings
- Ctrl+K cut line / Ctrl+U paste line operations
- Save-on-quit prompt (Y/n/Esc) replacing "press again" flow
- 11 new tests covering all new keybindings

Closes #11

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] `go build` compiles
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)