### PR TITLE
feat: clipboard copy with OSC 52 fallback

### DIFF
--- a/cmd/dispatcher.go
+++ b/cmd/dispatcher.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/oobagi/notebook/internal/clipboard"
 	"github.com/oobagi/notebook/internal/editor"
 	"github.com/oobagi/notebook/internal/render"
 	"github.com/spf13/cobra"
@@ -225,6 +226,19 @@ func editNote(w io.Writer, book, note string) error {
 }
 
 func copyNote(w io.Writer, book, note string) error {
-	fmt.Fprintln(w, "copy: not implemented yet")
+	n, err := store.GetNote(book, note)
+	if err != nil {
+		if strings.Contains(err.Error(), "no such file or directory") {
+			printError(w, fmt.Sprintf("Note %q not found in %q", note, book))
+			return nil
+		}
+		return fmt.Errorf("copy note %q/%q: %w", book, note, err)
+	}
+
+	if err := clipboard.Copy(n.Content); err != nil {
+		printError(w, fmt.Sprintf("Could not copy to clipboard: %s", err))
+		return nil
+	}
+	printSuccess(w, fmt.Sprintf("Copied %q to clipboard", note))
 	return nil
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -280,13 +280,31 @@ func TestDispatchNoteDelete(t *testing.T) {
 
 func TestDispatchNoteCopy(t *testing.T) {
 	dir := setupTestStore(t)
+	st := storage.NewStore(dir)
+	_ = st.CreateNote("work", "readme", "# Hello\n\nSome content.")
 
 	out, err := executeCapture([]string{"--dir", dir, "work", "readme", "copy"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(out, "not implemented") {
-		t.Errorf("expected stub message, got %q", out)
+	// Should show success message (clipboard copy may use OSC 52 fallback in CI).
+	if !strings.Contains(out, "Copied") || !strings.Contains(out, "readme") {
+		t.Errorf("expected success message with note name, got %q", out)
+	}
+}
+
+func TestDispatchNoteCopyNotFound(t *testing.T) {
+	dir := setupTestStore(t)
+
+	out, err := executeCapture([]string{"--dir", dir, "work", "nonexistent", "copy"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "\u2717") {
+		t.Errorf("expected error symbol in output, got %q", out)
+	}
+	if !strings.Contains(out, "not found") {
+		t.Errorf("expected 'not found' in output, got %q", out)
 	}
 }
 

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -1,0 +1,47 @@
+package clipboard
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// Copy copies text to the system clipboard.
+// Tries the system clipboard first (more reliable), falls back to OSC 52
+// (works over SSH).
+func Copy(text string) error {
+	if err := copySystem(text); err == nil {
+		return nil
+	}
+	return copyOSC52(text, os.Stdout)
+}
+
+// copyOSC52 writes an OSC 52 escape sequence to w.
+// Format: \x1b]52;c;<base64>\x07
+func copyOSC52(text string, w io.Writer) error {
+	encoded := base64.StdEncoding.EncodeToString([]byte(text))
+	_, err := fmt.Fprintf(w, "\x1b]52;c;%s\x07", encoded)
+	return err
+}
+
+// copySystem uses platform-specific commands to copy text to the clipboard.
+// macOS: pbcopy
+// Linux: xclip -selection clipboard
+func copySystem(text string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("pbcopy")
+	case "linux":
+		cmd = exec.Command("xclip", "-selection", "clipboard")
+	default:
+		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+	}
+
+	cmd.Stdin = strings.NewReader(text)
+	return cmd.Run()
+}

--- a/internal/clipboard/clipboard_test.go
+++ b/internal/clipboard/clipboard_test.go
@@ -1,0 +1,55 @@
+package clipboard
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestOSC52Format(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"simple text", "hello world"},
+		{"multiline", "line1\nline2\nline3"},
+		{"empty", ""},
+		{"special chars", "# Header\n\n- item one\n- item two"},
+		{"unicode", "hello \u2713 world \u203A test"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := copyOSC52(tt.input, &buf)
+			if err != nil {
+				t.Fatalf("copyOSC52() error = %v", err)
+			}
+
+			out := buf.String()
+
+			// Must start with OSC 52 prefix.
+			prefix := "\x1b]52;c;"
+			if !strings.HasPrefix(out, prefix) {
+				t.Errorf("output should start with OSC 52 prefix, got %q", out)
+			}
+
+			// Must end with BEL.
+			if !strings.HasSuffix(out, "\x07") {
+				t.Errorf("output should end with BEL (\\x07), got %q", out)
+			}
+
+			// Extract and decode the base64 payload.
+			payload := out[len(prefix) : len(out)-1]
+			decoded, err := base64.StdEncoding.DecodeString(payload)
+			if err != nil {
+				t.Fatalf("base64 decode error: %v", err)
+			}
+
+			if string(decoded) != tt.input {
+				t.Errorf("decoded = %q, want %q", string(decoded), tt.input)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `notebook <book> <note> copy` copies note content to clipboard
- Uses pbcopy/xclip, falls back to OSC 52 for SSH sessions
- 5 new tests (OSC 52 format + command integration)

Closes #20

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] `go build` compiles
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)