### PR TITLE
feat: interactive checkboxes, links, and preview mode

### DIFF
--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -12,6 +12,12 @@ import (
 	"github.com/oobagi/notebook/internal/render"
 )
 
+// linkOpenMsg is sent after attempting to open a link in the browser.
+type linkOpenMsg struct {
+	url string
+	err error
+}
+
 // Config holds the configuration for the editor.
 type Config struct {
 	// Title is displayed in the status bar (e.g. "book > note").
@@ -45,21 +51,25 @@ const minSplitWidth = 40
 
 // Model is the Bubble Tea model for the editor.
 type Model struct {
-	textarea     textarea.Model
-	config       Config
-	initial      string
-	width        int
-	height       int
-	status       string
-	statusStyle  statusKind
-	quitPrompt   bool
-	quitting     bool
-	showPreview  bool
-	showHelp     bool
-	clipboard    string
-	preview      string
-	previewDirty bool
-	previewSeq   int
+	textarea       textarea.Model
+	config         Config
+	initial        string
+	width          int
+	height         int
+	status         string
+	statusStyle    statusKind
+	quitPrompt     bool
+	quitting       bool
+	showPreview    bool
+	showHelp       bool
+	clipboard      string
+	preview        string
+	previewDirty   bool
+	previewSeq     int
+	previewMode    bool
+	elements       []Element
+	focusedElement int
+	previewScroll  int
 }
 
 type statusKind int
@@ -143,6 +153,75 @@ func (m *Model) renderPreview() {
 	}
 	m.preview = render.RenderMarkdown(content, pw)
 	m.previewDirty = false
+}
+
+// renderPreviewWithFocus builds a preview pane that shows an element list
+// with the currently focused element highlighted. This is displayed when
+// the editor is in preview mode.
+func (m Model) renderPreviewWithFocus(width, height int) string {
+	var lines []string
+	for i, el := range m.elements {
+		prefix := "  "
+		if i == m.focusedElement {
+			prefix = "> "
+		}
+		line := prefix + elementDisplayText(el)
+		// Truncate to fit width.
+		if len(line) > width {
+			line = line[:width-1] + "\u2026"
+		}
+		lines = append(lines, line)
+	}
+
+	// If there are more lines than height, scroll to keep focused element visible.
+	if len(lines) > height {
+		start := m.focusedElement - height/2
+		if start < 0 {
+			start = 0
+		}
+		end := start + height
+		if end > len(lines) {
+			end = len(lines)
+			start = end - height
+			if start < 0 {
+				start = 0
+			}
+		}
+		lines = lines[start:end]
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// refreshElements re-parses interactive elements from the current content.
+// It clamps the focused element index to remain valid.
+func (m *Model) refreshElements() {
+	m.elements = parseElements(m.textarea.Value())
+	if m.focusedElement >= len(m.elements) {
+		m.focusedElement = len(m.elements) - 1
+	}
+	if m.focusedElement < 0 {
+		m.focusedElement = 0
+	}
+}
+
+// enterPreviewMode switches to preview mode with interactive element navigation.
+func (m *Model) enterPreviewMode() {
+	m.refreshElements()
+	if len(m.elements) == 0 {
+		m.status = "No interactive elements"
+		m.statusStyle = statusWarning
+		return
+	}
+	m.previewMode = true
+	m.focusedElement = 0
+	m.textarea.Blur()
+}
+
+// exitPreviewMode returns to edit mode.
+func (m *Model) exitPreviewMode() {
+	m.previewMode = false
+	m.textarea.Focus()
 }
 
 // schedulePreviewTick increments the sequence counter and returns a tick command.
@@ -290,6 +369,67 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
+		// When in preview mode, handle interactive navigation.
+		if m.previewMode {
+			switch msg.String() {
+			case "ctrl+e", "esc":
+				m.exitPreviewMode()
+				return m, nil
+
+			case "up", "shift+tab":
+				if m.focusedElement > 0 {
+					m.focusedElement--
+				}
+				return m, nil
+
+			case "down", "tab":
+				if m.focusedElement < len(m.elements)-1 {
+					m.focusedElement++
+				}
+				return m, nil
+
+			case "enter", " ":
+				if m.focusedElement >= 0 && m.focusedElement < len(m.elements) {
+					el := m.elements[m.focusedElement]
+					switch el.Kind {
+					case ElementCheckbox:
+						newContent, checked := toggleCheckbox(m.textarea.Value(), el.Line)
+						m.textarea.SetValue(newContent)
+						m.elements[m.focusedElement].Checked = checked
+						m.refreshElements()
+						m.previewDirty = true
+						return m, m.schedulePreviewTick()
+					case ElementLink:
+						url := el.URL
+						m.status = "Opening link..."
+						m.statusStyle = statusSuccess
+						return m, func() tea.Msg {
+							err := openLink(url)
+							return linkOpenMsg{url: url, err: err}
+						}
+					}
+				}
+				return m, nil
+
+			case "ctrl+q":
+				if m.modified() {
+					m.exitPreviewMode()
+					m.quitPrompt = true
+					m.status = "Save before quitting? [Y/n/Esc]"
+					m.statusStyle = statusWarning
+					return m, nil
+				}
+				m.quitting = true
+				return m, tea.Quit
+
+			case "ctrl+c":
+				m.quitting = true
+				return m, tea.Quit
+			}
+			// Ignore all other keys in preview mode.
+			return m, nil
+		}
+
 		// Clear transient status on any keypress.
 		if m.statusStyle == statusSuccess {
 			m.status = ""
@@ -297,6 +437,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		switch msg.String() {
+		case "ctrl+e":
+			if m.showPreview && m.width >= minSplitWidth {
+				m.enterPreviewMode()
+			}
+			return m, nil
+
 		case "ctrl+g":
 			m.showHelp = true
 			return m, nil
@@ -347,6 +493,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 
+	case linkOpenMsg:
+		if msg.err != nil {
+			m.status = fmt.Sprintf("Failed to open link: %s", msg.err)
+			m.statusStyle = statusError
+		}
+		return m, nil
+
 	case savedMsg:
 		m.initial = msg.content
 		m.status = "Saved"
@@ -388,6 +541,7 @@ func (m Model) renderHelpOverlay() string {
   Ctrl+Q    Quit
   Ctrl+C    Force quit (no save)
   Ctrl+P    Toggle preview
+  Ctrl+E    Preview mode
   Ctrl+G    Toggle this help
   Ctrl+K    Cut line
   Ctrl+U    Paste line
@@ -455,7 +609,14 @@ func (m Model) View() string {
 		Height(editorHeight)
 
 	leftPane := m.textarea.View()
-	rightPane := previewStyle.Render(m.preview)
+
+	// When in preview mode, overlay a focused-element indicator on the preview.
+	previewContent := m.preview
+	if m.previewMode && len(m.elements) > 0 {
+		previewContent = m.renderPreviewWithFocus(rightWidth, editorHeight)
+	}
+
+	rightPane := previewStyle.Render(previewContent)
 
 	split := lipgloss.JoinHorizontal(lipgloss.Top, leftPane, border, rightPane)
 
@@ -469,8 +630,11 @@ func (m Model) renderStatusBar() string {
 		width = 80
 	}
 
-	// Left side: title + modified indicator.
+	// Left side: title + mode indicator + modified indicator.
 	left := m.config.Title
+	if m.previewMode {
+		left += " PREVIEW"
+	}
 	if m.modified() {
 		left += " [modified]"
 	}
@@ -479,8 +643,10 @@ func (m Model) renderStatusBar() string {
 	var right string
 	if m.status != "" {
 		right = m.status
+	} else if m.previewMode {
+		right = "\u2191/\u2193 navigate \u00B7 Enter toggle/open \u00B7 Ctrl+E edit \u00B7 Ctrl+Q quit"
 	} else {
-		right = "Ctrl+S save \u00B7 Ctrl+P preview \u00B7 Ctrl+G help \u00B7 Ctrl+Q quit"
+		right = "Ctrl+S save \u00B7 Ctrl+E preview \u00B7 Ctrl+G help \u00B7 Ctrl+Q quit"
 	}
 
 	// Calculate gap between left and right.

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -490,8 +490,8 @@ func TestStatusBarContainsPreviewHint(t *testing.T) {
 	m = updated.(Model)
 
 	view := m.View()
-	if !containsPlainText(view, "Ctrl+P preview") {
-		t.Fatal("status bar should contain Ctrl+P preview hint")
+	if !containsPlainText(view, "Ctrl+E preview") {
+		t.Fatal("status bar should contain Ctrl+E preview hint")
 	}
 }
 
@@ -687,6 +687,237 @@ func TestStatusBarShowsModifiedIndicator(t *testing.T) {
 	view = m.View()
 	if !containsPlainText(view, "[modified]") {
 		t.Fatal("should show [modified] after content is changed")
+	}
+}
+
+func TestCtrlETogglesPreviewMode(t *testing.T) {
+	content := "- [ ] task one\n- [x] task two"
+	m := New(Config{Title: "test", Content: content})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	if m.previewMode {
+		t.Fatal("preview mode should be off initially")
+	}
+
+	// Press Ctrl+E to enter preview mode.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlE})
+	m = updated.(Model)
+
+	if !m.previewMode {
+		t.Fatal("Ctrl+E should activate preview mode")
+	}
+	if len(m.elements) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(m.elements))
+	}
+
+	// Press Ctrl+E again to exit preview mode.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlE})
+	m = updated.(Model)
+
+	if m.previewMode {
+		t.Fatal("Ctrl+E should deactivate preview mode")
+	}
+}
+
+func TestCtrlENoElementsShowsWarning(t *testing.T) {
+	content := "just plain text"
+	m := New(Config{Title: "test", Content: content})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Press Ctrl+E with no interactive elements.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlE})
+	m = updated.(Model)
+
+	if m.previewMode {
+		t.Fatal("preview mode should not activate with no elements")
+	}
+	if m.status == "" {
+		t.Fatal("should show a warning status when no elements found")
+	}
+}
+
+func TestPreviewModeNavigatesElements(t *testing.T) {
+	content := "- [ ] first\n- [ ] second\n- [ ] third"
+	m := New(Config{Title: "test", Content: content})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Enter preview mode.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlE})
+	m = updated.(Model)
+
+	if m.focusedElement != 0 {
+		t.Fatalf("focused element should start at 0, got %d", m.focusedElement)
+	}
+
+	// Down arrow.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(Model)
+
+	if m.focusedElement != 1 {
+		t.Fatalf("focused element should be 1 after down, got %d", m.focusedElement)
+	}
+
+	// Down again.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(Model)
+
+	if m.focusedElement != 2 {
+		t.Fatalf("focused element should be 2 after second down, got %d", m.focusedElement)
+	}
+
+	// Down at end should stay at 2.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(Model)
+
+	if m.focusedElement != 2 {
+		t.Fatalf("focused element should stay at 2 when at end, got %d", m.focusedElement)
+	}
+
+	// Up arrow.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(Model)
+
+	if m.focusedElement != 1 {
+		t.Fatalf("focused element should be 1 after up, got %d", m.focusedElement)
+	}
+
+	// Up at beginning should stay at 0.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(Model)
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(Model)
+
+	if m.focusedElement != 0 {
+		t.Fatalf("focused element should stay at 0 when at beginning, got %d", m.focusedElement)
+	}
+}
+
+func TestPreviewModeTabNavigation(t *testing.T) {
+	content := "- [ ] first\n- [ ] second"
+	m := New(Config{Title: "test", Content: content})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Enter preview mode.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlE})
+	m = updated.(Model)
+
+	// Tab moves forward.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+
+	if m.focusedElement != 1 {
+		t.Fatalf("Tab should move to next element, got %d", m.focusedElement)
+	}
+
+	// Shift+Tab moves backward.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	m = updated.(Model)
+
+	if m.focusedElement != 0 {
+		t.Fatalf("Shift+Tab should move to previous element, got %d", m.focusedElement)
+	}
+}
+
+func TestPreviewModeToggleCheckbox(t *testing.T) {
+	content := "- [ ] unchecked\n- [x] checked"
+	m := New(Config{Title: "test", Content: content})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Enter preview mode.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlE})
+	m = updated.(Model)
+
+	// Press Enter to toggle first checkbox (unchecked -> checked).
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+
+	if !strings.Contains(m.Content(), "- [x] unchecked") {
+		t.Fatalf("checkbox should be toggled to checked, got: %q", m.Content())
+	}
+
+	// Navigate to second checkbox.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(Model)
+
+	// Press Space to toggle second checkbox (checked -> unchecked).
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	m = updated.(Model)
+
+	if !strings.Contains(m.Content(), "- [ ] checked") {
+		t.Fatalf("checkbox should be toggled to unchecked, got: %q", m.Content())
+	}
+}
+
+func TestPreviewModeEscReturnsToEdit(t *testing.T) {
+	content := "- [ ] task"
+	m := New(Config{Title: "test", Content: content})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Enter preview mode.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlE})
+	m = updated.(Model)
+
+	if !m.previewMode {
+		t.Fatal("should be in preview mode")
+	}
+
+	// Press Esc to exit.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+
+	if m.previewMode {
+		t.Fatal("Esc should exit preview mode")
+	}
+}
+
+func TestPreviewModeStatusBar(t *testing.T) {
+	content := "- [ ] task"
+	m := New(Config{Title: "test", Content: content})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = updated.(Model)
+
+	// Enter preview mode.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlE})
+	m = updated.(Model)
+
+	view := m.View()
+
+	if !containsPlainText(view, "PREVIEW") {
+		t.Fatal("status bar should contain PREVIEW indicator in preview mode")
+	}
+	if !containsPlainText(view, "navigate") {
+		t.Fatal("status bar should contain navigate hint in preview mode")
+	}
+	if !containsPlainText(view, "toggle/open") {
+		t.Fatal("status bar should contain toggle/open hint in preview mode")
+	}
+}
+
+func TestPreviewModeBlocksTyping(t *testing.T) {
+	content := "- [ ] task"
+	m := New(Config{Title: "test", Content: content})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	contentBefore := m.Content()
+
+	// Enter preview mode.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlE})
+	m = updated.(Model)
+
+	// Try to type — should be blocked.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = updated.(Model)
+
+	if m.Content() != contentBefore {
+		t.Fatal("typing should be blocked in preview mode")
 	}
 }
 

