### PR TITLE
feat: TUI inline text input and create operation

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -44,6 +44,13 @@ type Model struct {
 	quitting    bool
 	selected    *Selection // set when user picks a note to edit
 	err         error
+
+	// Inline text input mode (used for create, rename, etc.)
+	inputMode   bool                  // whether text input is active
+	inputPrompt string                // prompt text (e.g., "New notebook:")
+	inputValue  string                // current text in the input field
+	inputAction func(string) tea.Cmd  // callback when Enter is pressed
+	inputErr    string                // validation error to show inline
 }
 
 // notebookItem holds pre-fetched metadata for a notebook.
@@ -128,6 +135,9 @@ func (m Model) loadNotes(book string) tea.Cmd {
 
 type errMsg struct{ err error }
 
+// reloadMsg signals that the current list should be reloaded.
+type reloadMsg struct{}
+
 // Update implements tea.Model.
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
@@ -151,6 +161,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.err = msg.err
 		return m, nil
 
+	case reloadMsg:
+		if m.level == 0 {
+			return m, m.loadNotebooks()
+		}
+		return m, m.loadNotes(m.currentBook)
+
 	case tea.KeyMsg:
 		return m.handleKey(msg)
 	}
@@ -164,6 +180,11 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case tea.KeyCtrlC:
 		m.quitting = true
 		return m, tea.Quit
+	}
+
+	// Input mode intercepts all keys.
+	if m.inputMode {
+		return m.handleInputKey(msg)
 	}
 
 	// When filtering, handle text input first.
@@ -205,6 +226,9 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filter = ""
 			m.applyFilter()
 			return m, nil
+		}
+		if s == "n" {
+			return m.startCreate()
 		}
 		return m, nil
 	}
@@ -253,6 +277,74 @@ func (m Model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	return m, nil
+}
+
+func (m Model) handleInputKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEsc:
+		m.inputMode = false
+		m.inputValue = ""
+		m.inputErr = ""
+		return m, nil
+
+	case tea.KeyEnter:
+		value := strings.TrimSpace(m.inputValue)
+		if value == "" {
+			m.inputErr = "Name can't be empty"
+			return m, nil
+		}
+		action := m.inputAction
+		m.inputMode = false
+		m.inputValue = ""
+		m.inputErr = ""
+		return m, action(value)
+
+	case tea.KeyBackspace:
+		if len(m.inputValue) > 0 {
+			m.inputValue = m.inputValue[:len(m.inputValue)-1]
+			m.inputErr = ""
+		}
+		return m, nil
+
+	case tea.KeyRunes:
+		m.inputValue += string(msg.Runes)
+		m.inputErr = ""
+		return m, nil
+	}
+
+	return m, nil
+}
+
+func (m Model) startCreate() (tea.Model, tea.Cmd) {
+	if m.level == 0 {
+		m.inputMode = true
+		m.inputPrompt = "New notebook:"
+		m.inputValue = ""
+		m.inputErr = ""
+		m.inputAction = func(name string) tea.Cmd {
+			return func() tea.Msg {
+				if err := m.store.CreateNotebook(name); err != nil {
+					return errMsg{err}
+				}
+				return reloadMsg{}
+			}
+		}
+	} else {
+		book := m.currentBook
+		m.inputMode = true
+		m.inputPrompt = fmt.Sprintf("New note in %s:", book)
+		m.inputValue = ""
+		m.inputErr = ""
+		m.inputAction = func(name string) tea.Cmd {
+			return func() tea.Msg {
+				if err := m.store.CreateNote(book, name, ""); err != nil {
+					return errMsg{err}
+				}
+				return reloadMsg{}
+			}
+		}
+	}
 	return m, nil
 }
 
