### PR TITLE
feat: GitHub-style admonition blocks in rendering

### DIFF
--- a/internal/render/admonitions.go
+++ b/internal/render/admonitions.go
@@ -1,0 +1,133 @@
+package render
+
+import (
+	"regexp"
+	"strings"
+)
+
+// admonitionConfig holds the display properties for an admonition type.
+type admonitionConfig struct {
+	Icon  string
+	Label string
+	Color string // ANSI color parameter (e.g. "36" for cyan)
+}
+
+// admonitions maps GitHub-style admonition keywords to their display config.
+var admonitions = map[string]admonitionConfig{
+	"NOTE":      {Icon: "\u2192", Label: "Note", Color: "36"},      // cyan
+	"TIP":       {Icon: "\u2713", Label: "Tip", Color: "32"},       // green
+	"IMPORTANT": {Icon: "!", Label: "Important", Color: "1;35"},    // bold magenta
+	"WARNING":   {Icon: "!", Label: "Warning", Color: "33"},        // yellow
+	"CAUTION":   {Icon: "\u2717", Label: "Caution", Color: "31"},   // red
+}
+
+// ansiStripRe matches ANSI escape sequences so they can be removed for
+// pattern matching while preserving the original string for output.
+var ansiStripRe = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// admonitionTagRe matches [!TYPE] in ANSI-stripped text, where TYPE is one of
+// the recognised admonition keywords. The match is case-insensitive to be
+// forgiving, but the canonical GitHub syntax is uppercase.
+var admonitionTagRe = regexp.MustCompile(`\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]`)
+
+// isBlockquoteLine checks whether a raw (ANSI-containing) line is a Glamour
+// blockquote line by looking for the │ border character in the stripped text.
+func isBlockquoteLine(line string) bool {
+	stripped := ansiStripRe.ReplaceAllString(line, "")
+	trimmed := strings.TrimLeft(stripped, " ")
+	return strings.HasPrefix(trimmed, "\u2502 ") || strings.HasPrefix(trimmed, "\u2502")
+}
+
+// RenderAdmonitions post-processes Glamour-rendered markdown to detect
+// GitHub-style admonition blocks ([!NOTE], [!TIP], etc.) and restyle them
+// with colored borders and header labels.
+//
+// The function scans each line for the [!TYPE] pattern. When found it:
+//  1. Replaces the [!TYPE] tag with a colored header showing the icon and label.
+//  2. Recolors the │ border on the header line and all subsequent blockquote
+//     lines that belong to the same block.
+func RenderAdmonitions(content string) string {
+	lines := strings.Split(content, "\n")
+	result := make([]string, 0, len(lines))
+
+	i := 0
+	for i < len(lines) {
+		line := lines[i]
+		stripped := ansiStripRe.ReplaceAllString(line, "")
+
+		match := admonitionTagRe.FindStringSubmatch(stripped)
+		if match != nil && isBlockquoteLine(line) {
+			adType := strings.ToUpper(match[1])
+			cfg, ok := admonitions[adType]
+			if !ok {
+				result = append(result, line)
+				i++
+				continue
+			}
+
+			// Restyle the header line: replace the [!TYPE] tag text and
+			// recolor the border.
+			headerLine := restyleAdmonitionHeader(line, match[0], cfg)
+			result = append(result, headerLine)
+			i++
+
+			// Recolor subsequent blockquote lines in the same block.
+			for i < len(lines) && isBlockquoteLine(lines[i]) {
+				result = append(result, recolorBorder(lines[i], cfg.Color))
+				i++
+			}
+			continue
+		}
+
+		result = append(result, line)
+		i++
+	}
+
+	return strings.Join(result, "\n")
+}
+
+// restyleAdmonitionHeader replaces the [!TYPE] tag in a rendered blockquote
+// line with a colored "ICON Label" header and recolors the border.
+func restyleAdmonitionHeader(line, tag string, cfg admonitionConfig) string {
+	// Build the colored header text: "ICON Label"
+	header := "\x1b[" + cfg.Color + "m" + cfg.Icon + " " + cfg.Label + "\x1b[0m"
+
+	// We need to replace the [!TYPE] portion in the raw line. Because ANSI
+	// codes are interspersed between the characters of [!TYPE], we build a
+	// regex that matches the tag characters with optional ANSI codes between
+	// them. We also consume a trailing space/ANSI if present.
+	tagPattern := buildAnsiInterspersedPattern(tag)
+	re := regexp.MustCompile(tagPattern + `(\x1b\[[0-9;]*m)?(\s?)`)
+
+	line = re.ReplaceAllString(line, header+" ")
+
+	// Recolor the border character.
+	line = recolorBorder(line, cfg.Color)
+
+	return line
+}
+
+// buildAnsiInterspersedPattern builds a regex pattern that matches the given
+// literal text with optional ANSI escape sequences between each character.
+// For example, "[!NOTE]" becomes a pattern matching "[", then optional ANSI,
+// then "!", then optional ANSI, etc.
+func buildAnsiInterspersedPattern(text string) string {
+	ansiOpt := `(?:\x1b\[[0-9;]*m)*`
+	var b strings.Builder
+	for i, ch := range text {
+		if i > 0 {
+			b.WriteString(ansiOpt)
+		}
+		b.WriteString(regexp.QuoteMeta(string(ch)))
+	}
+	return b.String()
+}
+
+// recolorBorder replaces the default Glamour blockquote border color with
+// the admonition color. The border character │ (U+2502) is preceded by
+// a color code like \x1b[38;5;252m — we replace that with the admonition color.
+func recolorBorder(line, color string) string {
+	// Match: ANSI-color then "│ " then ANSI-reset, and replace the color.
+	borderRe := regexp.MustCompile(`\x1b\[[\d;]*m(` + "\u2502" + ` )\x1b\[0m`)
+	return borderRe.ReplaceAllString(line, "\x1b["+color+"m${1}\x1b[0m")
+}

