### PR TITLE
feat: TUI delete with type-to-confirm

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -45,6 +45,15 @@ type Model struct {
 	quitting    bool
 	selected    *Selection // set when user picks a note to edit
 	err         error
+
+	// Input mode fields (used by delete type-to-confirm).
+	inputMode   bool
+	inputPrompt string
+	inputValue  string
+	inputAction func(typed string) tea.Cmd
+
+	// Temporary status message shown in the status bar.
+	statusText string
 }
 
 // notebookItem holds pre-fetched metadata for a notebook.
@@ -129,6 +138,12 @@ func (m Model) loadNotes(book string) tea.Cmd {
 
 type errMsg struct{ err error }
 
+// reloadMsg triggers a reload of the current list after a mutation.
+type reloadMsg struct{}
+
+// statusMsg carries a temporary status message for the status bar.
+type statusMsg struct{ text string }
+
 // Update implements tea.Model.
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
@@ -148,6 +163,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.resetFilter()
 		return m, nil
 
+	case reloadMsg:
+		if m.level == 0 {
+			return m, m.loadNotebooks()
+		}
+		return m, m.loadNotes(m.currentBook)
+
+	case statusMsg:
+		m.statusText = msg.text
+		return m, nil
+
 	case errMsg:
 		m.err = msg.err
 		return m, nil
@@ -160,6 +185,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Clear any lingering status text on next keypress.
+	m.statusText = ""
+
 	// Global quit keys.
 	switch msg.Type {
 	case tea.KeyCtrlC:
@@ -180,6 +208,11 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 		return m, nil
+	}
+
+	// When in input mode, delegate to input handler.
+	if m.inputMode {
+		return m.handleInputKey(msg)
 	}
 
 	// When filtering, handle text input first.
@@ -225,6 +258,9 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filter = ""
 			m.applyFilter()
 			return m, nil
+		}
+		if s == "d" {
+			return m.startDelete()
 		}
 		return m, nil
 	}
@@ -273,6 +309,92 @@ func (m Model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	return m, nil
+}
+
+func (m Model) handleInputKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEsc:
+		m.inputMode = false
+		m.inputPrompt = ""
+		m.inputValue = ""
+		m.inputAction = nil
+		return m, nil
+
+	case tea.KeyEnter:
+		action := m.inputAction
+		value := m.inputValue
+		m.inputMode = false
+		m.inputPrompt = ""
+		m.inputValue = ""
+		m.inputAction = nil
+		if action != nil {
+			return m, action(value)
+		}
+		return m, nil
+
+	case tea.KeyBackspace:
+		if len(m.inputValue) > 0 {
+			m.inputValue = m.inputValue[:len(m.inputValue)-1]
+		}
+		return m, nil
+
+	case tea.KeyRunes:
+		m.inputValue += string(msg.Runes)
+		return m, nil
+	}
+
+	return m, nil
+}
+
+func (m Model) startDelete() (tea.Model, tea.Cmd) {
+	if m.level == 0 {
+		// Delete notebook.
+		if len(m.filtered) == 0 {
+			return m, nil
+		}
+		idx := m.filtered[m.cursor]
+		name := m.notebooks[idx].name
+		m.inputMode = true
+		m.inputPrompt = fmt.Sprintf("Delete %q? Type the name to confirm:", name)
+		m.inputValue = ""
+		m.inputAction = func(typed string) tea.Cmd {
+			if typed != name {
+				return func() tea.Msg {
+					return statusMsg{"Name doesn't match \u2014 cancelled"}
+				}
+			}
+			return func() tea.Msg {
+				if err := m.store.DeleteNotebook(name); err != nil {
+					return errMsg{err}
+				}
+				return reloadMsg{}
+			}
+		}
+	} else {
+		// Delete note.
+		if len(m.filtered) == 0 {
+			return m, nil
+		}
+		idx := m.filtered[m.cursor]
+		name := m.notes[idx].Name
+		m.inputMode = true
+		m.inputPrompt = fmt.Sprintf("Delete %q from %s? Type the name to confirm:", name, m.currentBook)
+		m.inputValue = ""
+		m.inputAction = func(typed string) tea.Cmd {
+			if typed != name {
+				return func() tea.Msg {
+					return statusMsg{"Name doesn't match \u2014 cancelled"}
+				}
+			}
+			return func() tea.Msg {
+				if err := m.store.DeleteNote(m.currentBook, name); err != nil {
+					return errMsg{err}
+				}
+				return reloadMsg{}
+			}
+		}
+	}
 	return m, nil
 }
 