@@ -570,11 +662,20 @@ func (m Model) renderEmptyNotes() string {
 func (m Model) renderStatusBar() string {
 	dim := lipgloss.NewStyle().Faint(true)
 
+	if m.inputMode {
+		line := fmt.Sprintf("  %s %s_", m.inputPrompt, m.inputValue)
+		if m.inputErr != "" {
+			errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("1")) // red
+			line += "\n" + errStyle.Render("  "+m.inputErr)
+		}
+		return line
+	}
+
 	if m.filtering {
 		return dim.Render(fmt.Sprintf("  Filter: %s_ \u00B7 Esc clear \u00B7 Enter select", m.filter))
 	}
 
-	return dim.Render("  \u2191/\u2193 navigate \u00B7 Enter open \u00B7 / search \u00B7 Esc back \u00B7 q quit")
+	return dim.Render("  \u2191/\u2193 navigate \u00B7 Enter open \u00B7 / search \u00B7 n new \u00B7 Esc back \u00B7 q quit")
 }
 
 // pluralize returns "1 note" or "3 notes" style strings.

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -55,29 +55,28 @@ func sendKey(t *testing.T, m Model, key tea.KeyType) Model {
 	t.Helper()
 	updated, cmd := m.Update(tea.KeyMsg{Type: key})
 	m = updated.(Model)
-
-	// Process any commands (like loadNotes).
-	if cmd != nil {
-		msg := cmd()
-		if msg != nil {
-			updated, _ = m.Update(msg)
-			m = updated.(Model)
-		}
-	}
-	return m
+	return drainCmds(t, m, cmd)
 }
 
 func sendRune(t *testing.T, m Model, r rune) Model {
 	t.Helper()
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
 	m = updated.(Model)
+	return drainCmds(t, m, cmd)
+}
 