--- a/internal/editor/interactive.go
+++ b/internal/editor/interactive.go
@@ -1,0 +1,138 @@
+package editor
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// ElementKind distinguishes interactive element types found in the markdown.
+type ElementKind int
+
+const (
+	// ElementCheckbox represents a markdown checkbox (- [ ] or - [x]).
+	ElementCheckbox ElementKind = iota
+	// ElementLink represents a markdown link ([text](url)).
+	ElementLink
+)
+
+// Element represents an interactive element found in markdown content.
+type Element struct {
+	Kind    ElementKind
+	Line    int    // zero-based line number in the source markdown
+	Col     int    // column offset in the source line
+	Text    string // display text
+	URL     string // for links
+	Checked bool   // for checkboxes
+}
+
+// checkboxRe matches markdown checkboxes: optional whitespace, dash, space,
+// bracket-space/x-bracket, then text.
+var checkboxRe = regexp.MustCompile(`^(\s*)-\s+\[([ xX])\]\s*(.*)$`)
+
+// linkRe matches inline markdown links: [text](url).
+var linkRe = regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`)
+
+// parseElements scans markdown content and extracts interactive elements
+// (checkboxes and links). It returns them in document order.
+func parseElements(content string) []Element {
+	if content == "" {
+		return nil
+	}
+
+	var elements []Element
+	lines := strings.Split(content, "\n")
+
+	for i, line := range lines {
+		// Check for checkboxes first.
+		if m := checkboxRe.FindStringSubmatchIndex(line); m != nil {
+			// m[0..1] = full match
+			// m[2..3] = leading whitespace
+			// m[4..5] = check character (space or x/X)
+			// m[6..7] = text after checkbox
+			checkChar := line[m[4]:m[5]]
+			text := line[m[6]:m[7]]
+			col := m[0] // start of the full match (same as leading whitespace start)
+
+			elements = append(elements, Element{
+				Kind:    ElementCheckbox,
+				Line:    i,
+				Col:     col,
+				Text:    text,
+				Checked: checkChar == "x" || checkChar == "X",
+			})
+		}
+
+		// Find all links in the line.
+		linkMatches := linkRe.FindAllStringSubmatchIndex(line, -1)
+		for _, lm := range linkMatches {
+			// lm[0..1] = full match
+			// lm[2..3] = link text
+			// lm[4..5] = URL
+			text := line[lm[2]:lm[3]]
+			url := line[lm[4]:lm[5]]
+			col := lm[0]
+
+			elements = append(elements, Element{
+				Kind: ElementLink,
+				Line: i,
+				Col:  col,
+				Text: text,
+				URL:  url,
+			})
+		}
+	}
+
+	return elements
+}
+
+// toggleCheckbox toggles the checkbox on the given line in the content string.
+// It replaces "- [ ]" with "- [x]" or vice versa. Returns the modified content
+// and the new checked state.
+func toggleCheckbox(content string, line int) (string, bool) {
+	lines := strings.Split(content, "\n")
+	if line < 0 || line >= len(lines) {
+		return content, false
+	}
+
+	l := lines[line]
+	var newChecked bool
+
+	if strings.Contains(l, "- [ ]") {
+		lines[line] = strings.Replace(l, "- [ ]", "- [x]", 1)
+		newChecked = true
+	} else if strings.Contains(l, "- [x]") {
+		lines[line] = strings.Replace(l, "- [x]", "- [ ]", 1)
+		newChecked = false
+	} else if strings.Contains(l, "- [X]") {
+		lines[line] = strings.Replace(l, "- [X]", "- [ ]", 1)
+		newChecked = false
+	} else {
+		return content, false
+	}
+
+	return strings.Join(lines, "\n"), newChecked
+}
+
+// openLink opens a URL in the default browser (macOS only).
+func openLink(url string) error {
+	return exec.Command("open", url).Start()
+}
+
+// elementDisplayText returns a short label for an element, used in the preview
+// to indicate the focused item.
+func elementDisplayText(el Element) string {
+	switch el.Kind {
+	case ElementCheckbox:
+		mark := " "
+		if el.Checked {
+			mark = "x"
+		}
+		return fmt.Sprintf("[%s] %s", mark, el.Text)
+	case ElementLink:
+		return fmt.Sprintf("%s (%s)", el.Text, el.URL)
+	default:
+		return el.Text
+	}
+}

--- a/internal/editor/interactive_test.go
+++ b/internal/editor/interactive_test.go
@@ -1,0 +1,259 @@
+package editor
+
+import (
+	"testing"
+)
+
+func TestParseCheckboxes(t *testing.T) {
+	content := "- [ ] unchecked item\n- [x] checked item"
+	elements := parseElements(content)
+
+	checkboxes := filterByKind(elements, ElementCheckbox)
+	if len(checkboxes) != 2 {
+		t.Fatalf("expected 2 checkboxes, got %d", len(checkboxes))
+	}
+
+	if checkboxes[0].Text != "unchecked item" {
+		t.Fatalf("expected text %q, got %q", "unchecked item", checkboxes[0].Text)
+	}
+	if checkboxes[0].Checked {
+		t.Fatal("first checkbox should be unchecked")
+	}
+	if checkboxes[0].Line != 0 {
+		t.Fatalf("first checkbox should be on line 0, got %d", checkboxes[0].Line)
+	}
+
+	if checkboxes[1].Text != "checked item" {
+		t.Fatalf("expected text %q, got %q", "checked item", checkboxes[1].Text)
+	}
+	if !checkboxes[1].Checked {
+		t.Fatal("second checkbox should be checked")
+	}
+	if checkboxes[1].Line != 1 {
+		t.Fatalf("second checkbox should be on line 1, got %d", checkboxes[1].Line)
+	}
+}
+
+func TestParseLinks(t *testing.T) {
+	content := "Check out [Google](https://google.com) and [GitHub](https://github.com)."
+	elements := parseElements(content)
+
+	links := filterByKind(elements, ElementLink)
+	if len(links) != 2 {
+		t.Fatalf("expected 2 links, got %d", len(links))
+	}
+
+	if links[0].Text != "Google" {
+		t.Fatalf("expected text %q, got %q", "Google", links[0].Text)
+	}
+	if links[0].URL != "https://google.com" {
+		t.Fatalf("expected URL %q, got %q", "https://google.com", links[0].URL)
+	}
+
+	if links[1].Text != "GitHub" {
+		t.Fatalf("expected text %q, got %q", "GitHub", links[1].Text)
+	}
+	if links[1].URL != "https://github.com" {
+		t.Fatalf("expected URL %q, got %q", "https://github.com", links[1].URL)
+	}
+}
+
+func TestParseNestedCheckboxes(t *testing.T) {
+	content := "- [ ] top level\n  - [ ] nested once\n    - [x] nested twice"
+	elements := parseElements(content)
+
+	checkboxes := filterByKind(elements, ElementCheckbox)
+	if len(checkboxes) != 3 {
+		t.Fatalf("expected 3 checkboxes, got %d", len(checkboxes))
+	}
+
+	if checkboxes[0].Text != "top level" {
+		t.Fatalf("expected text %q, got %q", "top level", checkboxes[0].Text)
+	}
+	if checkboxes[0].Col != 0 {
+		t.Fatalf("top level checkbox col should be 0, got %d", checkboxes[0].Col)
+	}
+
+	if checkboxes[1].Text != "nested once" {
+		t.Fatalf("expected text %q, got %q", "nested once", checkboxes[1].Text)
+	}
+	if checkboxes[1].Col != 0 {
+		// The full match starts at column 0 because leading whitespace is part of the match.
+		// But the indentation is captured as part of the match start.
+	}
+
+	if checkboxes[2].Text != "nested twice" {
+		t.Fatalf("expected text %q, got %q", "nested twice", checkboxes[2].Text)
+	}
+	if !checkboxes[2].Checked {
+		t.Fatal("third checkbox should be checked")
+	}
+}
+
+func TestToggleCheckbox(t *testing.T) {
+	content := "- [ ] first\n- [x] second\n- [ ] third"
+
+	// Toggle first: unchecked -> checked.
+	result, checked := toggleCheckbox(content, 0)
+	if !checked {
+		t.Fatal("toggling unchecked should return checked=true")
+	}
+	lines := splitLines(result)
+	if lines[0] != "- [x] first" {
+		t.Fatalf("expected %q, got %q", "- [x] first", lines[0])
+	}
+	// Other lines unchanged.
+	if lines[1] != "- [x] second" {
+		t.Fatalf("expected %q, got %q", "- [x] second", lines[1])
+	}
+	if lines[2] != "- [ ] third" {
+		t.Fatalf("expected %q, got %q", "- [ ] third", lines[2])
+	}
+
+	// Toggle second: checked -> unchecked.
+	result, checked = toggleCheckbox(content, 1)
+	if checked {
+		t.Fatal("toggling checked should return checked=false")
+	}
+	lines = splitLines(result)
+	if lines[1] != "- [ ] second" {
+		t.Fatalf("expected %q, got %q", "- [ ] second", lines[1])
+	}
+}
+
+func TestToggleCheckboxOutOfRange(t *testing.T) {
+	content := "- [ ] item"
+
+	result, _ := toggleCheckbox(content, 5)
+	if result != content {
+		t.Fatal("toggling out-of-range line should return original content")
+	}
+
+	result, _ = toggleCheckbox(content, -1)
+	if result != content {
+		t.Fatal("toggling negative line should return original content")
+	}
+}
+
+func TestToggleCheckboxNonCheckboxLine(t *testing.T) {
+	content := "just text\n- [ ] item"
+
+	result, _ := toggleCheckbox(content, 0)
+	if result != content {
+		t.Fatal("toggling non-checkbox line should return original content")
+	}
+}
+
+func TestParseEmpty(t *testing.T) {
+	elements := parseElements("")
+	if len(elements) != 0 {
+		t.Fatalf("expected 0 elements, got %d", len(elements))
+	}
+}
+
+func TestParseMixedContent(t *testing.T) {
+	content := `# Shopping List
+
+- [ ] Buy groceries
+- [x] Clean house
+
+Check [recipes](https://recipes.com) for ideas.
+
+- [ ] Cook dinner
+
+Also see [tips](https://tips.com).`
+
+	elements := parseElements(content)
+
+	checkboxes := filterByKind(elements, ElementCheckbox)
+	links := filterByKind(elements, ElementLink)
+
+	if len(checkboxes) != 3 {
+		t.Fatalf("expected 3 checkboxes, got %d", len(checkboxes))
+	}
+	if len(links) != 2 {
+		t.Fatalf("expected 2 links, got %d", len(links))
+	}
+
+	// Verify order: elements should be in document order.
+	if elements[0].Kind != ElementCheckbox {
+		t.Fatal("first element should be a checkbox")
+	}
+	if elements[1].Kind != ElementCheckbox {
+		t.Fatal("second element should be a checkbox")
+	}
+	if elements[2].Kind != ElementLink {
+		t.Fatal("third element should be a link")
+	}
+	if elements[3].Kind != ElementCheckbox {
+		t.Fatal("fourth element should be a checkbox")
+	}
+	if elements[4].Kind != ElementLink {
+		t.Fatal("fifth element should be a link")
+	}
+}
+
+func TestParseUppercaseX(t *testing.T) {
+	content := "- [X] uppercase checked"
+	elements := parseElements(content)
+
+	if len(elements) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(elements))
+	}
+	if !elements[0].Checked {
+		t.Fatal("uppercase X checkbox should be checked")
+	}
+}
+
+func TestToggleUppercaseX(t *testing.T) {
+	content := "- [X] item"
+	result, checked := toggleCheckbox(content, 0)
+	if checked {
+		t.Fatal("toggling uppercase X should return checked=false")
+	}
+	if result != "- [ ] item" {
+		t.Fatalf("expected %q, got %q", "- [ ] item", result)
+	}
+}
+
+func TestElementDisplayText(t *testing.T) {
+	checkbox := Element{Kind: ElementCheckbox, Text: "task", Checked: false}
+	if got := elementDisplayText(checkbox); got != "[ ] task" {
+		t.Fatalf("expected %q, got %q", "[ ] task", got)
+	}
+
+	checkedBox := Element{Kind: ElementCheckbox, Text: "done", Checked: true}
+	if got := elementDisplayText(checkedBox); got != "[x] done" {
+		t.Fatalf("expected %q, got %q", "[x] done", got)
+	}
+
+	link := Element{Kind: ElementLink, Text: "Go", URL: "https://go.dev"}
+	if got := elementDisplayText(link); got != "Go (https://go.dev)" {
+		t.Fatalf("expected %q, got %q", "Go (https://go.dev)", got)
+	}
+}
+
+// --- helpers ---
+
+func filterByKind(elements []Element, kind ElementKind) []Element {
+	var result []Element
+	for _, el := range elements {
+		if el.Kind == kind {
+			result = append(result, el)
+		}
+	}
+	return result
+}
+
+func splitLines(s string) []string {
+	var lines []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			lines = append(lines, s[start:i])
+			start = i + 1
+		}
+	}
+	lines = append(lines, s[start:])
+	return lines
+}


### PR DESCRIPTION
## Summary
- Ctrl+E toggles preview mode for interacting with markdown elements
- Checkboxes toggled with Enter/Space, state syncs to markdown source
- Links opened in browser with Enter
- Arrow keys, Tab/Shift+Tab navigate between elements
- 19 new tests (11 parsing + 8 editor integration)

Closes #16

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] `go build` compiles
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)