### PR TITLE
fix: Ctrl+C prompts to save unsaved changes (Closes #65)

### DIFF
--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -489,6 +489,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 
 		case "ctrl+c":
+			if m.modified() {
+				m.quitPrompt = true
+				m.status = "Save before quitting? [Y/n/Esc]"
+				m.statusStyle = statusWarning
+				return m, nil
+			}
 			m.quitting = true
 			return m, tea.Quit
 		}

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -182,7 +182,7 @@ func TestQuitPromptCancel(t *testing.T) {
 	}
 }
 
-func TestCtrlCForcesQuit(t *testing.T) {
+func TestCtrlCPromptsWhenModified(t *testing.T) {
 	m := New(Config{Title: "test", Content: "hello"})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = updated.(Model)
@@ -191,7 +191,27 @@ func TestCtrlCForcesQuit(t *testing.T) {
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
 	m = updated.(Model)
 
-	// Ctrl+C should quit without warning.
+	// Ctrl+C with unsaved changes should prompt, not quit.
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	m = updated.(Model)
+
+	if cmd != nil {
+		t.Fatal("Ctrl+C with unsaved changes should not return a command")
+	}
+	if !m.quitPrompt {
+		t.Fatal("expected quitPrompt to be true")
+	}
+	if m.quitting {
+		t.Fatal("should not be quitting yet")
+	}
+}
+
+func TestCtrlCQuitsWhenClean(t *testing.T) {
+	m := New(Config{Title: "test", Content: "hello"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Ctrl+C with no changes should quit immediately.
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
 	m = updated.(Model)
 


### PR DESCRIPTION
## Summary

- Ctrl+C now checks `modified()` and shows save prompt when there are unsaved changes (same as Ctrl+Q)
- Ctrl+C still quits immediately when buffer is clean
- Updated tests to verify both behaviors

## Test plan

- [x] `go test ./...` — 305 tests pass
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)