### PR TITLE
fix: TUI browser returns to L1 after editing (Closes #64)

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -12,12 +12,14 @@ import (
 // a note, the browser quits, the editor launches, and the browser
 // re-enters after the editor exits.
 func runBrowser() error {
+	var lastBook string
 	for {
 		m := browser.New(browser.Config{
 			Store: store,
 			EditNote: func(book, note string) error {
 				return editNote(nil, book, note)
 			},
+			InitialBook: lastBook,
 		})
 
 		p := tea.NewProgram(m, tea.WithAltScreen())
@@ -34,6 +36,7 @@ func runBrowser() error {
 		}
 
 		// Launch editor for the selected note.
+		lastBook = sel.Book
 		if err := editNote(os.Stderr, sel.Book, sel.Note); err != nil {
 			return fmt.Errorf("edit note: %w", err)
 		}

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -19,8 +19,9 @@ type EditFunc func(book, note string) error
 
 // Config holds the dependencies needed by the browser.
 type Config struct {
-	Store    *storage.Store
-	EditNote EditFunc
+	Store       *storage.Store
+	EditNote    EditFunc
+	InitialBook string // if set, start at L1 in this notebook
 }
 
 // Selection represents a note the user chose to open.
@@ -76,10 +77,15 @@ type notebookItem struct {
 
 // New creates a new browser model.
 func New(cfg Config) Model {
-	return Model{
+	m := Model{
 		store:    cfg.Store,
 		editNote: cfg.EditNote,
 	}
+	if cfg.InitialBook != "" {
+		m.level = 1
+		m.currentBook = cfg.InitialBook
+	}
+	return m
 }
 
 // Selected returns the note selection if the user chose one, or nil.
@@ -99,6 +105,9 @@ type notesLoadedMsg struct {
 
 // Init implements tea.Model.
 func (m Model) Init() tea.Cmd {
+	if m.level == 1 {
+		return m.loadNotes(m.currentBook)
+	}
 	return m.loadNotebooks()
 }
 

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -1032,6 +1032,43 @@ func TestBrowserRenameSameName(t *testing.T) {
 	}
 }
 
+func TestBrowserInitialBook(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo", "meeting-notes"},
+	})
+
+	m := New(Config{
+		Store:       s,
+		EditNote:    func(book, note string) error { return nil },
+		InitialBook: "work",
+	})
+
+	cmd := m.Init()
+	if cmd != nil {
+		msg := cmd()
+		updated, _ := m.Update(msg)
+		m = updated.(Model)
+	}
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	if m.level != 1 {
+		t.Errorf("expected level 1 with InitialBook, got %d", m.level)
+	}
+	if m.currentBook != "work" {
+		t.Errorf("expected currentBook 'work', got %q", m.currentBook)
+	}
+	if len(m.notes) != 2 {
+		t.Errorf("expected 2 notes loaded, got %d", len(m.notes))
+	}
+
+	// Pressing Esc should go back to L0.
+	m = sendKey(t, m, tea.KeyEsc)
+	if m.level != 0 {
+		t.Errorf("expected level 0 after Esc, got %d", m.level)
+	}
+}
+
 func TestBrowserViewAtL0IsNoop(t *testing.T) {
 	s := setupTestStore(t, map[string][]string{
 		"work": {"todo"},


### PR DESCRIPTION
## Summary

- Add `InitialBook` field to `browser.Config` — when set, browser starts at L1 in that notebook
- `runBrowser()` loop passes the last-edited notebook back so re-entry lands on the notes list
- Browser test for InitialBook behavior

## Test plan

- [x] `go test ./...` — 304 tests pass
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)