### PR TITLE
feat: add glamour markdown styles to theme system (Closes #79)

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -26,6 +26,7 @@ var configCmd = &cobra.Command{
 		displayValue("editor", cfg.Editor)
 		displayValue("theme", cfg.Theme)
 		displayValue("date_format", cfg.DateFormat)
+		displayValue("glamour_style", cfg.GlamourStyle)
 
 		fmt.Fprintln(w)
 		fmt.Fprintf(w, "  Config file: %s\n", config.Path())
@@ -43,7 +44,7 @@ var configSetCmd = &cobra.Command{
 		key, value := args[0], args[1]
 
 		if !config.ValidKeys[key] {
-			return fmt.Errorf("unknown config key: %q (valid keys: storage_dir, editor, theme, date_format)", key)
+			return fmt.Errorf("unknown config key: %q (valid keys: storage_dir, editor, theme, date_format, glamour_style)", key)
 		}
 
 		// Load current config, apply change, save.

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -33,6 +33,9 @@ func TestConfigShowsDefaults(t *testing.T) {
 	if !strings.Contains(out, "Config file:") {
 		t.Errorf("expected 'Config file:' in output, got %q", out)
 	}
+	if !strings.Contains(out, "glamour_style") {
+		t.Errorf("expected 'glamour_style' in config output, got %q", out)
+	}
 }
 
 func TestConfigSetKey(t *testing.T) {
@@ -98,10 +101,11 @@ func TestCLIFlagOverridesConfig(t *testing.T) {
 	configPath := filepath.Join(configDir, "config.toml")
 
 	cfg := config.Config{
-		StorageDir: "/config/notes",
-		Editor:     "",
-		Theme:      "auto",
-		DateFormat: "relative",
+		StorageDir:   "/config/notes",
+		Editor:       "",
+		Theme:        "auto",
+		DateFormat:   "relative",
+		GlamourStyle: "auto",
 	}
 	if err := config.SaveTo(cfg, configPath); err != nil {
 		t.Fatalf("SaveTo: %v", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/oobagi/notebook/internal/config"
+	"github.com/oobagi/notebook/internal/render"
 	"github.com/oobagi/notebook/internal/storage"
 	"github.com/oobagi/notebook/internal/theme"
 	"github.com/spf13/cobra"
@@ -38,6 +39,9 @@ var rootCmd = &cobra.Command{
 			themeName = "auto"
 		}
 		theme.SetTheme(theme.FromName(themeName))
+
+		// Pass the glamour style config to the render package.
+		render.SetGlamourStyle(cfg.GlamourStyle)
 
 		root := dirFlag
 		if root == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,28 +11,31 @@ import (
 
 // Config holds all user-configurable settings.
 type Config struct {
-	StorageDir string `toml:"storage_dir"`
-	Editor     string `toml:"editor"`
-	Theme      string `toml:"theme"`       // "auto", "dark", "light"
-	DateFormat string `toml:"date_format"` // "relative" or Go time format
+	StorageDir   string `toml:"storage_dir"`
+	Editor       string `toml:"editor"`
+	Theme        string `toml:"theme"`         // "auto", "dark", "light"
+	DateFormat   string `toml:"date_format"`   // "relative" or Go time format
+	GlamourStyle string `toml:"glamour_style"` // "auto", "dark", "light", "dracula", "tokyo-night", "notty", "ascii", "pink", or JSON file path
 }
 
 // DefaultConfig returns the default configuration.
 func DefaultConfig() Config {
 	return Config{
-		StorageDir: "~/.notebook",
-		Editor:     "",
-		Theme:      "auto",
-		DateFormat: "relative",
+		StorageDir:   "~/.notebook",
+		Editor:       "",
+		Theme:        "auto",
+		DateFormat:   "relative",
+		GlamourStyle: "auto",
 	}
 }
 
 // ValidKeys returns the set of keys that can be set via "config set".
 var ValidKeys = map[string]bool{
-	"storage_dir": true,
-	"editor":      true,
-	"theme":       true,
-	"date_format": true,
+	"storage_dir":   true,
+	"editor":        true,
+	"theme":         true,
+	"date_format":   true,
+	"glamour_style": true,
 }
 
 // Path returns the path to the config file: ~/.config/notebook/config.toml.
@@ -109,6 +112,8 @@ func Set(cfg *Config, key, value string) error {
 		cfg.Theme = value
 	case "date_format":
 		cfg.DateFormat = value
+	case "glamour_style":
+		cfg.GlamourStyle = value
 	default:
 		return fmt.Errorf("unknown config key: %q", key)
 	}
@@ -126,6 +131,8 @@ func Get(cfg Config, key string) (string, error) {
 		return cfg.Theme, nil
 	case "date_format":
 		return cfg.DateFormat, nil
+	case "glamour_style":
+		return cfg.GlamourStyle, nil
 	default:
 		return "", fmt.Errorf("unknown config key: %q", key)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,6 +21,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.DateFormat != "relative" {
 		t.Errorf("DateFormat = %q, want %q", cfg.DateFormat, "relative")
 	}
+	if cfg.GlamourStyle != "auto" {
+		t.Errorf("GlamourStyle = %q, want %q", cfg.GlamourStyle, "auto")
+	}
 }
 
 func TestLoadNoFile(t *testing.T) {
@@ -45,6 +48,7 @@ func TestLoadFromFile(t *testing.T) {
 editor = "nano"
 theme = "dark"
 date_format = "2006-01-02"
+glamour_style = "dracula"
 `
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write test config: %v", err)
@@ -67,6 +71,9 @@ date_format = "2006-01-02"
 	if cfg.DateFormat != "2006-01-02" {
 		t.Errorf("DateFormat = %q, want %q", cfg.DateFormat, "2006-01-02")
 	}
+	if cfg.GlamourStyle != "dracula" {
+		t.Errorf("GlamourStyle = %q, want %q", cfg.GlamourStyle, "dracula")
+	}
 }
 
 func TestSaveAndLoad(t *testing.T) {
@@ -74,10 +81,11 @@ func TestSaveAndLoad(t *testing.T) {
 	path := filepath.Join(dir, "sub", "config.toml")
 
 	cfg := Config{
-		StorageDir: "/my/notes",
-		Editor:     "vim",
-		Theme:      "light",
-		DateFormat: "relative",
+		StorageDir:   "/my/notes",
+		Editor:       "vim",
+		Theme:        "light",
+		DateFormat:   "relative",
+		GlamourStyle: "tokyo-night",
 	}
 
 	if err := SaveTo(cfg, path); err != nil {
@@ -117,6 +125,7 @@ func TestSetValidKeys(t *testing.T) {
 		{"editor", "nano", func() string { return cfg.Editor }},
 		{"theme", "dark", func() string { return cfg.Theme }},
 		{"date_format", "2006-01-02", func() string { return cfg.DateFormat }},
+		{"glamour_style", "dracula", func() string { return cfg.GlamourStyle }},
 	}
 
 	for _, tt := range tests {
@@ -139,10 +148,11 @@ func TestSetUnknownKey(t *testing.T) {
 
 func TestGetValidKeys(t *testing.T) {
 	cfg := Config{
-		StorageDir: "/notes",
-		Editor:     "nano",
-		Theme:      "dark",
-		DateFormat: "relative",
+		StorageDir:   "/notes",
+		Editor:       "nano",
+		Theme:        "dark",
+		DateFormat:   "relative",
+		GlamourStyle: "dracula",
 	}
 
 	tests := []struct {
@@ -153,6 +163,7 @@ func TestGetValidKeys(t *testing.T) {
 		{"editor", "nano"},
 		{"theme", "dark"},
 		{"date_format", "relative"},
+		{"glamour_style", "dracula"},
 	}
 
 	for _, tt := range tests {
@@ -228,5 +239,8 @@ func TestLoadPartialConfig(t *testing.T) {
 	}
 	if cfg.DateFormat != "relative" {
 		t.Errorf("DateFormat = %q, want default %q", cfg.DateFormat, "relative")
+	}
+	if cfg.GlamourStyle != "auto" {
+		t.Errorf("GlamourStyle = %q, want default %q", cfg.GlamourStyle, "auto")
 	}
 }

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -9,13 +9,14 @@ import (
 )
 
 // RenderMarkdown renders a markdown string for terminal display using Glamour.
-// When running on a TTY, the glamour style is derived from the active theme.
+// When running on a TTY, the glamour style is resolved from the user's
+// glamour_style config (which may be a built-in name or a JSON file path).
 // When output is not a terminal, glamour's NoTTY style is used via
 // WithAutoStyle to keep output free of ANSI escape codes.
 func RenderMarkdown(content string, width int) string {
 	var styleOpt glamour.TermRendererOption
 	if term.IsTerminal(int(os.Stdout.Fd())) {
-		styleOpt = glamour.WithStandardStyle(theme.Current().GlamourStyle)
+		styleOpt = resolveStyleOption()
 	} else {
 		styleOpt = glamour.WithAutoStyle()
 	}
@@ -49,4 +50,25 @@ func RenderMarkdown(content string, width int) string {
 	}
 
 	return out
+}
+
+// glamourStyleOverride holds the user's glamour_style config value.
+// It is set during initialization via SetGlamourStyle.
+var glamourStyleOverride string
+
+// SetGlamourStyle stores the user's glamour_style config value so that
+// RenderMarkdown can resolve it at render time.
+func SetGlamourStyle(style string) {
+	glamourStyleOverride = style
+}
+
+// resolveStyleOption returns the appropriate glamour TermRendererOption
+// based on the user's glamour_style config. It supports built-in style
+// names and custom JSON file paths.
+func resolveStyleOption() glamour.TermRendererOption {
+	style, isFile := theme.ResolveGlamourStyle(glamourStyleOverride)
+	if isFile {
+		return glamour.WithStylesFromJSONFile(style)
+	}
+	return glamour.WithStandardStyle(style)
 }

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -1,6 +1,11 @@
 package theme
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
 
 // Theme holds color values tuned for a specific terminal background.
 type Theme struct {
@@ -72,4 +77,46 @@ func FromName(name string) Theme {
 	default:
 		return Dark
 	}
+}
+
+// builtinGlamourStyles lists the style names that glamour ships with.
+// "auto" is handled separately before this map is consulted.
+var builtinGlamourStyles = map[string]bool{
+	"dark":        true,
+	"light":       true,
+	"dracula":     true,
+	"tokyo-night": true,
+	"notty":       true,
+	"ascii":       true,
+	"pink":        true,
+}
+
+// ResolveGlamourStyle determines the glamour style to use based on the
+// user's glamour_style config value and the active theme. The returned
+// string is either a built-in style name or an absolute path to a JSON
+// style file. The boolean indicates whether the result is a file path.
+//
+// When glamourCfg is empty or "auto", the theme's own GlamourStyle is used
+// (which is "dark" or "light" depending on terminal detection).
+func ResolveGlamourStyle(glamourCfg string) (style string, isFilePath bool) {
+	glamourCfg = strings.TrimSpace(glamourCfg)
+
+	// Empty or "auto" — defer to the active theme's default glamour style.
+	if glamourCfg == "" || glamourCfg == "auto" {
+		return current.GlamourStyle, false
+	}
+
+	// A known built-in style name.
+	if builtinGlamourStyles[glamourCfg] {
+		return glamourCfg, false
+	}
+
+	// Treat as a file path to a custom JSON style. If the file exists,
+	// return the path; otherwise fall back to the theme default.
+	if _, err := os.Stat(glamourCfg); err == nil {
+		return glamourCfg, true
+	}
+
+	// Unknown value — fall back to theme default.
+	return current.GlamourStyle, false
 }

--- a/internal/theme/theme_test.go
+++ b/internal/theme/theme_test.go
@@ -1,6 +1,10 @@
 package theme
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestDetectReturnsTheme(t *testing.T) {
 	got := Detect()
@@ -59,5 +63,86 @@ func TestThemeHasAllColors(t *testing.T) {
 				t.Error("GlamourStyle is empty")
 			}
 		})
+	}
+}
+
+func TestResolveGlamourStyleAuto(t *testing.T) {
+	SetTheme(Dark)
+	style, isFile := ResolveGlamourStyle("auto")
+	if style != "dark" {
+		t.Errorf("ResolveGlamourStyle(\"auto\") = %q, want %q", style, "dark")
+	}
+	if isFile {
+		t.Error("expected isFile=false for auto")
+	}
+}
+
+func TestResolveGlamourStyleEmpty(t *testing.T) {
+	SetTheme(Light)
+	style, isFile := ResolveGlamourStyle("")
+	if style != "light" {
+		t.Errorf("ResolveGlamourStyle(\"\") = %q, want %q", style, "light")
+	}
+	if isFile {
+		t.Error("expected isFile=false for empty")
+	}
+}
+
+func TestResolveGlamourStyleBuiltin(t *testing.T) {
+	SetTheme(Dark)
+
+	builtins := []string{"dark", "light", "dracula", "tokyo-night", "notty", "ascii", "pink"}
+	for _, name := range builtins {
+		t.Run(name, func(t *testing.T) {
+			style, isFile := ResolveGlamourStyle(name)
+			if style != name {
+				t.Errorf("ResolveGlamourStyle(%q) = %q, want %q", name, style, name)
+			}
+			if isFile {
+				t.Errorf("expected isFile=false for built-in %q", name)
+			}
+		})
+	}
+}
+
+func TestResolveGlamourStyleCustomFile(t *testing.T) {
+	SetTheme(Dark)
+
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "custom.json")
+	if err := os.WriteFile(jsonPath, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write custom style: %v", err)
+	}
+
+	style, isFile := ResolveGlamourStyle(jsonPath)
+	if style != jsonPath {
+		t.Errorf("ResolveGlamourStyle(%q) = %q, want file path", jsonPath, style)
+	}
+	if !isFile {
+		t.Error("expected isFile=true for custom JSON file")
+	}
+}
+
+func TestResolveGlamourStyleMissingFile(t *testing.T) {
+	SetTheme(Dark)
+
+	style, isFile := ResolveGlamourStyle("/nonexistent/style.json")
+	if style != "dark" {
+		t.Errorf("ResolveGlamourStyle with missing file = %q, want theme default %q", style, "dark")
+	}
+	if isFile {
+		t.Error("expected isFile=false for missing file")
+	}
+}
+
+func TestResolveGlamourStyleUnknownValue(t *testing.T) {
+	SetTheme(Light)
+
+	style, isFile := ResolveGlamourStyle("nonexistent-style")
+	if style != "light" {
+		t.Errorf("ResolveGlamourStyle(\"nonexistent-style\") = %q, want theme default %q", style, "light")
+	}
+	if isFile {
+		t.Error("expected isFile=false for unknown value")
 	}
 }


### PR DESCRIPTION
## Summary

- Added `glamour_style` config key (default: `"auto"`) to `Config` struct
- Built-in glamour v1.0.0 styles supported: dark, light, dracula, tokyo-night, notty, ascii, pink
- Custom JSON style file paths supported (validated with `os.Stat`)
- `"auto"` preserves existing terminal dark/light detection behavior
- `notebook config set glamour_style dracula` to change, `notebook config` to view
- Added `ResolveGlamourStyle()` to theme package for clean resolution logic
- Updated render pipeline to use configured style via `SetGlamourStyle()`

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test ./...` — all tests pass
- [x] Config round-trip: set, save, load, verify
- [x] Theme resolver: auto, empty, all built-ins, custom file, missing file, unknown value
- [x] Code review — no blockers
- [x] Reality check — implementation matches spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)