### PR TITLE
feat: n keybinding for create + fix empty state hints (Closes #66, #67)

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -362,6 +362,9 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if s == "r" {
 			return m.startRename()
 		}
+		if s == "n" {
+			return m.startCreate()
+		}
 		if s == "v" && m.level == 1 {
 			return m.startView()
 		}
@@ -550,6 +553,45 @@ func (m Model) startRename() (tea.Model, tea.Cmd) {
 			}
 			return func() tea.Msg {
 				if err := m.store.RenameNote(m.currentBook, name, typed); err != nil {
+					return statusMsg{err.Error()}
+				}
+				return reloadAndSelectMsg{typed}
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m Model) startCreate() (tea.Model, tea.Cmd) {
+	if m.level == 0 {
+		m.inputMode = true
+		m.inputPrompt = "New notebook:"
+		m.inputValue = ""
+		m.inputAction = func(typed string) tea.Cmd {
+			if typed == "" {
+				return func() tea.Msg {
+					return statusMsg{"Name must not be empty"}
+				}
+			}
+			return func() tea.Msg {
+				if err := m.store.CreateNotebook(typed); err != nil {
+					return statusMsg{err.Error()}
+				}
+				return reloadAndSelectMsg{typed}
+			}
+		}
+	} else {
+		m.inputMode = true
+		m.inputPrompt = fmt.Sprintf("New note in %s:", m.currentBook)
+		m.inputValue = ""
+		m.inputAction = func(typed string) tea.Cmd {
+			if typed == "" {
+				return func() tea.Msg {
+					return statusMsg{"Name must not be empty"}
+				}
+			}
+			return func() tea.Msg {
+				if err := m.store.CreateNote(m.currentBook, typed, ""); err != nil {
 					return statusMsg{err.Error()}
 				}
 				return reloadAndSelectMsg{typed}
@@ -1015,12 +1057,31 @@ func (m Model) nameColWidth(level int) int {
 }
 
 func (m Model) renderEmptyNotebooks() string {
-	return "  No notebooks yet.\n\n  Create one with: notebook new \"My Book\"\n"
+	w := m.width
+	if w <= 0 {
+		w = 80
+	}
+	h := m.height - 4
+	if h < 1 {
+		h = 1
+	}
+	dim := lipgloss.NewStyle().Faint(true)
+	msg := "No notebooks yet.\n\nPress n to create one."
+	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, dim.Render(msg))
 }
 
 func (m Model) renderEmptyNotes() string {
-	return fmt.Sprintf("  No notes in %s.\n\n  Create one with: notebook %s new \"My Note\"\n",
-		m.currentBook, m.currentBook)
+	w := m.width
+	if w <= 0 {
+		w = 80
+	}
+	h := m.height - 4
+	if h < 1 {
+		h = 1
+	}
+	dim := lipgloss.NewStyle().Faint(true)
+	msg := fmt.Sprintf("No notes in %s.\n\nPress n to create one.", m.currentBook)
+	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, dim.Render(msg))
 }
 
 func (m Model) renderStatusBar() string {

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -228,8 +228,8 @@ func TestBrowserEmptyState(t *testing.T) {
 	if !containsStr(view, "No notebooks yet") {
 		t.Errorf("expected empty state message, got:\n%s", view)
 	}
-	if !containsStr(view, "notebook new") {
-		t.Errorf("expected create hint, got:\n%s", view)
+	if !containsStr(view, "Press n") {
+		t.Errorf("expected 'Press n' hint, got:\n%s", view)
 	}
 }
 
@@ -254,6 +254,9 @@ func TestBrowserEmptyNotebook(t *testing.T) {
 	view := m.View()
 	if !containsStr(view, "No notes in") {
 		t.Errorf("expected empty notebook message, got:\n%s", view)
+	}
+	if !containsStr(view, "Press n") {
+		t.Errorf("expected 'Press n' hint, got:\n%s", view)
 	}
 }
 
@@ -1029,6 +1032,134 @@ func TestBrowserRenameSameName(t *testing.T) {
 	}
 	if len(notebooks) != 1 {
 		t.Errorf("expected 1 notebook, got %d", len(notebooks))
+	}
+}
+
+func TestBrowserCreateNotebook(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{})
+
+	m := initModel(t, s)
+
+	// Press 'n' to start create.
+	m = sendRune(t, m, 'n')
+
+	if !m.inputMode {
+		t.Fatal("expected inputMode to be true after pressing 'n'")
+	}
+	if m.inputValue != "" {
+		t.Errorf("expected empty inputValue, got %q", m.inputValue)
+	}
+
+	// Type a name and confirm.
+	m = sendString(t, m, "my-book")
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = processAllCmds(t, updated.(Model), cmd)
+
+	// Notebook should exist.
+	notebooks, err := s.ListNotebooks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(notebooks) != 1 || notebooks[0] != "my-book" {
+		t.Errorf("expected [my-book], got %v", notebooks)
+	}
+}
+
+func TestBrowserCreateNote(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {},
+	})
+
+	m := initModel(t, s)
+
+	// Enter the notebook.
+	m = sendKey(t, m, tea.KeyEnter)
+	if m.level != 1 {
+		t.Fatalf("expected level 1, got %d", m.level)
+	}
+
+	// Press 'n' to start create.
+	m = sendRune(t, m, 'n')
+
+	if !m.inputMode {
+		t.Fatal("expected inputMode to be true after pressing 'n'")
+	}
+
+	// Type a name and confirm.
+	m = sendString(t, m, "my-note")
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = processAllCmds(t, updated.(Model), cmd)
+
+	// Note should exist.
+	notes, err := s.ListNotes("work")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(notes) != 1 || notes[0].Name != "my-note" {
+		t.Errorf("expected [my-note], got %v", notes)
+	}
+}
+
+func TestBrowserCreateCancel(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{})
+
+	m := initModel(t, s)
+
+	// Press 'n' then Esc.
+	m = sendRune(t, m, 'n')
+	m = sendKey(t, m, tea.KeyEsc)
+
+	if m.inputMode {
+		t.Error("expected inputMode to be false after Esc")
+	}
+
+	// Nothing should have been created.
+	notebooks, err := s.ListNotebooks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(notebooks) != 0 {
+		t.Errorf("expected 0 notebooks, got %d", len(notebooks))
+	}
+}
+
+func TestBrowserCreateEmptyName(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{})
+
+	m := initModel(t, s)
+
+	// Press 'n' then Enter with empty name.
+	m = sendRune(t, m, 'n')
+	m = sendKey(t, m, tea.KeyEnter)
+
+	if m.statusText == "" {
+		t.Error("expected error status for empty name")
+	}
+	if !containsStr(m.statusText, "empty") {
+		t.Errorf("expected status to mention 'empty', got %q", m.statusText)
+	}
+}
+
+func TestBrowserCreateDuplicate(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Enter the notebook.
+	m = sendKey(t, m, tea.KeyEnter)
+
+	// Try to create a duplicate note.
+	m = sendRune(t, m, 'n')
+	m = sendString(t, m, "todo")
+	m = sendKey(t, m, tea.KeyEnter)
+
+	if m.statusText == "" {
+		t.Error("expected error status for duplicate name")
+	}
+	if !containsStr(m.statusText, "already exists") {
+		t.Errorf("expected status to mention 'already exists', got %q", m.statusText)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Wire `n` keybinding in TUI browser — creates notebooks at L0, notes at L1
- Input validation: empty name rejected, duplicate shows store error
- New items auto-selected after create via `reloadAndSelectMsg`
- Replace empty state CLI command hints (`notebook new "My Book"`) with TUI-appropriate `Press n to create one`
- Center empty state messages in viewport using `lipgloss.Place`
- 5 new browser tests for create operations

## Test plan

- [x] `go test ./...` — 310 tests pass
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)