### PR TITLE
feat: auto light/dark theme detection

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,13 +8,15 @@ import (
 
 	"github.com/oobagi/notebook/internal/config"
 	"github.com/oobagi/notebook/internal/storage"
+	"github.com/oobagi/notebook/internal/theme"
 	"github.com/spf13/cobra"
 )
 
 var (
-	store   *storage.Store
-	dirFlag string
-	cfg     config.Config
+	store     *storage.Store
+	dirFlag   string
+	themeFlag string
+	cfg       config.Config
 )
 
 var rootCmd = &cobra.Command{
@@ -29,6 +31,13 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("load config: %w", err)
 		}
+
+		// Resolve the active theme: flag > config > auto-detect.
+		themeName := themeFlag
+		if themeName == "auto" && cfg.Theme != "" && cfg.Theme != "auto" {
+			themeName = cfg.Theme
+		}
+		theme.SetTheme(theme.FromName(themeName))
 
 		root := dirFlag
 		if root == "" {
@@ -59,6 +68,7 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&dirFlag, "dir", "", "root directory for notebook storage (default ~/.notebook)")
+	rootCmd.PersistentFlags().StringVar(&themeFlag, "theme", "auto", "color theme (auto, dark, light)")
 }
 
 // Execute runs the root command.

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -1,13 +1,26 @@
 package render
 
 import (
+	"os"
+
 	"github.com/charmbracelet/glamour"
+	"github.com/oobagi/notebook/internal/theme"
+	"golang.org/x/term"
 )
 
 // RenderMarkdown renders a markdown string for terminal display using Glamour.
-// On rendering failure, the raw content is returned as a fallback.
+// When running on a TTY, the glamour style is derived from the active theme.
+// When output is not a terminal, glamour's NoTTY style is used via
+// WithAutoStyle to keep output free of ANSI escape codes.
 func RenderMarkdown(content string, width int) string {
-	opts := []glamour.TermRendererOption{glamour.WithAutoStyle()}
+	var styleOpt glamour.TermRendererOption
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		styleOpt = glamour.WithStandardStyle(theme.Current().GlamourStyle)
+	} else {
+		styleOpt = glamour.WithAutoStyle()
+	}
+
+	opts := []glamour.TermRendererOption{styleOpt}
 	if width > 0 {
 		opts = append(opts, glamour.WithWordWrap(width))
 	}

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -1,0 +1,75 @@
+package theme
+
+import "github.com/charmbracelet/lipgloss"
+
+// Theme holds color values tuned for a specific terminal background.
+type Theme struct {
+	Name         string // "dark" or "light"
+	Primary      string // main accent (cyan on dark, blue on light)
+	Success      string // confirmations
+	Error        string // errors
+	Warning      string // cautions
+	Muted        string // secondary/dim text
+	GlamourStyle string // passed to glamour.WithStandardStyle
+}
+
+// Dark is the color scheme for terminals with a dark background.
+var Dark = Theme{
+	Name:         "dark",
+	Primary:      "#00BFFF", // cyan
+	Success:      "#00E676", // green
+	Error:        "#FF5252", // red
+	Warning:      "#FFD740", // yellow
+	Muted:        "#777777", // dim gray
+	GlamourStyle: "dark",
+}
+
+// Light is the color scheme for terminals with a light background.
+var Light = Theme{
+	Name:         "light",
+	Primary:      "#0057B7", // blue
+	Success:      "#2E7D32", // green
+	Error:        "#C62828", // red
+	Warning:      "#F57F17", // yellow/amber
+	Muted:        "#999999", // mid gray
+	GlamourStyle: "light",
+}
+
+// current holds the active theme. It defaults to Dark and is set during
+// initialization via SetTheme or the Detect/FromName helpers.
+var current = Dark
+
+// Current returns the active theme.
+func Current() Theme {
+	return current
+}
+
+// SetTheme sets the active theme.
+func SetTheme(t Theme) {
+	current = t
+}
+
+// Detect uses lipgloss to query the terminal background color and returns
+// the appropriate theme. When detection is not possible (e.g. piped output),
+// it defaults to Dark.
+func Detect() Theme {
+	if lipgloss.HasDarkBackground() {
+		return Dark
+	}
+	return Light
+}
+
+// FromName returns a theme by name. Accepted values are "dark", "light", and
+// "auto". Any other value falls back to Dark.
+func FromName(name string) Theme {
+	switch name {
+	case "dark":
+		return Dark
+	case "light":
+		return Light
+	case "auto":
+		return Detect()
+	default:
+		return Dark
+	}
+}

--- a/internal/theme/theme_test.go
+++ b/internal/theme/theme_test.go
@@ -1,0 +1,63 @@
+package theme
+
+import "testing"
+
+func TestDetectReturnsTheme(t *testing.T) {
+	got := Detect()
+	if got.Name != "dark" && got.Name != "light" {
+		t.Errorf("Detect() returned theme with Name=%q, want \"dark\" or \"light\"", got.Name)
+	}
+}
+
+func TestFromNameDark(t *testing.T) {
+	got := FromName("dark")
+	if got.Name != "dark" {
+		t.Errorf("FromName(\"dark\") returned Name=%q, want \"dark\"", got.Name)
+	}
+}
+
+func TestFromNameLight(t *testing.T) {
+	got := FromName("light")
+	if got.Name != "light" {
+		t.Errorf("FromName(\"light\") returned Name=%q, want \"light\"", got.Name)
+	}
+}
+
+func TestFromNameAuto(t *testing.T) {
+	got := FromName("auto")
+	if got.Name != "dark" && got.Name != "light" {
+		t.Errorf("FromName(\"auto\") returned Name=%q, want \"dark\" or \"light\"", got.Name)
+	}
+}
+
+func TestFromNameInvalid(t *testing.T) {
+	got := FromName("invalid")
+	if got.Name != "dark" {
+		t.Errorf("FromName(\"invalid\") returned Name=%q, want \"dark\"", got.Name)
+	}
+}
+
+func TestThemeHasAllColors(t *testing.T) {
+	for _, th := range []Theme{Dark, Light} {
+		t.Run(th.Name, func(t *testing.T) {
+			if th.Primary == "" {
+				t.Error("Primary is empty")
+			}
+			if th.Success == "" {
+				t.Error("Success is empty")
+			}
+			if th.Error == "" {
+				t.Error("Error is empty")
+			}
+			if th.Warning == "" {
+				t.Error("Warning is empty")
+			}
+			if th.Muted == "" {
+				t.Error("Muted is empty")
+			}
+			if th.GlamourStyle == "" {
+				t.Error("GlamourStyle is empty")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Automatic terminal background detection using lipgloss
- Dark and light color palettes
- `--theme auto|dark|light` flag with config file support
- Glamour rendering uses correct style based on theme

Closes #18

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] `go build` compiles
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)