### PR TITLE
feat: TUI help overlay

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -41,6 +41,7 @@ type Model struct {
 	filtered    []int  // indices into notebooks/notes after filtering
 	width       int
 	height      int
+	showHelp    bool   // help overlay visible
 	quitting    bool
 	selected    *Selection // set when user picks a note to edit
 	err         error
@@ -166,6 +167,21 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	}
 
+	// When help overlay is showing, only ? and Esc dismiss it.
+	if m.showHelp {
+		switch msg.Type {
+		case tea.KeyEsc:
+			m.showHelp = false
+			return m, nil
+		case tea.KeyRunes:
+			if string(msg.Runes) == "?" {
+				m.showHelp = false
+				return m, nil
+			}
+		}
+		return m, nil
+	}
+
 	// When filtering, handle text input first.
 	if m.filtering {
 		return m.handleFilterKey(msg)
@@ -199,6 +215,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if s == "q" {
 			m.quitting = true
 			return m, tea.Quit
+		}
+		if s == "?" {
+			m.showHelp = true
+			return m, nil
 		}
 		if s == "/" {
 			m.filtering = true
@@ -352,10 +372,71 @@ func (m Model) handleEsc() (tea.Model, tea.Cmd) {
 	return m, tea.Quit
 }
 
+// renderHelpOverlay builds the centered help panel.
+func (m Model) renderHelpOverlay() string {
+	var help string
+	if m.level == 0 {
+		help = `  Keybindings
+  ───────────────────────────
+
+  ↑/↓       Navigate
+  Enter      Open notebook
+  n          New notebook
+  d          Delete notebook
+  r          Rename notebook
+  /          Search
+  q          Quit
+  ?          Toggle help
+
+  Press ? or Esc to close`
+	} else {
+		help = `  Keybindings
+  ───────────────────────────
+
+  ↑/↓       Navigate
+  Enter      Edit note
+  v          View note
+  n          New note
+  d          Delete note
+  r          Rename note
+  c          Copy to clipboard
+  /          Search
+  Esc        Back to notebooks
+  q          Quit
+  ?          Toggle help
+
+  Press ? or Esc to close`
+	}
+
+	w := m.width
+	if w <= 0 {
+		w = 80
+	}
+	h := m.height
+	if h <= 0 {
+		h = 24
+	}
+
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("8")).
+		Padding(1, 2).
+		Width(36).
+		Align(lipgloss.Left)
+
+	rendered := box.Render(help)
+
+	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, rendered)
+}
+
 // View implements tea.Model.
 func (m Model) View() string {
 	if m.quitting {
 		return ""
+	}
+
+	if m.showHelp {
+		return m.renderHelpOverlay()
 	}
 
 	if m.err != nil {
@@ -574,7 +655,7 @@ func (m Model) renderStatusBar() string {
 		return dim.Render(fmt.Sprintf("  Filter: %s_ \u00B7 Esc clear \u00B7 Enter select", m.filter))
 	}
 
-	return dim.Render("  \u2191/\u2193 navigate \u00B7 Enter open \u00B7 / search \u00B7 Esc back \u00B7 q quit")
+	return dim.Render("  \u2191/\u2193 navigate \u00B7 Enter open \u00B7 / search \u00B7 Esc back \u00B7 q quit \u00B7 ? help")
 }
 
 // pluralize returns "1 note" or "3 notes" style strings.

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -361,6 +361,78 @@ func TestBrowserFilterClearOnEsc(t *testing.T) {
 }
 
 
+func TestBrowserHelpToggle(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Help should be hidden initially.
+	if m.showHelp {
+		t.Fatal("expected showHelp to be false initially")
+	}
+
+	// Press '?' to open help.
+	m = sendRune(t, m, '?')
+
+	if !m.showHelp {
+		t.Fatal("expected showHelp to be true after pressing '?'")
+	}
+
+	view := m.View()
+	if !containsStr(view, "Keybindings") {
+		t.Errorf("help overlay should contain 'Keybindings', got:\n%s", view)
+	}
+	if !containsStr(view, "Navigate") {
+		t.Errorf("help overlay should contain 'Navigate', got:\n%s", view)
+	}
+
+	// Press '?' again to dismiss.
+	m = sendRune(t, m, '?')
+
+	if m.showHelp {
+		t.Fatal("expected showHelp to be false after pressing '?' again")
+	}
+
+	view = m.View()
+	if containsStr(view, "Keybindings") {
+		t.Error("help overlay should not be visible after dismissing")
+	}
+}
+
+func TestBrowserHelpEscDismisses(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Enter the notebook so we're at level 1.
+	m = sendKey(t, m, tea.KeyEnter)
+	if m.level != 1 {
+		t.Fatalf("expected level 1, got %d", m.level)
+	}
+
+	// Open help.
+	m = sendRune(t, m, '?')
+	if !m.showHelp {
+		t.Fatal("expected showHelp to be true")
+	}
+
+	// Press Esc to dismiss help.
+	m = sendKey(t, m, tea.KeyEsc)
+
+	if m.showHelp {
+		t.Fatal("expected showHelp to be false after Esc")
+	}
+
+	// Esc should NOT navigate back -- still at level 1.
+	if m.level != 1 {
+		t.Errorf("expected level 1 after Esc dismisses help, got %d", m.level)
+	}
+}
+
 func containsStr(s, substr string) bool {
 	return len(s) > 0 && len(substr) > 0 && contains(s, substr)
 }


### PR DESCRIPTION
## Summary

- `?` toggles a centered help overlay in the TUI browser
- Context-aware: shows different keybindings for notebooks (L0) vs notes (L1)
- Esc or `?` dismisses without navigating
- Status bar now includes `? help` hint

Closes #50

## Test plan

- [x] `?` opens help overlay with keybinding list
- [x] `?` again dismisses overlay
- [x] Esc dismisses overlay without navigating back
- [x] `go test ./...` — 278 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)