### PR TITLE
fix: underline cursor in TUI input mode

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -1119,7 +1119,13 @@ func (m Model) renderStatusBar() string {
 	if m.inputMode {
 		before := m.inputValue[:m.inputCursor]
 		after := m.inputValue[m.inputCursor:]
-		return dim.Render(fmt.Sprintf("  %s %s", m.inputPrompt, before)) + "█" + dim.Render(after)
+		underline := lipgloss.NewStyle().Underline(true)
+		cursorChar := " "
+		if m.inputCursor < len(m.inputValue) {
+			cursorChar = string(m.inputValue[m.inputCursor])
+			after = after[1:]
+		}
+		return dim.Render(fmt.Sprintf("  %s %s", m.inputPrompt, before)) + underline.Render(cursorChar) + dim.Render(after)
 	}
 
 	if m.statusText != "" {


### PR DESCRIPTION
## Summary

- Replace block cursor with underline style on the character at cursor position
- At end of input, underlines a space (no shift)
- No text shifting — cursor overlays existing text

## Test plan

- [x] `go test ./...` — 322 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)