@@ -650,6 +772,14 @@ func (m Model) renderEmptyNotes() string {
 
 func (m Model) renderStatusBar() string {
 	dim := lipgloss.NewStyle().Faint(true)
+
+	if m.inputMode {
+		return dim.Render(fmt.Sprintf("  %s %s_", m.inputPrompt, m.inputValue))
+	}
+
+	if m.statusText != "" {
+		return dim.Render(fmt.Sprintf("  %s", m.statusText))
+	}
 
 	if m.filtering {
 		return dim.Render(fmt.Sprintf("  Filter: %s_ \u00B7 Esc clear \u00B7 Enter select", m.filter))

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -433,6 +433,226 @@ func TestBrowserHelpEscDismisses(t *testing.T) {
 	}
 }
 
+// sendString types a sequence of runes into the model, processing commands after each.
+func sendString(t *testing.T, m Model, s string) Model {
+	t.Helper()
+	for _, r := range s {
+		m = sendRune(t, m, r)
+	}
+	return m
+}
+
+func TestBrowserDeleteNotebook(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work":     {"todo"},
+		"personal": {"journal"},
+	})
+
+	m := initModel(t, s)
+
+	// Find which notebook is at cursor 0.
+	if len(m.filtered) == 0 {
+		t.Fatal("expected notebooks in filtered list")
+	}
+	idx := m.filtered[m.cursor]
+	name := m.notebooks[idx].name
+
+	// Press 'd' to start delete.
+	m = sendRune(t, m, 'd')
+
+	if !m.inputMode {
+		t.Fatal("expected inputMode to be true after pressing 'd'")
+	}
+
+	// Type the correct name.
+	m = sendString(t, m, name)
+
+	// Press Enter to confirm.
+	m = sendKey(t, m, tea.KeyEnter)
+
+	// The notebook should be deleted from the store.
+	notebooks, err := s.ListNotebooks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, nb := range notebooks {
+		if nb == name {
+			t.Errorf("notebook %q should have been deleted", name)
+		}
+	}
+
+	// Should NOT be in input mode anymore.
+	if m.inputMode {
+		t.Error("expected inputMode to be false after confirming delete")
+	}
+}
+
+func TestBrowserDeleteNote(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"meeting-notes", "todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Enter the notebook.
+	m = sendKey(t, m, tea.KeyEnter)
+	if m.level != 1 {
+		t.Fatalf("expected level 1, got %d", m.level)
+	}
+
+	// Find which note is at cursor 0.
+	if len(m.filtered) == 0 {
+		t.Fatal("expected notes in filtered list")
+	}
+	idx := m.filtered[m.cursor]
+	name := m.notes[idx].Name
+
+	// Press 'd' to start delete.
+	m = sendRune(t, m, 'd')
+
+	if !m.inputMode {
+		t.Fatal("expected inputMode to be true after pressing 'd'")
+	}
+
+	// Type the correct note name.
+	m = sendString(t, m, name)
+
+	// Press Enter to confirm.
+	m = sendKey(t, m, tea.KeyEnter)
+
+	// The note should be deleted from the store.
+	notes, err := s.ListNotes(m.currentBook)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range notes {
+		if n.Name == name {
+			t.Errorf("note %q should have been deleted", name)
+		}
+	}
+
+	if m.inputMode {
+		t.Error("expected inputMode to be false after confirming delete")
+	}
+}
+
+func TestBrowserDeleteWrongName(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Press 'd' to start delete.
+	m = sendRune(t, m, 'd')
+
+	if !m.inputMode {
+		t.Fatal("expected inputMode to be true after pressing 'd'")
+	}
+
+	// Type the wrong name.
+	m = sendString(t, m, "wrong-name")
+
+	// Press Enter.
+	m = sendKey(t, m, tea.KeyEnter)
+
+	// The notebook should NOT have been deleted.
+	notebooks, err := s.ListNotebooks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(notebooks) != 1 {
+		t.Errorf("expected 1 notebook (not deleted), got %d", len(notebooks))
+	}
+
+	// A status message should be set.
+	if m.statusText == "" {
+		t.Error("expected a status message after wrong name")
+	}
+	if !containsStr(m.statusText, "match") {
+		t.Errorf("expected status to mention 'match', got %q", m.statusText)
+	}
+
+	// Should NOT be in input mode.
+	if m.inputMode {
+		t.Error("expected inputMode to be false after wrong name")
+	}
+}
+
+func TestBrowserDeleteCancel(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Press 'd' to start delete.
+	m = sendRune(t, m, 'd')
+
+	if !m.inputMode {
+		t.Fatal("expected inputMode to be true after pressing 'd'")
+	}
+
+	// Press Esc to cancel.
+	m = sendKey(t, m, tea.KeyEsc)
+
+	// The notebook should NOT have been deleted.
+	notebooks, err := s.ListNotebooks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(notebooks) != 1 {
+		t.Errorf("expected 1 notebook (not deleted), got %d", len(notebooks))
+	}
+
+	// Should NOT be in input mode.
+	if m.inputMode {
+		t.Error("expected inputMode to be false after Esc")
+	}
+}
+
+func TestBrowserDeleteEmptyList(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{})
+
+	m := initModel(t, s)
+
+	// Press 'd' on empty list should do nothing.
+	m = sendRune(t, m, 'd')
+
+	if m.inputMode {
+		t.Error("expected inputMode to be false when list is empty")
+	}
+}
+
+func TestBrowserDeleteCursorAdjust(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"alpha": {"a"},
+		"bravo": {"b"},
+	})
+
+	m := initModel(t, s)
+
+	// Move cursor to last item.
+	m = sendKey(t, m, tea.KeyDown)
+	if m.cursor != 1 {
+		t.Fatalf("expected cursor at 1, got %d", m.cursor)
+	}
+
+	// Get the name at cursor position.
+	idx := m.filtered[m.cursor]
+	name := m.notebooks[idx].name
+
+	// Delete it.
+	m = sendRune(t, m, 'd')
+	m = sendString(t, m, name)
+	m = sendKey(t, m, tea.KeyEnter)
+
+	// After reload, cursor should be clamped (only 1 item left).
+	if m.cursor >= len(m.filtered) {
+		t.Errorf("cursor %d is out of bounds for %d items", m.cursor, len(m.filtered))
+	}
+}
+
 func containsStr(s, substr string) bool {
 	return len(s) > 0 && len(substr) > 0 && contains(s, substr)
 }


### PR DESCRIPTION
## Summary

- `d` deletes selected notebook (L0) or note (L1) with type-to-confirm
- Must type exact name to confirm — wrong name cancels with status message
- Adds `statusMsg` pattern for temporary status bar feedback
- Cursor auto-adjusts after deletion

Closes #52

## Test plan

- [x] `d` + correct name deletes notebook
- [x] `d` + correct name deletes note
- [x] Wrong name cancels, shows status message
- [x] Esc cancels without deleting
- [x] Empty list — `d` is a no-op
- [x] Cursor adjusts after deleting last item
- [x] `go test ./...` — 284 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)