### PR TITLE
feat: TUI notebook/note browser with fuzzy search

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/oobagi/notebook/internal/browser"
+	"github.com/spf13/cobra"
+)
+
+var browseCmd = &cobra.Command{
+	Use:   "browse",
+	Short: "Browse notebooks and notes in a fullscreen TUI",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runBrowser()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(browseCmd)
+}
+
+// runBrowser launches the TUI browser in a loop. When the user selects
+// a note, the browser quits, the editor launches, and the browser
+// re-enters after the editor exits.
+func runBrowser() error {
+	for {
+		m := browser.New(browser.Config{
+			Store: store,
+			EditNote: func(book, note string) error {
+				return editNote(nil, book, note)
+			},
+		})
+
+		p := tea.NewProgram(m, tea.WithAltScreen())
+		result, err := p.Run()
+		if err != nil {
+			return fmt.Errorf("run browser: %w", err)
+		}
+
+		final := result.(browser.Model)
+		sel := final.Selected()
+		if sel == nil {
+			// User quit without selecting a note.
+			return nil
+		}
+
+		// Launch editor for the selected note.
+		if err := editNote(os.Stderr, sel.Book, sel.Note); err != nil {
+			return fmt.Errorf("edit note: %w", err)
+		}
+
+		// Loop back to re-enter the browser.
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,7 @@ var rootCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			return cmd.Help()
+			return runBrowser()
 		}
 		return dispatch(cmd, args)
 	},

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -415,17 +415,19 @@ func TestTopLevelConfig(t *testing.T) {
 	}
 }
 
-// --- No args shows help ---
+// --- No args launches browser ---
 
