### PR TITLE
fix: handle space key in TUI input mode

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -448,6 +448,10 @@ func (m Model) handleInputKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case tea.KeySpace:
+		m.inputValue += " "
+		return m, nil
+
 	case tea.KeyRunes:
 		m.inputValue += string(msg.Runes)
 		return m, nil


### PR DESCRIPTION
## Summary

- Add `tea.KeySpace` case to `handleInputKey()` — spaces were silently dropped because Bubble Tea sends them as a separate key type, not `tea.KeyRunes`

## Test plan

- [x] `go test ./...` — 322 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)