### PR TITLE
fix: replace version subcommand with --version/-v flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ var (
 var rootCmd = &cobra.Command{
 	SilenceErrors: true,
 	SilenceUsage:  true,
+	Version:       Version,
 	Use:           "notebook",
 	Short:         "A dead-simple CLI note manager with live markdown preview",
 	Long:          "Notebook is a CLI tool for managing markdown notes organized into notebooks, with a live-preview editor mode right in your terminal.",
@@ -69,6 +70,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.PersistentFlags().StringVar(&dirFlag, "dir", "", "root directory for notebook storage (default ~/.notebook)")
 	rootCmd.PersistentFlags().StringVar(&themeFlag, "theme", "auto", "color theme (auto, dark, light)")
+	rootCmd.SetVersionTemplate("notebook {{.Version}}\n")
 }
 
 // Execute runs the root command.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,23 +1,4 @@
 package cmd
 
-import (
-	"fmt"
-
-	"github.com/spf13/cobra"
-)
-
 // Version is set at build time via ldflags.
 var Version = "dev"
-
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print the version of notebook",
-	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Fprintln(cmd.OutOrStdout(), "notebook "+Version)
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(versionCmd)
-}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-func TestVersionCommand(t *testing.T) {
-	out, err := executeCapture([]string{"version"})
+func TestVersionFlag(t *testing.T) {
+	out, err := executeCapture([]string{"--version"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Removed `notebook version` subcommand
- Added `Version` field to root Cobra command for `--version` / `-v` flags
- Custom version template outputs `notebook <version>` (clean, no "version version")
- Updated tests to use `--version` flag

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] `notebook --version` outputs `notebook dev`
- [x] `notebook -v` outputs `notebook dev`
- [x] `notebook version` no longer exists as a subcommand

🤖 Generated with [Claude Code](https://claude.com/claude-code)