### PR TITLE
feat: full-text search across notes and notebooks

### DIFF
--- a/cmd/dispatcher.go
+++ b/cmd/dispatcher.go
@@ -151,8 +151,7 @@ func deleteNoteFromBook(w io.Writer, book, note string) error {
 }
 
 func searchInBook(w io.Writer, book, query string) error {
-	fmt.Fprintln(w, "search: not implemented yet")
-	return nil
+	return runSearch(w, query, book, false)
 }
 
 // --- Note-scoped operations ---

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -163,13 +163,18 @@ func TestDispatchBookDelete(t *testing.T) {
 
 func TestDispatchBookSearch(t *testing.T) {
 	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNote("work", "todo", "hello world")
 
 	out, err := executeCapture([]string{"--dir", dir, "work", "search", "hello"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(out, "not implemented") {
-		t.Errorf("expected stub message, got %q", out)
+	if !strings.Contains(out, "work") {
+		t.Errorf("expected 'work' in output, got %q", out)
+	}
+	if !strings.Contains(out, "todo") {
+		t.Errorf("expected 'todo' in output, got %q", out)
 	}
 }
 
@@ -389,8 +394,9 @@ func TestTopLevelSearch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(out, "not implemented") {
-		t.Errorf("expected stub message, got %q", out)
+	// No notebooks exist, so should show "No matches".
+	if !strings.Contains(out, "No matches") {
+		t.Errorf("expected 'No matches' message, got %q", out)
 	}
 }
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -2,8 +2,16 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"strings"
 
+	"github.com/oobagi/notebook/internal/storage"
 	"github.com/spf13/cobra"
+)
+
+var (
+	searchNotebookFlag    string
+	searchCaseSensitive   bool
 )
 
 var searchCmd = &cobra.Command{
@@ -11,11 +19,175 @@ var searchCmd = &cobra.Command{
 	Short: "Search across all notebooks",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Fprintln(cmd.OutOrStdout(), "search: not implemented yet")
-		return nil
+		return runSearch(cmd.OutOrStdout(), args[0], searchNotebookFlag, searchCaseSensitive)
 	},
 }
 
 func init() {
+	searchCmd.Flags().StringVar(&searchNotebookFlag, "notebook", "", "limit search to a specific notebook")
+	searchCmd.Flags().BoolVar(&searchCaseSensitive, "case-sensitive", false, "use case-sensitive matching")
 	rootCmd.AddCommand(searchCmd)
+}
+
+// runSearch executes the search and prints formatted results.
+func runSearch(w io.Writer, query, notebook string, caseSensitive bool) error {
+	results, err := store.SearchNotes(query, notebook, caseSensitive)
+	if err != nil {
+		return fmt.Errorf("search: %w", err)
+	}
+
+	if len(results) == 0 {
+		printInfo(w, fmt.Sprintf("No matches for %q", query))
+		return nil
+	}
+
+	printSearchResults(w, results, query, caseSensitive)
+	return nil
+}
+
+// printSearchResults formats and prints search results according to the
+// design system: breadcrumb path, snippet with bold match, summary count.
+func printSearchResults(w io.Writer, results []storage.SearchResult, query string, caseSensitive bool) {
+	// Group results by notebook+note to show one breadcrumb per note,
+	// using the first matching line as the snippet.
+	type key struct{ notebook, note string }
+	seen := make(map[key]bool)
+	var unique []storage.SearchResult
+	for _, r := range results {
+		k := key{r.Notebook, r.Note}
+		if !seen[k] {
+			seen[k] = true
+			unique = append(unique, r)
+		}
+	}
+
+	books := make(map[string]bool)
+	for i, r := range unique {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		books[r.Notebook] = true
+
+		// Breadcrumb: "  Work > Meeting Notes"
+		fmt.Fprintf(w, "  %s \u203A %s\n", r.Notebook, r.Note)
+
+		// Snippet: "    ...discussed the quarterly plan and..."
+		snippet := formatSnippet(r.Text, query, caseSensitive)
+		fmt.Fprintf(w, "    %s\n", snippet)
+	}
+
+	// Summary line
+	fmt.Fprintln(w)
+	matchWord := "match"
+	if len(unique) != 1 {
+		matchWord = "matches"
+	}
+	bookWord := "book"
+	if len(books) != 1 {
+		bookWord = "books"
+	}
+	fmt.Fprintf(w, "  \x1b[2m%d %s across %d %s\x1b[0m\n", len(unique), matchWord, len(books), bookWord)
+}
+
+// formatSnippet creates a truncated snippet line with the matched term in bold.
+// The snippet is at most ~60 chars, with ellipsis on sides if truncated.
+func formatSnippet(line, query string, caseSensitive bool) string {
+	const maxLen = 60
+
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return "\u2026"
+	}
+
+	// Find the match position in the line for centering.
+	haystack := trimmed
+	needle := query
+	if !caseSensitive {
+		haystack = strings.ToLower(trimmed)
+		needle = strings.ToLower(query)
+	}
+
+	idx := strings.Index(haystack, needle)
+	if idx < 0 {
+		// Should not happen, but handle gracefully.
+		if len(trimmed) > maxLen {
+			return "\u2026" + trimmed[:maxLen-1] + "\u2026"
+		}
+		return trimmed
+	}
+
+	// Extract a window of ~maxLen chars centered on the match.
+	matchLen := len(query)
+	// Available space for context around the match (account for ANSI bold codes which are invisible).
+	contextBudget := maxLen - matchLen
+	if contextBudget < 0 {
+		contextBudget = 0
+	}
+	leftCtx := contextBudget / 2
+	rightCtx := contextBudget - leftCtx
+
+	start := idx - leftCtx
+	end := idx + matchLen + rightCtx
+
+	prefixEllipsis := false
+	suffixEllipsis := false
+
+	if start < 0 {
+		// Shift surplus to the right side.
+		end += -start
+		start = 0
+	}
+	if end > len(trimmed) {
+		// Shift surplus to the left side.
+		start -= end - len(trimmed)
+		end = len(trimmed)
+	}
+	if start < 0 {
+		start = 0
+	}
+
+	if start > 0 {
+		prefixEllipsis = true
+		start++ // make room for the ellipsis character
+		if start > idx {
+			start = idx
+		}
+	}
+	if end < len(trimmed) {
+		suffixEllipsis = true
+		end-- // make room for the ellipsis character
+		if end < idx+matchLen {
+			end = idx + matchLen
+		}
+	}
+
+	window := trimmed[start:end]
+
+	// Rebuild with bold match. We need to find the match in the window.
+	winHaystack := window
+	winNeedle := query
+	if !caseSensitive {
+		winHaystack = strings.ToLower(window)
+		winNeedle = strings.ToLower(query)
+	}
+	winIdx := strings.Index(winHaystack, winNeedle)
+
+	var b strings.Builder
+	if prefixEllipsis {
+		b.WriteString("\u2026")
+	}
+	if winIdx >= 0 {
+		b.WriteString(window[:winIdx])
+		b.WriteString("\x1b[1m")
+		b.WriteString(window[winIdx : winIdx+matchLen])
+		b.WriteString("\x1b[0m")
+		b.WriteString(window[winIdx+matchLen:])
+	} else {
+		b.WriteString(window)
+	}
+	if suffixEllipsis {
+		b.WriteString("\u2026")
+	}
+
+	return b.String()
 }

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/oobagi/notebook/internal/storage"
+)
+
+func TestSearchCommand(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNote("Work", "Meeting Notes", "discussed the quarterly plan and budget")
+	_ = st.CreateNote("Personal", "Journal", "reminded me of the quarterly review")
+
+	out, err := executeCapture([]string{"--dir", dir, "search", "quarterly"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should contain breadcrumb-style output.
+	if !strings.Contains(out, "\u203A") {
+		t.Errorf("expected breadcrumb separator in output, got %q", out)
+	}
+
+	// Should contain both notebook names.
+	if !strings.Contains(out, "Work") {
+		t.Errorf("expected 'Work' in output, got %q", out)
+	}
+	if !strings.Contains(out, "Personal") {
+		t.Errorf("expected 'Personal' in output, got %q", out)
+	}
+
+	// Should contain match term (in bold ANSI).
+	if !strings.Contains(out, "quarterly") {
+		t.Errorf("expected 'quarterly' in output, got %q", out)
+	}
+
+	// Should contain summary line.
+	if !strings.Contains(out, "2 matches") {
+		t.Errorf("expected '2 matches' in output, got %q", out)
+	}
+	if !strings.Contains(out, "2 books") {
+		t.Errorf("expected '2 books' in output, got %q", out)
+	}
+}
+
+func TestSearchBookScoped(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNote("work", "todo", "buy milk for the team")
+	_ = st.CreateNote("personal", "list", "buy milk at the store")
+
+	out, err := executeCapture([]string{"--dir", dir, "work", "search", "milk"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should only contain work results.
+	if !strings.Contains(out, "work") {
+		t.Errorf("expected 'work' in output, got %q", out)
+	}
+	if !strings.Contains(out, "todo") {
+		t.Errorf("expected 'todo' in output, got %q", out)
+	}
+
+	// Should NOT contain personal results.
+	if strings.Contains(out, "personal") {
+		t.Errorf("scoped search should not contain 'personal', got %q", out)
+	}
+
+	// Should show 1 match across 1 book.
+	if !strings.Contains(out, "1 match across 1 book") {
+		t.Errorf("expected '1 match across 1 book' in output, got %q", out)
+	}
+}
+
+func TestSearchNoResults(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNote("nb", "note", "nothing relevant")
+
+	out, err := executeCapture([]string{"--dir", dir, "search", "zzzzz"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out, "No matches") {
+		t.Errorf("expected 'No matches' in output, got %q", out)
+	}
+}
+
+func TestSearchCaseSensitiveFlag(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNote("nb", "note", "Hello World\nhello world")
+
+	// Case-sensitive: only "Hello" should match line 1.
+	out, err := executeCapture([]string{"--dir", dir, "search", "--case-sensitive", "Hello"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "1 match") {
+		t.Errorf("expected exactly '1 match' for case-sensitive search, got %q", out)
+	}
+}
+
+func TestSearchOutputFormat(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNote("Work", "Notes", "the quarterly plan was discussed")
+
+	out, err := executeCapture([]string{"--dir", dir, "search", "quarterly"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+
+	// First line: breadcrumb with two-space indent.
+	if len(lines) < 1 || !strings.HasPrefix(lines[0], "  ") {
+		t.Errorf("breadcrumb line missing two-space indent: %q", lines[0])
+	}
+	if !strings.Contains(lines[0], "Work \u203A Notes") {
+		t.Errorf("expected breadcrumb 'Work > Notes', got %q", lines[0])
+	}
+
+	// Second line: snippet with four-space indent.
+	if len(lines) < 2 || !strings.HasPrefix(lines[1], "    ") {
+		t.Errorf("snippet line missing four-space indent: %q", lines[1])
+	}
+
+	// Should contain bold ANSI around the match.
+	if !strings.Contains(lines[1], "\x1b[1m") {
+		t.Errorf("expected ANSI bold in snippet, got %q", lines[1])
+	}
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,15 +1,25 @@
 package storage
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/oobagi/notebook/internal/model"
 )
+
+// SearchResult represents a single line that matched a search query.
+type SearchResult struct {
+	Notebook string
+	Note     string
+	Line     int    // 1-based line number
+	Text     string // the matching line
+}
 
 // ErrInvalidName is returned when a notebook or note name contains
 // path-traversal sequences or is otherwise unsafe for use as a filename.
@@ -276,4 +286,87 @@ func (s *Store) UpdateNote(notebook, name, content string) error {
 		return fmt.Errorf("update note %q/%q: %w", notebook, name, err)
 	}
 	return nil
+}
+
+// SearchNotes searches for a query string across notes. If notebook is
+// non-empty, only that notebook is searched. Results are sorted by
+// notebook, note name, then line number.
+func (s *Store) SearchNotes(query string, notebook string, caseSensitive bool) ([]SearchResult, error) {
+	var notebooks []string
+	if notebook != "" {
+		if err := validName(notebook); err != nil {
+			return nil, err
+		}
+		notebooks = []string{notebook}
+	} else {
+		var err error
+		notebooks, err = s.ListNotebooks()
+		if err != nil {
+			return nil, fmt.Errorf("search: list notebooks: %w", err)
+		}
+	}
+
+	q := query
+	if !caseSensitive {
+		q = strings.ToLower(query)
+	}
+
+	var results []SearchResult
+	for _, nb := range notebooks {
+		dir := s.notebookPath(nb)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("search: read dir %q: %w", nb, err)
+		}
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+				continue
+			}
+			noteName := strings.TrimSuffix(e.Name(), ".md")
+			p := filepath.Join(dir, e.Name())
+
+			f, err := os.Open(p)
+			if err != nil {
+				return nil, fmt.Errorf("search: open %q/%q: %w", nb, noteName, err)
+			}
+
+			scanner := bufio.NewScanner(f)
+			lineNum := 0
+			for scanner.Scan() {
+				lineNum++
+				line := scanner.Text()
+				haystack := line
+				if !caseSensitive {
+					haystack = strings.ToLower(line)
+				}
+				if strings.Contains(haystack, q) {
+					results = append(results, SearchResult{
+						Notebook: nb,
+						Note:     noteName,
+						Line:     lineNum,
+						Text:     line,
+					})
+				}
+			}
+			f.Close()
+			if err := scanner.Err(); err != nil {
+				return nil, fmt.Errorf("search: scan %q/%q: %w", nb, noteName, err)
+			}
+		}
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Notebook != results[j].Notebook {
+			return results[i].Notebook < results[j].Notebook
+		}
+		if results[i].Note != results[j].Note {
+			return results[i].Note < results[j].Note
+		}
+		return results[i].Line < results[j].Line
+	})
+
+	return results, nil
 }

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -449,3 +449,97 @@ func TestListNotesNonExistentNotebook(t *testing.T) {
 		t.Fatal("ListNotes on non-existent notebook should return an error")
 	}
 }
+
+// --- SearchNotes tests ---
+
+func TestSearchNotesFindsMatch(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	_ = store.CreateNote("work", "meeting", "discussed the quarterly plan\nother stuff")
+	_ = store.CreateNote("personal", "journal", "reminded me of the quarterly review")
+
+	results, err := store.SearchNotes("quarterly", "", false)
+	if err != nil {
+		t.Fatalf("SearchNotes: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+
+	// Results should be sorted by notebook name.
+	if results[0].Notebook != "personal" {
+		t.Errorf("first result notebook = %q, want %q", results[0].Notebook, "personal")
+	}
+	if results[1].Notebook != "work" {
+		t.Errorf("second result notebook = %q, want %q", results[1].Notebook, "work")
+	}
+}
+
+func TestSearchNotesCaseInsensitive(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	_ = store.CreateNote("nb", "note", "Hello World\ngoodbye world")
+
+	results, err := store.SearchNotes("HELLO", "", false)
+	if err != nil {
+		t.Fatalf("SearchNotes: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1 (case-insensitive match)", len(results))
+	}
+	if results[0].Line != 1 {
+		t.Errorf("Line = %d, want 1", results[0].Line)
+	}
+	if results[0].Text != "Hello World" {
+		t.Errorf("Text = %q, want %q", results[0].Text, "Hello World")
+	}
+}
+
+func TestSearchNotesCaseSensitive(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	_ = store.CreateNote("nb", "note", "Hello World\nhello world")
+
+	results, err := store.SearchNotes("Hello", "", true)
+	if err != nil {
+		t.Fatalf("SearchNotes: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1 (case-sensitive, only first line)", len(results))
+	}
+	if results[0].Line != 1 {
+		t.Errorf("Line = %d, want 1", results[0].Line)
+	}
+}
+
+func TestSearchNotesScoped(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	_ = store.CreateNote("work", "todo", "buy milk")
+	_ = store.CreateNote("personal", "list", "buy milk")
+
+	results, err := store.SearchNotes("milk", "work", false)
+	if err != nil {
+		t.Fatalf("SearchNotes: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1 (scoped to work)", len(results))
+	}
+	if results[0].Notebook != "work" {
+		t.Errorf("Notebook = %q, want %q", results[0].Notebook, "work")
+	}
+}
+
+func TestSearchNotesNoResults(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	_ = store.CreateNote("nb", "note", "nothing relevant here")
+
+	results, err := store.SearchNotes("zzzzz", "", false)
+	if err != nil {
+		t.Fatalf("SearchNotes: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("got %d results, want 0", len(results))
+	}
+}


### PR DESCRIPTION
## Summary
- `notebook search <query>` with breadcrumb output and bold match highlighting
- `--notebook` flag for scoped search, `--case-sensitive` flag
- Design-doc compliant output format with snippets and match counts
- 11 new tests (5 storage + 6 command)

Closes #12

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] `go build` compiles
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)