### PR TITLE
feat: display names with spaces in TUI + inverted block cursor

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -488,10 +488,10 @@ func (m Model) startDelete() (tea.Model, tea.Cmd) {
 		idx := m.filtered[m.cursor]
 		name := m.notebooks[idx].name
 		m.inputMode = true
-		m.inputPrompt = fmt.Sprintf("Delete %q? Type the name to confirm:", name)
+		m.inputPrompt = fmt.Sprintf("Delete %q? Type the name to confirm:", storage.DisplayName(name))
 		m.inputValue = ""
 		m.inputAction = func(typed string) tea.Cmd {
-			if typed != name {
+			if typed != storage.DisplayName(name) {
 				return func() tea.Msg {
 					return statusMsg{"Name doesn't match \u2014 cancelled"}
 				}
@@ -511,10 +511,10 @@ func (m Model) startDelete() (tea.Model, tea.Cmd) {
 		idx := m.filtered[m.cursor]
 		name := m.notes[idx].Name
 		m.inputMode = true
-		m.inputPrompt = fmt.Sprintf("Delete %q from %s? Type the name to confirm:", name, m.currentBook)
+		m.inputPrompt = fmt.Sprintf("Delete %q from %s? Type the name to confirm:", storage.DisplayName(name), storage.DisplayName(m.currentBook))
 		m.inputValue = ""
 		m.inputAction = func(typed string) tea.Cmd {
-			if typed != name {
+			if typed != storage.DisplayName(name) {
 				return func() tea.Msg {
 					return statusMsg{"Name doesn't match \u2014 cancelled"}
 				}
@@ -539,8 +539,8 @@ func (m Model) startRename() (tea.Model, tea.Cmd) {
 		name := m.notebooks[idx].name
 		m.inputMode = true
 		m.inputPrompt = "Rename notebook:"
-		m.inputValue = name
-		m.inputCursor = len(name)
+		m.inputValue = storage.DisplayName(name)
+		m.inputCursor = len(m.inputValue)
 		m.inputAction = func(typed string) tea.Cmd {
 			slug := storage.Slugify(typed)
 			if slug == "" {
@@ -566,8 +566,8 @@ func (m Model) startRename() (tea.Model, tea.Cmd) {
 		name := m.notes[idx].Name
 		m.inputMode = true
 		m.inputPrompt = "Rename note:"
-		m.inputValue = name
-		m.inputCursor = len(name)
+		m.inputValue = storage.DisplayName(name)
+		m.inputCursor = len(m.inputValue)
 		m.inputAction = func(typed string) tea.Cmd {
 			slug := storage.Slugify(typed)
 			if slug == "" {
@@ -610,7 +610,7 @@ func (m Model) startCreate() (tea.Model, tea.Cmd) {
 		}
 	} else {
 		m.inputMode = true
-		m.inputPrompt = fmt.Sprintf("New note in %s:", m.currentBook)
+		m.inputPrompt = fmt.Sprintf("New note in %s:", storage.DisplayName(m.currentBook))
 		m.inputValue = ""
 		m.inputAction = func(typed string) tea.Cmd {
 			slug := storage.Slugify(typed)
@@ -642,7 +642,7 @@ func (m Model) startView() (tea.Model, tea.Cmd) {
 			return errMsg{err}
 		}
 		return viewLoadedMsg{
-			title:   fmt.Sprintf("%s \u203A %s", m.currentBook, note.Name),
+			title:   fmt.Sprintf("%s \u203A %s", storage.DisplayName(m.currentBook), storage.DisplayName(note.Name)),
 			content: n.Content,
 		}
 	}
@@ -662,7 +662,7 @@ func (m Model) copyNote() (tea.Model, tea.Cmd) {
 		if err := clipboard.Copy(n.Content); err != nil {
 			return statusMsg{fmt.Sprintf("Could not copy: %s", err)}
 		}
-		return statusMsg{fmt.Sprintf("Copied %q to clipboard", note.Name)}
+		return statusMsg{fmt.Sprintf("Copied %q to clipboard", storage.DisplayName(note.Name))}
 	}
 }
 
@@ -672,13 +672,13 @@ func (m *Model) applyFilter() {
 
 	if m.level == 0 {
 		for i, nb := range m.notebooks {
-			if query == "" || strings.Contains(strings.ToLower(nb.name), query) {
+			if query == "" || strings.Contains(storage.DisplayName(nb.name), query) {
 				m.filtered = append(m.filtered, i)
 			}
 		}
 	} else {
 		for i, n := range m.notes {
-			if query == "" || strings.Contains(strings.ToLower(n.Name), query) {
+			if query == "" || strings.Contains(storage.DisplayName(n.Name), query) {
 				m.filtered = append(m.filtered, i)
 			}
 		}
@@ -925,7 +925,7 @@ func (m Model) renderBreadcrumb() string {
 	if m.level == 0 {
 		return style.Render("notebook")
 	}
-	return style.Render(fmt.Sprintf("notebook \u203A %s", m.currentBook))
+	return style.Render(fmt.Sprintf("notebook \u203A %s", storage.DisplayName(m.currentBook)))
 }
 
 func (m Model) renderContent(maxLines int) string {
@@ -1018,14 +1018,15 @@ func (m Model) visibleRange(total, maxLines int) []int {
 
 func (m Model) formatNotebookLine(nb notebookItem, selected bool) string {
 	bullet := "  "
-	name := nb.name
+	display := storage.DisplayName(nb.name)
+	name := display
 	countStr := pluralize(nb.noteCount, "note", "notes")
 
 	if selected {
 		bulletStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("6")) // cyan
 		bullet = bulletStyle.Render("\u25CF") + " "
 		nameStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
-		name = nameStyle.Render(nb.name)
+		name = nameStyle.Render(display)
 	}
 
 	return fmt.Sprintf("%s%-*s    %-*s    %s",
@@ -1038,7 +1039,8 @@ func (m Model) formatNotebookLine(nb notebookItem, selected bool) string {
 
 func (m Model) formatNoteLine(n model.Note, selected bool) string {
 	bullet := "  "
-	name := n.Name
+	display := storage.DisplayName(n.Name)
+	name := display
 
 	// Get file size.
 	p := m.store.NotebookDir(m.currentBook) + "/" + n.Name + ".md"
@@ -1053,7 +1055,7 @@ func (m Model) formatNoteLine(n model.Note, selected bool) string {
 		bulletStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
 		bullet = bulletStyle.Render("\u25CF") + " "
 		nameStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
-		name = nameStyle.Render(n.Name)
+		name = nameStyle.Render(display)
 	}
 
 	return fmt.Sprintf("%s%-*s    %-*s    %s",
@@ -1068,14 +1070,14 @@ func (m Model) nameColWidth(level int) int {
 	maxLen := 0
 	if level == 0 {
 		for _, nb := range m.notebooks {
-			if len(nb.name) > maxLen {
-				maxLen = len(nb.name)
+			if dl := len(storage.DisplayName(nb.name)); dl > maxLen {
+				maxLen = dl
 			}
 		}
 	} else {
 		for _, n := range m.notes {
-			if len(n.Name) > maxLen {
-				maxLen = len(n.Name)
+			if dl := len(storage.DisplayName(n.Name)); dl > maxLen {
+				maxLen = dl
 			}
 		}
 	}
@@ -1109,7 +1111,7 @@ func (m Model) renderEmptyNotes() string {
 		h = 1
 	}
 	dim := lipgloss.NewStyle().Faint(true)
-	msg := fmt.Sprintf("No notes in %s.\n\nPress n to create one.", m.currentBook)
+	msg := fmt.Sprintf("No notes in %s.\n\nPress n to create one.", storage.DisplayName(m.currentBook))
 	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, dim.Render(msg))
 }
 
@@ -1119,13 +1121,13 @@ func (m Model) renderStatusBar() string {
 	if m.inputMode {
 		before := m.inputValue[:m.inputCursor]
 		after := m.inputValue[m.inputCursor:]
-		underline := lipgloss.NewStyle().Underline(true)
+		cursor := lipgloss.NewStyle().Reverse(true)
 		cursorChar := " "
 		if m.inputCursor < len(m.inputValue) {
 			cursorChar = string(m.inputValue[m.inputCursor])
 			after = after[1:]
 		}
-		return dim.Render(fmt.Sprintf("  %s %s", m.inputPrompt, before)) + underline.Render(cursorChar) + dim.Render(after) + dim.Render(" · Enter confirm · Esc cancel")
+		return dim.Render(fmt.Sprintf("  %s %s", m.inputPrompt, before)) + cursor.Render(cursorChar) + dim.Render(after) + dim.Render(" · Enter confirm · Esc cancel")
 	}
 
 	if m.statusText != "" {

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -131,8 +131,8 @@ func TestBrowserEnterOpensNotebook(t *testing.T) {
 	}
 
 	view := m.View()
-	if !containsStr(view, "meeting-notes") {
-		t.Errorf("view should contain 'meeting-notes', got:\n%s", view)
+	if !containsStr(view, "meeting notes") {
+		t.Errorf("view should contain 'meeting notes', got:\n%s", view)
 	}
 	if !containsStr(view, "todo") {
 		t.Errorf("view should contain 'todo', got:\n%s", view)
@@ -440,7 +440,11 @@ func TestBrowserHelpEscDismisses(t *testing.T) {
 func sendString(t *testing.T, m Model, s string) Model {
 	t.Helper()
 	for _, r := range s {
-		m = sendRune(t, m, r)
+		if r == ' ' {
+			m = sendKey(t, m, tea.KeySpace)
+		} else {
+			m = sendRune(t, m, r)
+		}
 	}
 	return m
 }
@@ -517,8 +521,8 @@ func TestBrowserDeleteNote(t *testing.T) {
 		t.Fatal("expected inputMode to be true after pressing 'd'")
 	}
 
-	// Type the correct note name.
-	m = sendString(t, m, name)
+	// Type the correct note name (display name with spaces).
+	m = sendString(t, m, storage.DisplayName(name))
 
 	// Press Enter to confirm.
 	m = sendKey(t, m, tea.KeyEnter)
@@ -830,8 +834,8 @@ func TestBrowserRenameNotebook(t *testing.T) {
 	if !m.inputMode {
 		t.Fatal("expected inputMode to be true after pressing 'r'")
 	}
-	if m.inputValue != "old-name" {
-		t.Errorf("expected inputValue pre-populated with 'old-name', got %q", m.inputValue)
+	if m.inputValue != "old name" {
+		t.Errorf("expected inputValue pre-populated with 'old name', got %q", m.inputValue)
 	}
 
 	// Clear the pre-populated value and type a new name.
@@ -897,8 +901,8 @@ func TestBrowserRenameNote(t *testing.T) {
 	if !m.inputMode {
 		t.Fatal("expected inputMode to be true after pressing 'r'")
 	}
-	if m.inputValue != "old-note" {
-		t.Errorf("expected inputValue pre-populated with 'old-note', got %q", m.inputValue)
+	if m.inputValue != "old note" {
+		t.Errorf("expected inputValue pre-populated with 'old note', got %q", m.inputValue)
 	}
 
 	// Clear and type new name.

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -25,6 +25,12 @@ type SearchResult struct {
 // path-traversal sequences or is otherwise unsafe for use as a filename.
 var ErrInvalidName = errors.New("invalid name")
 
+// DisplayName converts a slug back to a human-readable name for UI display.
+// "meeting-notes" → "meeting notes".
+func DisplayName(slug string) string {
+	return strings.ReplaceAll(slug, "-", " ")
+}
+
 // Slugify converts a user-provided name into a clean filesystem-safe slug.
 // "Meeting Notes" → "meeting-notes", "  My Book  " → "my-book".
 func Slugify(name string) string {


### PR DESCRIPTION
## Summary

- Add `storage.DisplayName()` — converts slugs to display names (hyphens → spaces)
- TUI renders display names everywhere: breadcrumbs, lists, prompts, view titles, copy messages, empty states, search filtering
- CLI stays on slugs (per user preference)
- Delete confirmation accepts display name (type "meeting notes" not "meeting-notes")
- Rename pre-populates with display name
- Inverted block cursor (Reverse style) like Claude Code TUI
- Fix `sendString` test helper to handle spaces via `tea.KeySpace`

## Test plan

- [x] `go test ./...` — 322 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)