--- a/internal/render/admonitions_test.go
+++ b/internal/render/admonitions_test.go
@@ -1,0 +1,160 @@
+package render
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// stripANSI removes ANSI escape sequences for easier assertion on visible text.
+func stripANSI(s string) string {
+	re := regexp.MustCompile(`\x1b\[[0-9;]*m`)
+	return re.ReplaceAllString(s, "")
+}
+
+// containsANSI checks whether s contains the given ANSI color code parameter
+// (e.g. "36" matches \x1b[36m).
+func containsANSI(s, code string) bool {
+	return strings.Contains(s, "\x1b["+code+"m")
+}
+
+func TestRenderAdmonitionNote(t *testing.T) {
+	// Simulate Glamour-rendered blockquote with [!NOTE].
+	input := "\x1b[38;5;252m\x1b[0m  \x1b[38;5;252m\u2502 \x1b[0m\x1b[38;5;252m[\x1b[0m\x1b[38;5;252m!NOTE\x1b[0m\x1b[38;5;252m] \x1b[0m\x1b[38;5;252mThis is a note\x1b[0m"
+	got := RenderAdmonitions(input)
+
+	stripped := stripANSI(got)
+	if !strings.Contains(stripped, "\u2192 Note") {
+		t.Errorf("expected Note header with arrow icon, got %q", stripped)
+	}
+	if strings.Contains(stripped, "[!NOTE]") {
+		t.Errorf("expected [!NOTE] tag to be removed, got %q", stripped)
+	}
+	// Cyan color code.
+	if !containsANSI(got, "36") {
+		t.Errorf("expected cyan ANSI code (36) in output, got %q", got)
+	}
+}
+
+func TestRenderAdmonitionTip(t *testing.T) {
+	input := "\x1b[38;5;252m\x1b[0m  \x1b[38;5;252m\u2502 \x1b[0m\x1b[38;5;252m[\x1b[0m\x1b[38;5;252m!TIP\x1b[0m\x1b[38;5;252m] \x1b[0m\x1b[38;5;252mHelpful tip\x1b[0m"
+	got := RenderAdmonitions(input)
+
+	stripped := stripANSI(got)
+	if !strings.Contains(stripped, "\u2713 Tip") {
+		t.Errorf("expected Tip header with checkmark icon, got %q", stripped)
+	}
+	if !containsANSI(got, "32") {
+		t.Errorf("expected green ANSI code (32) in output, got %q", got)
+	}
+}
+
+func TestRenderAdmonitionWarning(t *testing.T) {
+	input := "\x1b[38;5;252m\x1b[0m  \x1b[38;5;252m\u2502 \x1b[0m\x1b[38;5;252m[\x1b[0m\x1b[38;5;252m!WARNING\x1b[0m\x1b[38;5;252m] \x1b[0m\x1b[38;5;252mBe careful\x1b[0m"
+	got := RenderAdmonitions(input)
+
+	stripped := stripANSI(got)
+	if !strings.Contains(stripped, "! Warning") {
+		t.Errorf("expected Warning header with ! icon, got %q", stripped)
+	}
+	if !containsANSI(got, "33") {
+		t.Errorf("expected yellow ANSI code (33) in output, got %q", got)
+	}
+}
+
+func TestRenderAdmonitionCaution(t *testing.T) {
+	input := "\x1b[38;5;252m\x1b[0m  \x1b[38;5;252m\u2502 \x1b[0m\x1b[38;5;252m[\x1b[0m\x1b[38;5;252m!CAUTION\x1b[0m\x1b[38;5;252m] \x1b[0m\x1b[38;5;252mDangerous operation\x1b[0m"
+	got := RenderAdmonitions(input)
+
+	stripped := stripANSI(got)
+	if !strings.Contains(stripped, "\u2717 Caution") {
+		t.Errorf("expected Caution header with X icon, got %q", stripped)
+	}
+	if !containsANSI(got, "31") {
+		t.Errorf("expected red ANSI code (31) in output, got %q", got)
+	}
+}
+
+func TestRenderAdmonitionImportant(t *testing.T) {
+	input := "\x1b[38;5;252m\x1b[0m  \x1b[38;5;252m\u2502 \x1b[0m\x1b[38;5;252m[\x1b[0m\x1b[38;5;252m!IMPORTANT\x1b[0m\x1b[38;5;252m] \x1b[0m\x1b[38;5;252mRead this\x1b[0m"
+	got := RenderAdmonitions(input)
+
+	stripped := stripANSI(got)
+	if !strings.Contains(stripped, "! Important") {
+		t.Errorf("expected Important header with ! icon, got %q", stripped)
+	}
+	// Bold magenta: 1;35.
+	if !containsANSI(got, "1;35") {
+		t.Errorf("expected bold magenta ANSI code (1;35) in output, got %q", got)
+	}
+}
+
+func TestRenderAdmonitionPreservesNonAdmonition(t *testing.T) {
+	// A regular blockquote without [!TYPE] should pass through unchanged.
+	input := "\x1b[38;5;252m\x1b[0m  \x1b[38;5;252m\u2502 \x1b[0m\x1b[38;5;252mJust a normal quote\x1b[0m"
+	got := RenderAdmonitions(input)
+
+	if got != input {
+		t.Errorf("expected non-admonition blockquote unchanged\n got: %q\nwant: %q", got, input)
+	}
+}
+
+func TestRenderAdmonitionMultiple(t *testing.T) {
+	// Two admonitions separated by a non-blockquote line.
+	note := "\x1b[38;5;252m\x1b[0m  \x1b[38;5;252m\u2502 \x1b[0m\x1b[38;5;252m[\x1b[0m\x1b[38;5;252m!NOTE\x1b[0m\x1b[38;5;252m] \x1b[0m\x1b[38;5;252mFirst\x1b[0m"
+	separator := "  \x1b[38;5;252mSome text\x1b[0m"
+	warning := "\x1b[38;5;252m\x1b[0m  \x1b[38;5;252m\u2502 \x1b[0m\x1b[38;5;252m[\x1b[0m\x1b[38;5;252m!WARNING\x1b[0m\x1b[38;5;252m] \x1b[0m\x1b[38;5;252mSecond\x1b[0m"
+
+	input := note + "\n" + separator + "\n" + warning
+	got := RenderAdmonitions(input)
+
+	stripped := stripANSI(got)
+	if !strings.Contains(stripped, "\u2192 Note") {
+		t.Errorf("expected Note header, got %q", stripped)
+	}
+	if !strings.Contains(stripped, "! Warning") {
+		t.Errorf("expected Warning header, got %q", stripped)
+	}
+	if !strings.Contains(stripped, "Some text") {
+		t.Errorf("expected separator text preserved, got %q", stripped)
+	}
+}
+
+func TestRenderAdmonitionMultiLine(t *testing.T) {
+	// An admonition block spanning multiple blockquote lines.
+	header := "\x1b[38;5;252m\x1b[0m  \x1b[38;5;252m\u2502 \x1b[0m\x1b[38;5;252m[\x1b[0m\x1b[38;5;252m!TIP\x1b[0m\x1b[38;5;252m] \x1b[0m\x1b[38;5;252mFirst line\x1b[0m"
+	body := "\x1b[38;5;252m\x1b[0m  \x1b[38;5;252m\u2502 \x1b[0m\x1b[38;5;252mSecond line\x1b[0m"
+
+	input := header + "\n" + body
+	got := RenderAdmonitions(input)
+
+	// Both lines should get the green color on the border.
+	lines := strings.Split(got, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines, got %d", len(lines))
+	}
+	for i, line := range lines {
+		if line == "" {
+			continue
+		}
+		if !containsANSI(line, "32") {
+			t.Errorf("line %d: expected green ANSI code (32), got %q", i, line)
+		}
+	}
+}
+
+func TestRenderAdmonitionEmptyInput(t *testing.T) {
+	got := RenderAdmonitions("")
+	if got != "" {
+		t.Errorf("expected empty output for empty input, got %q", got)
+	}
+}
+
+func TestRenderAdmonitionNoBlockquote(t *testing.T) {
+	// Plain text with [!NOTE] but not in a blockquote should pass through.
+	input := "This has [!NOTE] but is not a blockquote"
+	got := RenderAdmonitions(input)
+	if got != input {
+		t.Errorf("expected unchanged output for non-blockquote [!NOTE]\n got: %q\nwant: %q", got, input)
+	}
+}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -35,9 +35,15 @@ func RenderMarkdown(content string, width int) string {
 		return content
 	}
 
+	// Style GitHub-style admonition blocks ([!NOTE], [!TIP], etc.) when
+	// outputting to a TTY with colors enabled.
+	_, noColor := os.LookupEnv("NO_COLOR")
+	if term.IsTerminal(int(os.Stdout.Fd())) && !noColor {
+		out = RenderAdmonitions(out)
+	}
+
 	// Add clickable hyperlinks via OSC 8 when outputting to a TTY.
 	// Skip when NO_COLOR is set to keep output free of escape sequences.
-	_, noColor := os.LookupEnv("NO_COLOR")
 	if term.IsTerminal(int(os.Stdout.Fd())) && !noColor {
 		out = LinkifyMarkdown(out)
 	}


### PR DESCRIPTION
## Summary
- Post-processes Glamour output to style [!NOTE], [!TIP], [!IMPORTANT], [!WARNING], [!CAUTION] blocks
- Colored borders and labeled headers with design-doc compliant icons
- Respects NO_COLOR and non-TTY environments
- 10 new tests

Closes #21

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] `go build` compiles
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)