### PR TITLE
feat: shell completions with dynamic suggestions

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/oobagi/notebook/internal/storage"
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate shell completion scripts",
+	Long: `Generate shell completion scripts for notebook.
+
+Bash:
+  source <(notebook completion bash)
+
+  # To load completions for each session, execute once:
+  notebook completion bash > /etc/bash_completion.d/notebook
+
+Zsh:
+  source <(notebook completion zsh)
+
+  # To load completions for each session, execute once:
+  notebook completion zsh > "${fpath[1]}/_notebook"
+
+Fish:
+  notebook completion fish | source
+
+  # To load completions for each session, execute once:
+  notebook completion fish > ~/.config/fish/completions/notebook.fish`,
+	Args:      cobra.ExactArgs(1),
+	ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "bash":
+			return rootCmd.GenBashCompletionV2(cmd.OutOrStdout(), true)
+		case "zsh":
+			return rootCmd.GenZshCompletion(cmd.OutOrStdout())
+		case "fish":
+			return rootCmd.GenFishCompletion(cmd.OutOrStdout(), true)
+		case "powershell":
+			return rootCmd.GenPowerShellCompletionWithDesc(cmd.OutOrStdout())
+		default:
+			return fmt.Errorf("unsupported shell: %s", args[0])
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+
+	rootCmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		// Need store initialized for completions.
+		if store == nil {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			store = storage.NewStore(filepath.Join(home, ".notebook"))
+		}
+
+		if len(args) == 0 {
+			// Complete notebook names + known subcommands.
+			notebooks, err := store.ListNotebooks()
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			completions := append(notebooks, "list", "new", "delete", "search", "config", "version", "completion")
+			return completions, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		if len(args) == 1 {
+			book := args[0]
+			// Complete note names in the notebook + book-level verbs.
+			notes, err := store.ListNotes(book)
+			if err != nil {
+				return []string{"list", "new", "delete", "search"}, cobra.ShellCompDirectiveNoFileComp
+			}
+			completions := make([]string, 0, len(notes)+4)
+			for _, n := range notes {
+				completions = append(completions, n.Name)
+			}
+			completions = append(completions, "list", "new", "delete", "search")
+			return completions, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		if len(args) == 2 {
+			// Complete note-level verbs.
+			return []string{"edit", "delete", "copy"}, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+}

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -1,0 +1,247 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/oobagi/notebook/internal/storage"
+	"github.com/spf13/cobra"
+)
+
+func TestCompletionBash(t *testing.T) {
+	out, err := executeCapture([]string{"completion", "bash"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "notebook") {
+		t.Errorf("expected bash completion script to contain %q, got %q", "notebook", out)
+	}
+	if !strings.Contains(out, "bash") {
+		t.Errorf("expected bash completion script to contain %q, got %q", "bash", out)
+	}
+}
+
+func TestCompletionZsh(t *testing.T) {
+	out, err := executeCapture([]string{"completion", "zsh"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "notebook") {
+		t.Errorf("expected zsh completion script to contain %q, got %q", "notebook", out)
+	}
+}
+
+func TestCompletionFish(t *testing.T) {
+	out, err := executeCapture([]string{"completion", "fish"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "notebook") {
+		t.Errorf("expected fish completion script to contain %q, got %q", "notebook", out)
+	}
+}
+
+func TestCompletionInvalidShell(t *testing.T) {
+	_, err := executeCapture([]string{"completion", "nushell"})
+	if err == nil {
+		t.Fatal("expected error for unsupported shell")
+	}
+	if !strings.Contains(err.Error(), "unsupported shell") {
+		t.Errorf("expected 'unsupported shell' in error, got %q", err.Error())
+	}
+}
+
+func TestCompletionNoArgs(t *testing.T) {
+	_, err := executeCapture([]string{"completion"})
+	if err == nil {
+		t.Fatal("expected error when no shell argument provided")
+	}
+}
+
+func TestDynamicCompletionNotebooks(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNotebook("work")
+	_ = st.CreateNotebook("personal")
+
+	fn := rootCmd.ValidArgsFunction
+	if fn == nil {
+		t.Fatal("ValidArgsFunction should be set on rootCmd")
+	}
+
+	completions, directive := fn(rootCmd, []string{}, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+	}
+
+	// Should contain notebook names.
+	found := map[string]bool{"work": false, "personal": false}
+	for _, c := range completions {
+		if _, ok := found[c]; ok {
+			found[c] = true
+		}
+	}
+	for name, ok := range found {
+		if !ok {
+			t.Errorf("expected completion to contain %q", name)
+		}
+	}
+
+	// Should also contain known subcommands.
+	subcommands := []string{"list", "new", "delete", "search", "config", "version", "completion"}
+	for _, sub := range subcommands {
+		contains := false
+		for _, c := range completions {
+			if c == sub {
+				contains = true
+				break
+			}
+		}
+		if !contains {
+			t.Errorf("expected completion to contain subcommand %q", sub)
+		}
+	}
+}
+
+func TestDynamicCompletionNotes(t *testing.T) {
+	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNote("work", "todo", "buy milk")
+	_ = st.CreateNote("work", "meeting", "standup notes")
+
+	fn := rootCmd.ValidArgsFunction
+	if fn == nil {
+		t.Fatal("ValidArgsFunction should be set on rootCmd")
+	}
+
+	completions, directive := fn(rootCmd, []string{"work"}, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+	}
+
+	// Should contain note names.
+	found := map[string]bool{"todo": false, "meeting": false}
+	for _, c := range completions {
+		if _, ok := found[c]; ok {
+			found[c] = true
+		}
+	}
+	for name, ok := range found {
+		if !ok {
+			t.Errorf("expected completion to contain note %q", name)
+		}
+	}
+
+	// Should also contain book-level verbs.
+	verbs := []string{"list", "new", "delete", "search"}
+	for _, v := range verbs {
+		contains := false
+		for _, c := range completions {
+			if c == v {
+				contains = true
+				break
+			}
+		}
+		if !contains {
+			t.Errorf("expected completion to contain verb %q", v)
+		}
+	}
+}
+
+func TestDynamicCompletionNoteVerbs(t *testing.T) {
+	dir := setupTestStore(t)
+	_ = dir
+
+	fn := rootCmd.ValidArgsFunction
+	if fn == nil {
+		t.Fatal("ValidArgsFunction should be set on rootCmd")
+	}
+
+	completions, directive := fn(rootCmd, []string{"work", "todo"}, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+	}
+
+	expected := []string{"edit", "delete", "copy"}
+	if len(completions) != len(expected) {
+		t.Fatalf("expected %d completions, got %d: %v", len(expected), len(completions), completions)
+	}
+	for _, e := range expected {
+		contains := false
+		for _, c := range completions {
+			if c == e {
+				contains = true
+				break
+			}
+		}
+		if !contains {
+			t.Errorf("expected completion to contain %q", e)
+		}
+	}
+}
+
+func TestDynamicCompletionNoNotebooks(t *testing.T) {
+	_ = setupTestStore(t) // empty store
+
+	fn := rootCmd.ValidArgsFunction
+	if fn == nil {
+		t.Fatal("ValidArgsFunction should be set on rootCmd")
+	}
+
+	completions, directive := fn(rootCmd, []string{}, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+	}
+
+	// With no notebooks, should still return subcommands.
+	subcommands := []string{"list", "new", "delete", "search", "config", "version", "completion"}
+	for _, sub := range subcommands {
+		contains := false
+		for _, c := range completions {
+			if c == sub {
+				contains = true
+				break
+			}
+		}
+		if !contains {
+			t.Errorf("expected completion to contain subcommand %q", sub)
+		}
+	}
+}
+
+func TestDynamicCompletionInvalidBook(t *testing.T) {
+	_ = setupTestStore(t) // empty store, no "nonexistent" notebook
+
+	fn := rootCmd.ValidArgsFunction
+	if fn == nil {
+		t.Fatal("ValidArgsFunction should be set on rootCmd")
+	}
+
+	completions, directive := fn(rootCmd, []string{"nonexistent"}, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+	}
+
+	// Should fall back to book-level verbs when notebook doesn't exist.
+	expected := []string{"list", "new", "delete", "search"}
+	if len(completions) != len(expected) {
+		t.Fatalf("expected %d completions, got %d: %v", len(expected), len(completions), completions)
+	}
+}
+
+func TestDynamicCompletionBeyondThreeArgs(t *testing.T) {
+	_ = setupTestStore(t)
+
+	fn := rootCmd.ValidArgsFunction
+	if fn == nil {
+		t.Fatal("ValidArgsFunction should be set on rootCmd")
+	}
+
+	completions, directive := fn(rootCmd, []string{"work", "todo", "edit"}, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+	}
+	if completions != nil {
+		t.Errorf("expected nil completions for 3+ args, got %v", completions)
+	}
+}


### PR DESCRIPTION
## Summary
- `notebook completion bash|zsh|fish|powershell` generates shell scripts
- Dynamic tab-completion: notebook names, note names, verbs by position
- Installation instructions in command help text
- 11 new tests

Closes #15

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] `go build` compiles
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)