### PR TITLE
feat: clickable hyperlinks via OSC 8

### DIFF
--- a/internal/render/links.go
+++ b/internal/render/links.go
@@ -1,0 +1,24 @@
+package render
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// urlPattern matches http:// and https:// URLs while avoiding ANSI escape
+// sequences and closing brackets that are part of surrounding syntax.
+var urlPattern = regexp.MustCompile(`https?://[^\s\x1b\]]+`)
+
+// WrapLink wraps text in an OSC 8 hyperlink escape sequence.
+func WrapLink(text, url string) string {
+	return fmt.Sprintf("\x1b]8;;%s\x1b\\%s\x1b]8;;\x1b\\", url, text)
+}
+
+// LinkifyMarkdown scans rendered output for URLs and wraps them in OSC 8
+// hyperlink escape sequences so they are clickable in supported terminals.
+// It matches http:// and https:// URLs and leaves non-URL text unchanged.
+func LinkifyMarkdown(content string) string {
+	return urlPattern.ReplaceAllStringFunc(content, func(rawURL string) string {
+		return WrapLink(rawURL, rawURL)
+	})
+}

--- a/internal/render/links_test.go
+++ b/internal/render/links_test.go
@@ -1,0 +1,63 @@
+package render
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestWrapLink(t *testing.T) {
+	got := WrapLink("example", "https://example.com")
+	want := "\x1b]8;;https://example.com\x1b\\example\x1b]8;;\x1b\\"
+	if got != want {
+		t.Errorf("WrapLink mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestLinkifyFindsURLs(t *testing.T) {
+	input := "Visit https://example.com for details."
+	got := LinkifyMarkdown(input)
+
+	wrapped := WrapLink("https://example.com", "https://example.com")
+	want := fmt.Sprintf("Visit %s for details.", wrapped)
+	if got != want {
+		t.Errorf("LinkifyMarkdown mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestLinkifyFindsHTTPURLs(t *testing.T) {
+	input := "Visit http://example.com for info."
+	got := LinkifyMarkdown(input)
+
+	if !strings.Contains(got, "\x1b]8;;http://example.com\x1b\\") {
+		t.Errorf("expected OSC 8 wrapping for http URL, got %q", got)
+	}
+}
+
+func TestLinkifyPreservesNonURLText(t *testing.T) {
+	input := "Hello world, no links here."
+	got := LinkifyMarkdown(input)
+	if got != input {
+		t.Errorf("expected unchanged text, got %q", got)
+	}
+}
+
+func TestLinkifyHandlesMultipleURLs(t *testing.T) {
+	input := "See https://one.com and https://two.com for more."
+	got := LinkifyMarkdown(input)
+
+	if !strings.Contains(got, WrapLink("https://one.com", "https://one.com")) {
+		t.Errorf("expected first URL wrapped, got %q", got)
+	}
+	if !strings.Contains(got, WrapLink("https://two.com", "https://two.com")) {
+		t.Errorf("expected second URL wrapped, got %q", got)
+	}
+}
+
+func TestLinkifyIgnoresPartialURLs(t *testing.T) {
+	input := "The word http alone is not a URL."
+	got := LinkifyMarkdown(input)
+	if got != input {
+		t.Errorf("expected unchanged text for partial URL, got %q", got)
+	}
+}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -35,5 +35,12 @@ func RenderMarkdown(content string, width int) string {
 		return content
 	}
 
+	// Add clickable hyperlinks via OSC 8 when outputting to a TTY.
+	// Skip when NO_COLOR is set to keep output free of escape sequences.
+	_, noColor := os.LookupEnv("NO_COLOR")
+	if term.IsTerminal(int(os.Stdout.Fd())) && !noColor {
+		out = LinkifyMarkdown(out)
+	}
+
 	return out
 }


### PR DESCRIPTION
## Summary
- Wraps URLs in OSC 8 escape sequences for clickable links in supported terminals
- Respects NO_COLOR env var and non-TTY contexts
- 6 new tests

Closes #19

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] `go build` compiles
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)