### PR TITLE
feat: TUI rename notebooks and notes

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -262,6 +262,9 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if s == "d" {
 			return m.startDelete()
 		}
+		if s == "r" {
+			return m.startRename()
+		}
 		return m, nil
 	}
 
@@ -389,6 +392,51 @@ func (m Model) startDelete() (tea.Model, tea.Cmd) {
 			}
 			return func() tea.Msg {
 				if err := m.store.DeleteNote(m.currentBook, name); err != nil {
+					return errMsg{err}
+				}
+				return reloadMsg{}
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m Model) startRename() (tea.Model, tea.Cmd) {
+	if m.level == 0 {
+		if len(m.filtered) == 0 {
+			return m, nil
+		}
+		idx := m.filtered[m.cursor]
+		oldName := m.notebooks[idx].name
+		m.inputMode = true
+		m.inputPrompt = "Rename notebook:"
+		m.inputValue = oldName
+		m.inputAction = func(newName string) tea.Cmd {
+			if newName == oldName {
+				return func() tea.Msg { return statusMsg{"No change"} }
+			}
+			return func() tea.Msg {
+				if err := m.store.RenameNotebook(oldName, newName); err != nil {
+					return errMsg{err}
+				}
+				return reloadMsg{}
+			}
+		}
+	} else {
+		if len(m.filtered) == 0 {
+			return m, nil
+		}
+		idx := m.filtered[m.cursor]
+		oldName := m.notes[idx].Name
+		m.inputMode = true
+		m.inputPrompt = fmt.Sprintf("Rename note in %s:", m.currentBook)
+		m.inputValue = oldName
+		m.inputAction = func(newName string) tea.Cmd {
+			if newName == oldName {
+				return func() tea.Msg { return statusMsg{"No change"} }
+			}
+			return func() tea.Msg {
+				if err := m.store.RenameNote(m.currentBook, oldName, newName); err != nil {
 					return errMsg{err}
 				}
 				return reloadMsg{}

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -653,6 +653,195 @@ func TestBrowserDeleteCursorAdjust(t *testing.T) {
 	}
 }
 
+func TestBrowserRenameNotebook(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"old-name": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Find which notebook is at cursor 0.
+	if len(m.filtered) == 0 {
+		t.Fatal("expected notebooks in filtered list")
+	}
+	idx := m.filtered[m.cursor]
+	oldName := m.notebooks[idx].name
+
+	// Press 'r' to start rename.
+	m = sendRune(t, m, 'r')
+
+	if !m.inputMode {
+		t.Fatal("expected inputMode to be true after pressing 'r'")
+	}
+
+	// Input should be pre-populated with the current name.
+	if m.inputValue != oldName {
+		t.Errorf("expected inputValue %q, got %q", oldName, m.inputValue)
+	}
+
+	// Clear the input and type new name.
+	for range m.inputValue {
+		m = sendKey(t, m, tea.KeyBackspace)
+	}
+	m = sendString(t, m, "new-name")
+
+	// Press Enter to confirm.
+	m = sendKey(t, m, tea.KeyEnter)
+
+	// The old notebook should be gone and new one should exist.
+	notebooks, err := s.ListNotebooks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := map[string]bool{}
+	for _, nb := range notebooks {
+		found[nb] = true
+	}
+	if found[oldName] {
+		t.Errorf("old notebook %q should have been renamed", oldName)
+	}
+	if !found["new-name"] {
+		t.Error("new notebook 'new-name' should exist after rename")
+	}
+
+	if m.inputMode {
+		t.Error("expected inputMode to be false after confirming rename")
+	}
+}
+
+func TestBrowserRenameNote(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"old-note", "other"},
+	})
+
+	m := initModel(t, s)
+
+	// Enter the notebook.
+	m = sendKey(t, m, tea.KeyEnter)
+	if m.level != 1 {
+		t.Fatalf("expected level 1, got %d", m.level)
+	}
+
+	// Find which note is at cursor 0.
+	if len(m.filtered) == 0 {
+		t.Fatal("expected notes in filtered list")
+	}
+	idx := m.filtered[m.cursor]
+	oldName := m.notes[idx].Name
+
+	// Press 'r' to start rename.
+	m = sendRune(t, m, 'r')
+
+	if !m.inputMode {
+		t.Fatal("expected inputMode to be true after pressing 'r'")
+	}
+
+	// Input should be pre-populated with the current name.
+	if m.inputValue != oldName {
+		t.Errorf("expected inputValue %q, got %q", oldName, m.inputValue)
+	}
+
+	// Clear the input and type new name.
+	for range m.inputValue {
+		m = sendKey(t, m, tea.KeyBackspace)
+	}
+	m = sendString(t, m, "new-note")
+
+	// Press Enter to confirm.
+	m = sendKey(t, m, tea.KeyEnter)
+
+	// The old note should be gone and new one should exist.
+	notes, err := s.ListNotes(m.currentBook)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := map[string]bool{}
+	for _, n := range notes {
+		found[n.Name] = true
+	}
+	if found[oldName] {
+		t.Errorf("old note %q should have been renamed", oldName)
+	}
+	if !found["new-note"] {
+		t.Error("new note 'new-note' should exist after rename")
+	}
+
+	if m.inputMode {
+		t.Error("expected inputMode to be false after confirming rename")
+	}
+}
+
+func TestBrowserRenameCancel(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Press 'r' to start rename.
+	m = sendRune(t, m, 'r')
+
+	if !m.inputMode {
+		t.Fatal("expected inputMode to be true after pressing 'r'")
+	}
+
+	// Press Esc to cancel.
+	m = sendKey(t, m, tea.KeyEsc)
+
+	// The notebook should NOT have been renamed.
+	notebooks, err := s.ListNotebooks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(notebooks) != 1 || notebooks[0] != "work" {
+		t.Errorf("expected notebook 'work' unchanged, got %v", notebooks)
+	}
+
+	if m.inputMode {
+		t.Error("expected inputMode to be false after Esc")
+	}
+}
+
+func TestBrowserRenameSameName(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Find which notebook is at cursor 0.
+	idx := m.filtered[m.cursor]
+	name := m.notebooks[idx].name
+
+	// Press 'r' to start rename.
+	m = sendRune(t, m, 'r')
+
+	if !m.inputMode {
+		t.Fatal("expected inputMode to be true after pressing 'r'")
+	}
+
+	// Input is pre-populated with current name. Press Enter without changing.
+	m = sendKey(t, m, tea.KeyEnter)
+
+	// Should show "No change" status.
+	if m.statusText != "No change" {
+		t.Errorf("expected status 'No change', got %q", m.statusText)
+	}
+
+	// Notebook should still exist.
+	notebooks, err := s.ListNotebooks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(notebooks) != 1 || notebooks[0] != name {
+		t.Errorf("expected notebook %q unchanged, got %v", name, notebooks)
+	}
+
+	if m.inputMode {
+		t.Error("expected inputMode to be false")
+	}
+}
+
 func containsStr(s, substr string) bool {
 	return len(s) > 0 && len(substr) > 0 && contains(s, substr)
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -267,6 +267,49 @@ func (s *Store) DeleteNotebook(name string) error {
 	return nil
 }
 
+// RenameNotebook renames a notebook directory.
+func (s *Store) RenameNotebook(oldName, newName string) error {
+	newName = strings.TrimSpace(newName)
+	if err := validName(oldName); err != nil {
+		return err
+	}
+	if err := validName(newName); err != nil {
+		return err
+	}
+	oldDir := s.notebookPath(oldName)
+	newDir := s.notebookPath(newName)
+	if _, err := os.Stat(oldDir); os.IsNotExist(err) {
+		return fmt.Errorf("notebook %q does not exist", oldName)
+	}
+	if _, err := os.Stat(newDir); err == nil {
+		return fmt.Errorf("notebook %q already exists", newName)
+	}
+	return os.Rename(oldDir, newDir)
+}
+
+// RenameNote renames a note file within a notebook.
+func (s *Store) RenameNote(book, oldName, newName string) error {
+	newName = strings.TrimSpace(newName)
+	if err := validName(book); err != nil {
+		return err
+	}
+	if err := validName(oldName); err != nil {
+		return err
+	}
+	if err := validName(newName); err != nil {
+		return err
+	}
+	oldPath := s.notePath(book, oldName)
+	newPath := s.notePath(book, newName)
+	if _, err := os.Stat(oldPath); os.IsNotExist(err) {
+		return fmt.Errorf("note %q does not exist in %q", oldName, book)
+	}
+	if _, err := os.Stat(newPath); err == nil {
+		return fmt.Errorf("note %q already exists in %q", newName, book)
+	}
+	return os.Rename(oldPath, newPath)
+}
+
 // UpdateNote overwrites the content of an existing note.
 func (s *Store) UpdateNote(notebook, name, content string) error {
 	if err := validName(notebook); err != nil {

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -571,3 +571,112 @@ func TestSearchNotesNoResults(t *testing.T) {
 		t.Fatalf("got %d results, want 0", len(results))
 	}
 }
+
+// --- Rename tests ---
+
+func TestRenameNotebook(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	if err := store.CreateNotebook("old-name"); err != nil {
+		t.Fatalf("CreateNotebook: %v", err)
+	}
+
+	if err := store.RenameNotebook("old-name", "new-name"); err != nil {
+		t.Fatalf("RenameNotebook: %v", err)
+	}
+
+	// Old dir should be gone.
+	if _, err := os.Stat(filepath.Join(store.Root, "old-name")); !os.IsNotExist(err) {
+		t.Error("old notebook dir should not exist after rename")
+	}
+
+	// New dir should exist.
+	info, err := os.Stat(filepath.Join(store.Root, "new-name"))
+	if err != nil {
+		t.Fatalf("new notebook dir missing: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("new notebook path should be a directory")
+	}
+}
+
+func TestRenameNotebookNotFound(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	err := store.RenameNotebook("nonexistent", "new-name")
+	if err == nil {
+		t.Fatal("expected error renaming nonexistent notebook, got nil")
+	}
+}
+
+func TestRenameNotebookDuplicate(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	if err := store.CreateNotebook("alpha"); err != nil {
+		t.Fatalf("CreateNotebook: %v", err)
+	}
+	if err := store.CreateNotebook("bravo"); err != nil {
+		t.Fatalf("CreateNotebook: %v", err)
+	}
+
+	err := store.RenameNotebook("alpha", "bravo")
+	if err == nil {
+		t.Fatal("expected error renaming to existing notebook name, got nil")
+	}
+}
+
+func TestRenameNote(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	content := "# Hello\nSome content here."
+	if err := store.CreateNote("nb", "old-note", content); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	if err := store.RenameNote("nb", "old-note", "new-note"); err != nil {
+		t.Fatalf("RenameNote: %v", err)
+	}
+
+	// Old file should be gone.
+	if _, err := os.Stat(filepath.Join(store.Root, "nb", "old-note.md")); !os.IsNotExist(err) {
+		t.Error("old note file should not exist after rename")
+	}
+
+	// New file should exist with same content.
+	note, err := store.GetNote("nb", "new-note")
+	if err != nil {
+		t.Fatalf("GetNote after rename: %v", err)
+	}
+	if note.Content != content {
+		t.Errorf("Content = %q, want %q", note.Content, content)
+	}
+}
+
+func TestRenameNoteNotFound(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	if err := store.CreateNotebook("nb"); err != nil {
+		t.Fatalf("CreateNotebook: %v", err)
+	}
+
+	err := store.RenameNote("nb", "nonexistent", "new-name")
+	if err == nil {
+		t.Fatal("expected error renaming nonexistent note, got nil")
+	}
+}
+
+func TestRenameNoteDuplicate(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	if err := store.CreateNote("nb", "alpha", "a"); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+	if err := store.CreateNote("nb", "bravo", "b"); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	err := store.RenameNote("nb", "alpha", "bravo")
+	if err == nil {
+		t.Fatal("expected error renaming to existing note name, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `RenameNotebook`/`RenameNote` to storage layer (atomic `os.Rename`)
- `r` in TUI browser opens input pre-populated with current name
- Same-name submission shows "No change" status
- Full validation: empty name, not-found, duplicate name

Closes #53

## Test plan

- [x] Storage: rename notebook success, not-found, duplicate
- [x] Storage: rename note success, not-found, duplicate
- [x] TUI: `r` at L0 renames notebook
- [x] TUI: `r` at L1 renames note
- [x] TUI: Esc cancels rename
- [x] TUI: same name shows "No change"
- [x] `go test ./...` — 294 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)