-func TestNoArgsPrintsHelp(t *testing.T) {
+func TestNoArgsLaunchesBrowser(t *testing.T) {
 	dir := setupTestStore(t)
 
-	out, err := executeCapture([]string{"--dir", dir})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	// Without a TTY the browser cannot open, so we expect a TTY-related error.
+	// This confirms the root command dispatches to the browser rather than help.
+	_, err := executeCapture([]string{"--dir", dir})
+	if err == nil {
+		t.Fatal("expected TTY error when launching browser without a terminal")
 	}
-	if !strings.Contains(out, "notebook") {
-		t.Errorf("expected help output, got %q", out)
+	if !strings.Contains(err.Error(), "TTY") {
+		t.Errorf("expected TTY error, got %q", err.Error())
 	}
 }
 

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -1,0 +1,586 @@
+// Package browser provides a fullscreen TUI for browsing notebooks and notes.
+package browser
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/oobagi/notebook/internal/model"
+	"github.com/oobagi/notebook/internal/storage"
+)
+
+// EditFunc is called when the user selects a note to edit.
+type EditFunc func(book, note string) error
+
+// Config holds the dependencies needed by the browser.
+type Config struct {
+	Store    *storage.Store
+	EditNote EditFunc
+}
+
+// Selection represents a note the user chose to open.
+type Selection struct {
+	Book string
+	Note string
+}
+
+// Model is the Bubble Tea model for the notebook/note browser.
+type Model struct {
+	store       *storage.Store
+	editNote    EditFunc
+	level       int    // 0=notebooks, 1=notes
+	notebooks   []notebookItem
+	notes       []model.Note
+	currentBook string // selected notebook name
+	cursor      int    // current selection index
+	filter      string // fuzzy search filter text
+	filtering   bool   // whether filter mode is active
+	filtered    []int  // indices into notebooks/notes after filtering
+	width       int
+	height      int
+	quitting    bool
+	selected    *Selection // set when user picks a note to edit
+	err         error
+}
+
+// notebookItem holds pre-fetched metadata for a notebook.
+type notebookItem struct {
+	name      string
+	noteCount int
+	modTime   string
+}
+
+// New creates a new browser model.
+func New(cfg Config) Model {
+	return Model{
+		store:    cfg.Store,
+		editNote: cfg.EditNote,
+	}
+}
+
+// Selected returns the note selection if the user chose one, or nil.
+func (m Model) Selected() *Selection {
+	return m.selected
+}
+
+// notebooksLoadedMsg carries the loaded notebook list.
+type notebooksLoadedMsg struct {
+	notebooks []notebookItem
+}
+
+// notesLoadedMsg carries the loaded note list.
+type notesLoadedMsg struct {
+	notes []model.Note
+}
+
+// Init implements tea.Model.
+func (m Model) Init() tea.Cmd {
+	return m.loadNotebooks()
+}
+
+func (m Model) loadNotebooks() tea.Cmd {
+	return func() tea.Msg {
+		names, err := m.store.ListNotebooks()
+		if err != nil {
+			return errMsg{err}
+		}
+
+		items := make([]notebookItem, 0, len(names))
+		for _, name := range names {
+			count, err := m.store.NoteCount(name)
+			if err != nil {
+				return errMsg{err}
+			}
+			modTime, err := m.store.NotebookModTime(name)
+			if err != nil {
+				return errMsg{err}
+			}
+
+			var timeStr string
+			if modTime.IsZero() {
+				timeStr = "empty"
+			} else {
+				timeStr = relativeTime(modTime)
+			}
+
+			items = append(items, notebookItem{
+				name:      name,
+				noteCount: count,
+				modTime:   timeStr,
+			})
+		}
+		return notebooksLoadedMsg{notebooks: items}
+	}
+}
+
+func (m Model) loadNotes(book string) tea.Cmd {
+	return func() tea.Msg {
+		notes, err := m.store.ListNotes(book)
+		if err != nil {
+			return errMsg{err}
+		}
+		return notesLoadedMsg{notes: notes}
+	}
+}
+
+type errMsg struct{ err error }
+
+// Update implements tea.Model.
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case notebooksLoadedMsg:
+		m.notebooks = msg.notebooks
+		m.resetFilter()
+		return m, nil
+
+	case notesLoadedMsg:
+		m.notes = msg.notes
+		m.resetFilter()
+		return m, nil
+
+	case errMsg:
+		m.err = msg.err
+		return m, nil
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	}
+
+	return m, nil
+}
+
+func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Global quit keys.
+	switch msg.Type {
+	case tea.KeyCtrlC:
+		m.quitting = true
+		return m, tea.Quit
+	}
+
+	// When filtering, handle text input first.
+	if m.filtering {
+		return m.handleFilterKey(msg)
+	}
+
+	switch msg.Type {
+	case tea.KeyUp:
+		if m.cursor > 0 {
+			m.cursor--
+		}
+		return m, nil
+
+	case tea.KeyDown:
+		max := m.listLen() - 1
+		if max < 0 {
+			max = 0
+		}
+		if m.cursor < max {
+			m.cursor++
+		}
+		return m, nil
+
+	case tea.KeyEnter:
+		return m.handleEnter()
+
+	case tea.KeyEsc:
+		return m.handleEsc()
+
+	case tea.KeyRunes:
+		s := string(msg.Runes)
+		if s == "q" {
+			m.quitting = true
+			return m, tea.Quit
+		}
+		if s == "/" {
+			m.filtering = true
+			m.filter = ""
+			m.applyFilter()
+			return m, nil
+		}
+		return m, nil
+	}
+
+	return m, nil
+}
+
+func (m Model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEsc:
+		m.filtering = false
+		m.filter = ""
+		m.resetFilter()
+		return m, nil
+
+	case tea.KeyEnter:
+		m.filtering = false
+		return m.handleEnter()
+
+	case tea.KeyBackspace:
+		if len(m.filter) > 0 {
+			m.filter = m.filter[:len(m.filter)-1]
+			m.applyFilter()
+		}
+		return m, nil
+
+	case tea.KeyUp:
+		if m.cursor > 0 {
+			m.cursor--
+		}
+		return m, nil
+
+	case tea.KeyDown:
+		max := len(m.filtered) - 1
+		if max < 0 {
+			max = 0
+		}
+		if m.cursor < max {
+			m.cursor++
+		}
+		return m, nil
+
+	case tea.KeyRunes:
+		m.filter += string(msg.Runes)
+		m.applyFilter()
+		return m, nil
+	}
+
+	return m, nil
+}
+
+func (m *Model) applyFilter() {
+	query := strings.ToLower(m.filter)
+	m.filtered = nil
+
+	if m.level == 0 {
+		for i, nb := range m.notebooks {
+			if query == "" || strings.Contains(strings.ToLower(nb.name), query) {
+				m.filtered = append(m.filtered, i)
+			}
+		}
+	} else {
+		for i, n := range m.notes {
+			if query == "" || strings.Contains(strings.ToLower(n.Name), query) {
+				m.filtered = append(m.filtered, i)
+			}
+		}
+	}
+
+	if m.cursor >= len(m.filtered) {
+		m.cursor = len(m.filtered) - 1
+	}
+	if m.cursor < 0 {
+		m.cursor = 0
+	}
+}
+
+func (m *Model) resetFilter() {
+	m.filter = ""
+	m.filtering = false
+	m.filtered = nil
+
+	if m.level == 0 {
+		m.filtered = make([]int, len(m.notebooks))
+		for i := range m.notebooks {
+			m.filtered[i] = i
+		}
+	} else {
+		m.filtered = make([]int, len(m.notes))
+		for i := range m.notes {
+			m.filtered[i] = i
+		}
+	}
+
+	if m.cursor >= len(m.filtered) {
+		m.cursor = len(m.filtered) - 1
+	}
+	if m.cursor < 0 {
+		m.cursor = 0
+	}
+}
+
+func (m Model) listLen() int {
+	return len(m.filtered)
+}
+
+func (m Model) handleEnter() (tea.Model, tea.Cmd) {
+	if len(m.filtered) == 0 {
+		return m, nil
+	}
+	if m.cursor >= len(m.filtered) {
+		return m, nil
+	}
+
+	idx := m.filtered[m.cursor]
+
+	if m.level == 0 {
+		m.currentBook = m.notebooks[idx].name
+		m.level = 1
+		m.cursor = 0
+		m.filter = ""
+		m.filtering = false
+		return m, m.loadNotes(m.currentBook)
+	}
+
+	// Level 1: quit the browser with the selection so the caller can
+	// launch the editor and then re-enter the browser.
+	note := m.notes[idx]
+	m.selected = &Selection{
+		Book: m.currentBook,
+		Note: note.Name,
+	}
+	return m, tea.Quit
+}
+
+func (m Model) handleEsc() (tea.Model, tea.Cmd) {
+	if m.level == 1 {
+		m.level = 0
+		m.cursor = 0
+		m.filter = ""
+		m.filtering = false
+		return m, m.loadNotebooks()
+	}
+	m.quitting = true
+	return m, tea.Quit
+}
+
+// View implements tea.Model.
+func (m Model) View() string {
+	if m.quitting {
+		return ""
+	}
+
+	if m.err != nil {
+		return fmt.Sprintf("\n  Error: %v\n", m.err)
+	}
+
+	var b strings.Builder
+
+	// Breadcrumb / path.
+	breadcrumb := m.renderBreadcrumb()
+	b.WriteString(breadcrumb)
+	b.WriteString("\n\n")
+
+	// Content area.
+	contentHeight := m.height - 4 // breadcrumb + blank + status bar + blank
+	if contentHeight < 1 {
+		contentHeight = 1
+	}
+
+	content := m.renderContent(contentHeight)
+	b.WriteString(content)
+
+	// Pad to push status bar to bottom.
+	contentLines := strings.Count(content, "\n")
+	if contentLines < contentHeight {
+		for i := 0; i < contentHeight-contentLines; i++ {
+			b.WriteString("\n")
+		}
+	}
+
+	// Status bar.
+	b.WriteString("\n")
+	b.WriteString(m.renderStatusBar())
+
+	return b.String()
+}
+
+func (m Model) renderBreadcrumb() string {
+	style := lipgloss.NewStyle().Bold(true).Padding(0, 1)
+	if m.level == 0 {
+		return style.Render("notebook")
+	}
+	return style.Render(fmt.Sprintf("notebook \u203A %s", m.currentBook))
+}
+
+func (m Model) renderContent(maxLines int) string {
+	if m.level == 0 {
+		return m.renderNotebookList(maxLines)
+	}
+	return m.renderNoteList(maxLines)
+}
+
+func (m Model) renderNotebookList(maxLines int) string {
+	if len(m.notebooks) == 0 {
+		return m.renderEmptyNotebooks()
+	}
+
+	if len(m.filtered) == 0 && m.filtering {
+		return "  No matches\n"
+	}
+
+	var b strings.Builder
+	visible := m.visibleRange(len(m.filtered), maxLines)
+
+	for vi, fi := range visible {
+		idx := m.filtered[fi]
+		nb := m.notebooks[idx]
+		selected := fi == m.cursor
+		line := m.formatNotebookLine(nb, selected)
+		b.WriteString(line)
+		if vi < len(visible)-1 {
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
+}
+
+func (m Model) renderNoteList(maxLines int) string {
+	if len(m.notes) == 0 {
+		return m.renderEmptyNotes()
+	}
+
+	if len(m.filtered) == 0 && m.filtering {
+		return "  No matches\n"
+	}
+
+	var b strings.Builder
+	visible := m.visibleRange(len(m.filtered), maxLines)
+
+	for vi, fi := range visible {
+		idx := m.filtered[fi]
+		n := m.notes[idx]
+		selected := fi == m.cursor
+		line := m.formatNoteLine(n, selected)
+		b.WriteString(line)
+		if vi < len(visible)-1 {
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
+}
+
+// visibleRange returns the slice of filtered indices to display,
+// implementing scrolling so the cursor stays visible.
+func (m Model) visibleRange(total, maxLines int) []int {
+	if total <= maxLines {
+		indices := make([]int, total)
+		for i := range indices {
+			indices[i] = i
+		}
+		return indices
+	}
+
+	// Scroll so cursor is visible.
+	start := 0
+	if m.cursor >= maxLines {
+		start = m.cursor - maxLines + 1
+	}
+	end := start + maxLines
+	if end > total {
+		end = total
+		start = end - maxLines
+	}
+
+	indices := make([]int, end-start)
+	for i := range indices {
+		indices[i] = start + i
+	}
+	return indices
+}
+
+func (m Model) formatNotebookLine(nb notebookItem, selected bool) string {
+	bullet := "  "
+	name := nb.name
+	countStr := pluralize(nb.noteCount, "note", "notes")
+
+	if selected {
+		bulletStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("6")) // cyan
+		bullet = bulletStyle.Render("\u25CF") + " "
+		nameStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+		name = nameStyle.Render(nb.name)
+	}
+
+	return fmt.Sprintf("%s%-*s    %-*s    %s",
+		bullet,
+		m.nameColWidth(0), name,
+		10, countStr,
+		nb.modTime,
+	)
+}
+
+func (m Model) formatNoteLine(n model.Note, selected bool) string {
+	bullet := "  "
+	name := n.Name
+
+	// Get file size.
+	p := m.store.NotebookDir(m.currentBook) + "/" + n.Name + ".md"
+	info, err := os.Stat(p)
+	var sizeStr, timeStr string
+	if err == nil {
+		sizeStr = humanSize(info.Size())
+		timeStr = relativeTime(info.ModTime())
+	}
+
+	if selected {
+		bulletStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+		bullet = bulletStyle.Render("\u25CF") + " "
+		nameStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+		name = nameStyle.Render(n.Name)
+	}
+
+	return fmt.Sprintf("%s%-*s    %-*s    %s",
+		bullet,
+		m.nameColWidth(1), name,
+		8, sizeStr,
+		timeStr,
+	)
+}
+
+func (m Model) nameColWidth(level int) int {
+	maxLen := 0
+	if level == 0 {
+		for _, nb := range m.notebooks {
+			if len(nb.name) > maxLen {
+				maxLen = len(nb.name)
+			}
+		}
+	} else {
+		for _, n := range m.notes {
+			if len(n.Name) > maxLen {
+				maxLen = len(n.Name)
+			}
+		}
+	}
+	if maxLen < 10 {
+		maxLen = 10
+	}
+	return maxLen
+}
+
+func (m Model) renderEmptyNotebooks() string {
+	return "  No notebooks yet.\n\n  Create one with: notebook new \"My Book\"\n"
+}
+
+func (m Model) renderEmptyNotes() string {
+	return fmt.Sprintf("  No notes in %s.\n\n  Create one with: notebook %s new \"My Note\"\n",
+		m.currentBook, m.currentBook)
+}
+
+func (m Model) renderStatusBar() string {
+	dim := lipgloss.NewStyle().Faint(true)
+
+	if m.filtering {
+		return dim.Render(fmt.Sprintf("  Filter: %s_ \u00B7 Esc clear \u00B7 Enter select", m.filter))
+	}
+
+	return dim.Render("  \u2191/\u2193 navigate \u00B7 Enter open \u00B7 / search \u00B7 Esc back \u00B7 q quit")
+}
+
+// pluralize returns "1 note" or "3 notes" style strings.
+func pluralize(count int, singular, plural string) string {
+	if count == 1 {
+		return fmt.Sprintf("1 %s", singular)
+	}
+	return fmt.Sprintf("%d %s", count, plural)
+}

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -1,0 +1,374 @@
+package browser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/oobagi/notebook/internal/storage"
+)
+
+// setupTestStore creates a temp directory with optional notebooks and notes.
+func setupTestStore(t *testing.T, books map[string][]string) *storage.Store {
+	t.Helper()
+	dir := t.TempDir()
+	s := storage.NewStore(dir)
+
+	for book, notes := range books {
+		if err := s.CreateNotebook(book); err != nil {
+			t.Fatalf("create notebook %q: %v", book, err)
+		}
+		for _, note := range notes {
+			if err := s.CreateNote(book, note, "test content for "+note); err != nil {
+				t.Fatalf("create note %q/%q: %v", book, note, err)
+			}
+		}
+	}
+	return s
+}
+
+// initModel creates a Model and processes the Init command to load data.
+func initModel(t *testing.T, s *storage.Store) Model {
+	t.Helper()
+	m := New(Config{
+		Store:    s,
+		EditNote: func(book, note string) error { return nil },
+	})
+
+	// Run Init and process the resulting message.
+	cmd := m.Init()
+	if cmd != nil {
+		msg := cmd()
+		updated, _ := m.Update(msg)
+		m = updated.(Model)
+	}
+
+	// Send a window size so the view renders properly.
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	return m
+}
+
+func sendKey(t *testing.T, m Model, key tea.KeyType) Model {
+	t.Helper()
+	updated, cmd := m.Update(tea.KeyMsg{Type: key})
+	m = updated.(Model)
+
+	// Process any commands (like loadNotes).
+	if cmd != nil {
+		msg := cmd()
+		if msg != nil {
+			updated, _ = m.Update(msg)
+			m = updated.(Model)
+		}
+	}
+	return m
+}
+
+func sendRune(t *testing.T, m Model, r rune) Model {
+	t.Helper()
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	m = updated.(Model)
+
+	if cmd != nil {
+		msg := cmd()
+		if msg != nil {
+			updated, _ = m.Update(msg)
+			m = updated.(Model)
+		}
+	}
+	return m
+}
+
+func TestBrowserInitShowsNotebooks(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work":     {"meeting-notes", "todo"},
+		"personal": {"journal"},
+	})
+
+	m := initModel(t, s)
+
+	if m.level != 0 {
+		t.Errorf("expected level 0, got %d", m.level)
+	}
+
+	if len(m.notebooks) != 2 {
+		t.Fatalf("expected 2 notebooks, got %d", len(m.notebooks))
+	}
+
+	view := m.View()
+	// Notebook names should appear in the view.
+	if !containsStr(view, "work") {
+		t.Errorf("view should contain 'work', got:\n%s", view)
+	}
+	if !containsStr(view, "personal") {
+		t.Errorf("view should contain 'personal', got:\n%s", view)
+	}
+}
+
+func TestBrowserEnterOpensNotebook(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"meeting-notes", "todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Cursor is on the first notebook. Press Enter.
+	m = sendKey(t, m, tea.KeyEnter)
+
+	if m.level != 1 {
+		t.Errorf("expected level 1 after Enter, got %d", m.level)
+	}
+
+	if m.currentBook == "" {
+		t.Error("currentBook should be set after Enter")
+	}
+
+	if len(m.notes) != 2 {
+		t.Errorf("expected 2 notes, got %d", len(m.notes))
+	}
+
+	view := m.View()
+	if !containsStr(view, "meeting-notes") {
+		t.Errorf("view should contain 'meeting-notes', got:\n%s", view)
+	}
+	if !containsStr(view, "todo") {
+		t.Errorf("view should contain 'todo', got:\n%s", view)
+	}
+}
+
+func TestBrowserEscGoesBack(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"meeting-notes"},
+	})
+
+	m := initModel(t, s)
+
+	// Enter notebook.
+	m = sendKey(t, m, tea.KeyEnter)
+	if m.level != 1 {
+		t.Fatalf("expected level 1, got %d", m.level)
+	}
+
+	// Press Esc to go back.
+	m = sendKey(t, m, tea.KeyEsc)
+	if m.level != 0 {
+		t.Errorf("expected level 0 after Esc, got %d", m.level)
+	}
+}
+
+func TestBrowserFilterReducesList(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work":     {"todo"},
+		"personal": {"journal"},
+		"recipes":  {"pasta"},
+	})
+
+	m := initModel(t, s)
+
+	if len(m.filtered) != 3 {
+		t.Fatalf("expected 3 filtered items, got %d", len(m.filtered))
+	}
+
+	// Press '/' to enter filter mode.
+	m = sendRune(t, m, '/')
+
+	if !m.filtering {
+		t.Fatal("expected filtering to be true after '/'")
+	}
+
+	// Type "per" to filter.
+	m = sendRune(t, m, 'p')
+	m = sendRune(t, m, 'e')
+	m = sendRune(t, m, 'r')
+
+	if m.filter != "per" {
+		t.Errorf("expected filter 'per', got %q", m.filter)
+	}
+
+	if len(m.filtered) != 1 {
+		t.Errorf("expected 1 filtered item, got %d", len(m.filtered))
+	}
+
+	// The filtered item should be "personal".
+	idx := m.filtered[0]
+	if m.notebooks[idx].name != "personal" {
+		t.Errorf("expected filtered notebook 'personal', got %q", m.notebooks[idx].name)
+	}
+}
+
+func TestBrowserQuitOnQ(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	m = updated.(Model)
+
+	if !m.quitting {
+		t.Error("expected quitting to be true after 'q'")
+	}
+
+	// cmd should be tea.Quit.
+	if cmd == nil {
+		t.Error("expected quit command")
+	}
+}
+
+func TestBrowserEmptyState(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{})
+
+	m := initModel(t, s)
+
+	view := m.View()
+	if !containsStr(view, "No notebooks yet") {
+		t.Errorf("expected empty state message, got:\n%s", view)
+	}
+	if !containsStr(view, "notebook new") {
+		t.Errorf("expected create hint, got:\n%s", view)
+	}
+}
+
+func TestBrowserEmptyNotebook(t *testing.T) {
+	dir := t.TempDir()
+	s := storage.NewStore(dir)
+
+	// Create a notebook directory with no notes.
+	if err := os.MkdirAll(filepath.Join(dir, "empty-book"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m := initModel(t, s)
+
+	// Enter the empty notebook.
+	m = sendKey(t, m, tea.KeyEnter)
+
+	if m.level != 1 {
+		t.Fatalf("expected level 1, got %d", m.level)
+	}
+
+	view := m.View()
+	if !containsStr(view, "No notes in") {
+		t.Errorf("expected empty notebook message, got:\n%s", view)
+	}
+}
+
+func TestBrowserNoteSelection(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"meeting-notes", "todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Enter notebook.
+	m = sendKey(t, m, tea.KeyEnter)
+
+	if m.level != 1 {
+		t.Fatalf("expected level 1, got %d", m.level)
+	}
+
+	// Press Enter on first note -- should set selected and quit.
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+
+	sel := m.Selected()
+	if sel == nil {
+		t.Fatal("expected a selection after Enter on a note")
+	}
+
+	if sel.Book == "" {
+		t.Error("selection book should not be empty")
+	}
+	if sel.Note == "" {
+		t.Error("selection note should not be empty")
+	}
+
+	if cmd == nil {
+		t.Error("expected quit command after note selection")
+	}
+}
+
+func TestBrowserArrowNavigation(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"alpha":   {"a"},
+		"bravo":   {"b"},
+		"charlie": {"c"},
+	})
+
+	m := initModel(t, s)
+
+	if m.cursor != 0 {
+		t.Fatalf("expected cursor at 0, got %d", m.cursor)
+	}
+
+	// Move down.
+	m = sendKey(t, m, tea.KeyDown)
+	if m.cursor != 1 {
+		t.Errorf("expected cursor at 1 after down, got %d", m.cursor)
+	}
+
+	// Move down again.
+	m = sendKey(t, m, tea.KeyDown)
+	if m.cursor != 2 {
+		t.Errorf("expected cursor at 2 after second down, got %d", m.cursor)
+	}
+
+	// Down at end should not move past last item.
+	m = sendKey(t, m, tea.KeyDown)
+	if m.cursor != 2 {
+		t.Errorf("expected cursor to stay at 2, got %d", m.cursor)
+	}
+
+	// Move up.
+	m = sendKey(t, m, tea.KeyUp)
+	if m.cursor != 1 {
+		t.Errorf("expected cursor at 1 after up, got %d", m.cursor)
+	}
+}
+
+func TestBrowserFilterClearOnEsc(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work":     {"todo"},
+		"personal": {"journal"},
+	})
+
+	m := initModel(t, s)
+
+	// Start filtering.
+	m = sendRune(t, m, '/')
+	m = sendRune(t, m, 'w')
+
+	if len(m.filtered) != 1 {
+		t.Fatalf("expected 1 filtered item, got %d", len(m.filtered))
+	}
+
+	// Esc should clear filter and show all items.
+	m = sendKey(t, m, tea.KeyEsc)
+
+	if m.filtering {
+		t.Error("expected filtering to be false after Esc")
+	}
+	if m.filter != "" {
+		t.Errorf("expected empty filter after Esc, got %q", m.filter)
+	}
+	if len(m.filtered) != 2 {
+		t.Errorf("expected 2 filtered items after Esc, got %d", len(m.filtered))
+	}
+}
+
+func containsStr(s, substr string) bool {
+	return len(s) > 0 && len(substr) > 0 && contains(s, substr)
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/browser/format.go
+++ b/internal/browser/format.go
@@ -1,0 +1,67 @@
+package browser
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// relativeTime returns a human-friendly relative timestamp string.
+func relativeTime(t time.Time) string {
+	return relativeTimeFrom(t, time.Now())
+}
+
+// relativeTimeFrom returns a relative timestamp using the given reference time.
+func relativeTimeFrom(t time.Time, now time.Time) string {
+	d := now.Sub(t)
+	if d < 0 {
+		d = 0
+	}
+
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		m := int(d.Minutes())
+		return fmt.Sprintf("%dm ago", m)
+	case d < 24*time.Hour:
+		h := int(d.Hours())
+		return fmt.Sprintf("%dh ago", h)
+	case d < 7*24*time.Hour:
+		days := int(d.Hours() / 24)
+		return fmt.Sprintf("%dd ago", days)
+	case d < 30*24*time.Hour:
+		weeks := int(d.Hours() / 24 / 7)
+		return fmt.Sprintf("%dw ago", weeks)
+	default:
+		if t.Year() == now.Year() {
+			return t.Format("Jan 2")
+		}
+		return t.Format("Jan 2, 2006")
+	}
+}
+
+// humanSize formats a byte count into a human-readable string.
+func humanSize(bytes int64) string {
+	switch {
+	case bytes < 1024:
+		return fmt.Sprintf("%d B", bytes)
+	case bytes < 1024*1024:
+		kb := float64(bytes) / 1024
+		return formatFloat(kb) + " KB"
+	case bytes < 1024*1024*1024:
+		mb := float64(bytes) / (1024 * 1024)
+		return formatFloat(mb) + " MB"
+	default:
+		gb := float64(bytes) / (1024 * 1024 * 1024)
+		return formatFloat(gb) + " GB"
+	}
+}
+
+func formatFloat(f float64) string {
+	s := fmt.Sprintf("%.1f", f)
+	if strings.HasSuffix(s, ".0") {
+		return s[:len(s)-2]
+	}
+	return s
+}


### PR DESCRIPTION
## Summary
- `notebook` (no args) or `notebook browse` launches fullscreen TUI browser
- Two-level navigation: notebooks → notes with arrow keys + Enter
- `/` for fuzzy search filtering, Esc to go back
- Opens editor for selected notes, then returns to browser
- 10 new tests

Closes #17

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] `go build` compiles
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)