### PR TITLE
feat: note metadata with timestamps in view output

### DIFF
--- a/cmd/dispatcher.go
+++ b/cmd/dispatcher.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/oobagi/notebook/internal/editor"
@@ -170,6 +171,23 @@ func viewNote(w io.Writer, book, note string) error {
 		printInfo(w, fmt.Sprintf("Note %q in %q is empty", note, book))
 		return nil
 	}
+
+	// Metadata header: breadcrumb (bold) and timestamps (dim).
+	fmt.Fprintf(w, "  \x1b[1m%s \u203A %s\x1b[0m\n", book, note)
+
+	// Show both timestamps when created and modified differ by more than 1 minute.
+	diff := n.UpdatedAt.Sub(n.CreatedAt)
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > time.Minute {
+		fmt.Fprintf(w, "  \x1b[2mCreated %s \u00B7 Modified %s\x1b[0m\n",
+			relativeTime(n.CreatedAt), relativeTime(n.UpdatedAt))
+	} else {
+		fmt.Fprintf(w, "  \x1b[2mModified %s\x1b[0m\n", relativeTime(n.UpdatedAt))
+	}
+
+	fmt.Fprintln(w)
 
 	width, _, err := term.GetSize(int(os.Stdout.Fd()))
 	if err != nil || width <= 0 {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -527,6 +527,36 @@ func TestNewNoteAutoCreatesNotebook(t *testing.T) {
 	}
 }
 
+func TestViewNoteShowsMetadata(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNote("ideas", "spark", "# Spark\n\nSome content here.")
+
+	out, err := executeCapture([]string{"--dir", dir, "ideas", "spark"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Output should contain the "Modified" timestamp line.
+	if !strings.Contains(out, "Modified") {
+		t.Errorf("expected 'Modified' timestamp in output, got %q", out)
+	}
+}
+
+func TestViewNoteShowsBreadcrumb(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNote("ideas", "spark", "# Spark\n\nSome content here.")
+
+	out, err := executeCapture([]string{"--dir", dir, "ideas", "spark"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Output should contain the breadcrumb with U+203A separator.
+	if !strings.Contains(out, "ideas \u203A spark") {
+		t.Errorf("expected breadcrumb 'ideas \u203A spark' in output, got %q", out)
+	}
+}
+
 func TestNewDuplicateNoteShowsError(t *testing.T) {
 	dir := setupTestStore(t)
 	st := storage.NewStore(dir)

--- a/internal/storage/stat_darwin.go
+++ b/internal/storage/stat_darwin.go
@@ -1,0 +1,14 @@
+//go:build darwin
+
+package storage
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func fileCreatedAt(info os.FileInfo) time.Time {
+	stat := info.Sys().(*syscall.Stat_t)
+	return time.Unix(stat.Birthtimespec.Sec, stat.Birthtimespec.Nsec)
+}

--- a/internal/storage/stat_other.go
+++ b/internal/storage/stat_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+package storage
+
+import (
+	"os"
+	"time"
+)
+
+func fileCreatedAt(info os.FileInfo) time.Time {
+	return info.ModTime() // fallback: no birthtime on Linux
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -129,7 +129,7 @@ func (s *Store) GetNote(notebook, name string) (model.Note, error) {
 		Name:      name,
 		Notebook:  notebook,
 		Content:   string(data),
-		CreatedAt: info.ModTime(), // best approximation; most filesystems lack birth time
+		CreatedAt: fileCreatedAt(info),
 		UpdatedAt: info.ModTime(),
 	}, nil
 }

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -422,6 +422,34 @@ func TestCreateNoteDuplicate(t *testing.T) {
 	}
 }
 
+// --- Timestamp tests ---
+
+func TestGetNotePopulatesTimestamps(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	if err := store.CreateNote("nb", "ts-test", "timestamp content"); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	note, err := store.GetNote("nb", "ts-test")
+	if err != nil {
+		t.Fatalf("GetNote: %v", err)
+	}
+
+	if note.CreatedAt.IsZero() {
+		t.Error("CreatedAt should be non-zero")
+	}
+	if note.UpdatedAt.IsZero() {
+		t.Error("UpdatedAt should be non-zero")
+	}
+
+	// CreatedAt should be <= UpdatedAt (or equal for a freshly created file).
+	if note.CreatedAt.After(note.UpdatedAt) {
+		t.Errorf("CreatedAt (%v) should not be after UpdatedAt (%v)",
+			note.CreatedAt, note.UpdatedAt)
+	}
+}
+
 // --- ListNotebooks with non-existent root ---
 
 func TestListNotebooksNonExistentRoot(t *testing.T) {


### PR DESCRIPTION
## Summary
- Metadata header in `notebook view` with breadcrumb and timestamps
- macOS birthtime for accurate creation dates (fallback on Linux)
- Shows both created/modified when they differ
- 3 new tests

Closes #13

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] `go build` compiles
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)