-	if cmd != nil {
+// drainCmds processes commands until none remain (up to a safety limit).
+func drainCmds(t *testing.T, m Model, cmd tea.Cmd) Model {
+	t.Helper()
+	for i := 0; i < 10 && cmd != nil; i++ {
 		msg := cmd()
-		if msg != nil {
-			updated, _ = m.Update(msg)
-			m = updated.(Model)
+		if msg == nil {
+			break
 		}
+		var next tea.Cmd
+		updated, next := m.Update(msg)
+		m = updated.(Model)
+		cmd = next
 	}
 	return m
 }
@@ -360,6 +359,199 @@ func TestBrowserFilterClearOnEsc(t *testing.T) {
 	}
 }
 
+
+func TestBrowserCreateNotebook(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"existing": {"note1"},
+	})
+
+	m := initModel(t, s)
+
+	// Press 'n' to start creating a notebook.
+	m = sendRune(t, m, 'n')
+
+	if !m.inputMode {
+		t.Fatal("expected inputMode to be true after 'n'")
+	}
+	if m.inputPrompt != "New notebook:" {
+		t.Errorf("expected prompt 'New notebook:', got %q", m.inputPrompt)
+	}
+
+	// Type the notebook name.
+	m = sendRune(t, m, 'n')
+	m = sendRune(t, m, 'e')
+	m = sendRune(t, m, 'w')
+
+	if m.inputValue != "new" {
+		t.Errorf("expected inputValue 'new', got %q", m.inputValue)
+	}
+
+	// Press Enter to submit.
+	m = sendKey(t, m, tea.KeyEnter)
+
+	if m.inputMode {
+		t.Error("expected inputMode to be false after Enter")
+	}
+
+	// The notebook should have been created and the list reloaded.
+	found := false
+	for _, nb := range m.notebooks {
+		if nb.name == "new" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'new' notebook in list, got %v", m.notebooks)
+	}
+}
+
+func TestBrowserCreateNote(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Enter the notebook.
+	m = sendKey(t, m, tea.KeyEnter)
+
+	if m.level != 1 {
+		t.Fatalf("expected level 1, got %d", m.level)
+	}
+
+	// Press 'n' to start creating a note.
+	m = sendRune(t, m, 'n')
+
+	if !m.inputMode {
+		t.Fatal("expected inputMode to be true after 'n'")
+	}
+	if !containsStr(m.inputPrompt, "New note in") {
+		t.Errorf("expected prompt to contain 'New note in', got %q", m.inputPrompt)
+	}
+
+	// Type note name.
+	for _, r := range "newnote" {
+		m = sendRune(t, m, r)
+	}
+
+	if m.inputValue != "newnote" {
+		t.Errorf("expected inputValue 'newnote', got %q", m.inputValue)
+	}
+
+	// Press Enter to submit.
+	m = sendKey(t, m, tea.KeyEnter)
+
+	if m.inputMode {
+		t.Error("expected inputMode to be false after Enter")
+	}
+
+	// The note should appear in the reloaded list.
+	found := false
+	for _, n := range m.notes {
+		if n.Name == "newnote" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'newnote' in notes list, got %v", m.notes)
+	}
+}
+
+func TestBrowserCreateCancel(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+	initialCount := len(m.notebooks)
+
+	// Press 'n' to start creating, type something, then cancel.
+	m = sendRune(t, m, 'n')
+	m = sendRune(t, m, 'x')
+	m = sendRune(t, m, 'y')
+
+	if m.inputValue != "xy" {
+		t.Errorf("expected inputValue 'xy', got %q", m.inputValue)
+	}
+
+	// Press Esc to cancel.
+	m = sendKey(t, m, tea.KeyEsc)
+
+	if m.inputMode {
+		t.Error("expected inputMode to be false after Esc")
+	}
+	if m.inputValue != "" {
+		t.Errorf("expected empty inputValue after Esc, got %q", m.inputValue)
+	}
+
+	// No new notebook should have been created.
+	names, err := s.ListNotebooks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(names) != initialCount {
+		t.Errorf("expected %d notebooks (unchanged), got %d", initialCount, len(names))
+	}
+}
+
+func TestBrowserCreateEmptyName(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Press 'n' to start creating.
+	m = sendRune(t, m, 'n')
+
+	// Press Enter immediately with no input.
+	m = sendKey(t, m, tea.KeyEnter)
+
+	if !m.inputMode {
+		t.Error("expected inputMode to stay true on empty submit")
+	}
+	if m.inputErr != "Name can't be empty" {
+		t.Errorf("expected error 'Name can't be empty', got %q", m.inputErr)
+	}
+
+	// Error should appear in the view.
+	view := m.View()
+	if !containsStr(view, "Name can't be empty") {
+		t.Errorf("expected error in view, got:\n%s", view)
+	}
+}
+
+func TestBrowserInputModeKeysDoNotTriggerCommands(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Press 'n' to enter input mode.
+	m = sendRune(t, m, 'n')
+
+	if !m.inputMode {
+		t.Fatal("expected inputMode to be true")
+	}
+
+	// Type characters that would otherwise trigger commands.
+	m = sendRune(t, m, 'q') // would quit
+	m = sendRune(t, m, 'd') // might trigger delete
+	m = sendRune(t, m, '/') // would trigger filter
+
+	if m.quitting {
+		t.Error("'q' should not quit in input mode")
+	}
+	if m.filtering {
+		t.Error("'/' should not activate filter in input mode")
+	}
+	if m.inputValue != "qd/" {
+		t.Errorf("expected inputValue 'qd/', got %q", m.inputValue)
+	}
+}
 
 func containsStr(s, substr string) bool {
 	return len(s) > 0 && len(substr) > 0 && contains(s, substr)


### PR DESCRIPTION
## Summary

- Add input mode to TUI browser with modal state management
- `n` creates notebooks (L0) or notes (L1) via inline text input
- Letter keys in input mode type characters, not trigger commands
- Esc cancels, Enter submits with empty-name validation
- `reloadMsg` pattern for refreshing lists after mutations

Closes #51

## Test plan

- [x] `n` at L0 creates notebook, appears in list
- [x] `n` at L1 creates note, appears in list
- [x] Esc cancels without creating
- [x] Enter on empty name shows error, keeps input open
- [x] `q`, `d`, `/` in input mode type characters, don't trigger commands
- [x] `go test ./...` — 281 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)