### PR TITLE
fix: show Enter/Esc hints in TUI input mode

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -1125,7 +1125,7 @@ func (m Model) renderStatusBar() string {
 			cursorChar = string(m.inputValue[m.inputCursor])
 			after = after[1:]
 		}
-		return dim.Render(fmt.Sprintf("  %s %s", m.inputPrompt, before)) + underline.Render(cursorChar) + dim.Render(after)
+		return dim.Render(fmt.Sprintf("  %s %s", m.inputPrompt, before)) + underline.Render(cursorChar) + dim.Render(after) + dim.Render(" · Enter confirm · Esc cancel")
 	}
 
 	if m.statusText != "" {


### PR DESCRIPTION
## Summary

- Append "Enter confirm · Esc cancel" hint to the input mode status bar

## Test plan

- [x] `go test ./...` — 322 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)