### PR TITLE
feat: TUI theme picker with live markdown preview (Closes #80)

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -9,6 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/oobagi/notebook/internal/clipboard"
+	"github.com/oobagi/notebook/internal/config"
 	"github.com/oobagi/notebook/internal/model"
 	"github.com/oobagi/notebook/internal/render"
 	"github.com/oobagi/notebook/internal/storage"
@@ -67,6 +68,12 @@ type Model struct {
 	viewContent string // rendered markdown content
 	viewScroll  int    // scroll offset for the view
 	viewTitle   string // breadcrumb title for the view
+
+	// Theme picker fields.
+	themeMode    bool     // theme picker overlay visible
+	themeStyles  []string // available glamour style names
+	themeCursor  int      // current selection in theme list
+	themePreview string   // rendered preview for currently highlighted style
 }
 
 // notebookItem holds pre-fetched metadata for a notebook.
@@ -308,6 +315,11 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// When theme picker is showing, handle navigation/selection.
+	if m.themeMode {
+		return m.handleThemeKey(msg)
+	}
+
 	// When in input mode, delegate to input handler.
 	if m.inputMode {
 		return m.handleInputKey(msg)
@@ -371,6 +383,9 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		if s == "c" && m.level == 1 {
 			return m.copyNote()
+		}
+		if s == "t" {
+			return m.startThemePicker()
 		}
 		return m, nil
 	}
@@ -666,6 +681,200 @@ func (m Model) copyNote() (tea.Model, tea.Cmd) {
 	}
 }
 
+// themePreviewSample is the hardcoded markdown snippet used to preview glamour styles.
+const themePreviewSample = `# Heading
+
+**Bold text** and regular text.
+
+` + "```go" + `
+fmt.Println("hello world")
+` + "```" + `
+
+- Item one
+- Item two
+
+- [x] Completed task
+- [ ] Pending task
+
+> A blockquote for emphasis.
+
+> [!NOTE]
+> This is an admonition note.
+`
+
+// availableThemeStyles lists the glamour style names shown in the picker.
+var availableThemeStyles = []string{
+	"auto",
+	"dark",
+	"light",
+	"dracula",
+	"tokyo-night",
+	"notty",
+	"ascii",
+	"pink",
+}
+
+func (m Model) startThemePicker() (tea.Model, tea.Cmd) {
+	m.themeMode = true
+	m.themeStyles = availableThemeStyles
+	m.themeCursor = 0
+	// Pre-select the currently active style if set.
+	if cfg, err := config.Load(); err == nil && cfg.GlamourStyle != "" {
+		for i, s := range availableThemeStyles {
+			if s == cfg.GlamourStyle {
+				m.themeCursor = i
+				break
+			}
+		}
+	}
+	m.themePreview = m.renderThemePreview(m.themeStyles[m.themeCursor])
+	return m, nil
+}
+
+func (m Model) handleThemeKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEsc:
+		m.themeMode = false
+		return m, nil
+
+	case tea.KeyUp:
+		if m.themeCursor > 0 {
+			m.themeCursor--
+			m.themePreview = m.renderThemePreview(m.themeStyles[m.themeCursor])
+		}
+		return m, nil
+
+	case tea.KeyDown:
+		if m.themeCursor < len(m.themeStyles)-1 {
+			m.themeCursor++
+			m.themePreview = m.renderThemePreview(m.themeStyles[m.themeCursor])
+		}
+		return m, nil
+
+	case tea.KeyEnter:
+		selected := m.themeStyles[m.themeCursor]
+		m.themeMode = false
+
+		// Persist to config and apply.
+		cfg, err := config.Load()
+		if err != nil {
+			m.statusText = fmt.Sprintf("Config load error: %s", err)
+			return m, nil
+		}
+		if err := config.Set(&cfg, "glamour_style", selected); err != nil {
+			m.statusText = fmt.Sprintf("Config error: %s", err)
+			return m, nil
+		}
+		if err := config.Save(cfg); err != nil {
+			m.statusText = fmt.Sprintf("Config save error: %s", err)
+			return m, nil
+		}
+		render.SetGlamourStyle(selected)
+		m.statusText = fmt.Sprintf("Theme set to %q", selected)
+		return m, nil
+
+	case tea.KeyRunes:
+		if string(msg.Runes) == "q" || string(msg.Runes) == "t" {
+			m.themeMode = false
+			return m, nil
+		}
+	}
+
+	return m, nil
+}
+
+func (m Model) renderThemePreview(styleName string) string {
+	w := m.width
+	if w <= 0 {
+		w = 80
+	}
+	// Use roughly half the width for the preview pane.
+	previewWidth := w/2 - 6
+	if previewWidth < 20 {
+		previewWidth = 20
+	}
+	return render.RenderMarkdownWithStyle(themePreviewSample, previewWidth, styleName)
+}
+
+// renderThemeOverlay builds the theme picker overlay with style list and preview.
+func (m Model) renderThemeOverlay() string {
+	w := m.width
+	if w <= 0 {
+		w = 80
+	}
+	h := m.height
+	if h <= 0 {
+		h = 24
+	}
+
+	// Left pane: style list.
+	listWidth := 22
+	var left strings.Builder
+	bold := lipgloss.NewStyle().Bold(true)
+	left.WriteString(bold.Render("  Glamour Style"))
+	left.WriteString("\n")
+	left.WriteString("  ─────────────────\n")
+
+	for i, s := range m.themeStyles {
+		if i == m.themeCursor {
+			sel := lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+			left.WriteString(fmt.Sprintf("  %s %s\n", sel.Render("●"), sel.Render(s)))
+		} else {
+			left.WriteString(fmt.Sprintf("    %s\n", s))
+		}
+	}
+
+	// Right pane: markdown preview.
+	previewWidth := w - listWidth - 10
+	if previewWidth < 20 {
+		previewWidth = 20
+	}
+
+	// Clamp preview lines to fit the overlay height.
+	previewLines := strings.Split(m.themePreview, "\n")
+	maxPreview := h - 6
+	if maxPreview < 1 {
+		maxPreview = 1
+	}
+	if len(previewLines) > maxPreview {
+		previewLines = previewLines[:maxPreview]
+	}
+
+	previewBox := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("8")).
+		Padding(0, 1).
+		Width(previewWidth)
+
+	preview := previewBox.Render(strings.Join(previewLines, "\n"))
+
+	// Combine left + right.
+	leftBox := lipgloss.NewStyle().
+		Width(listWidth).
+		Padding(1, 0)
+
+	rightBox := lipgloss.NewStyle().
+		Padding(1, 0)
+
+	combined := lipgloss.JoinHorizontal(lipgloss.Top, leftBox.Render(left.String()), rightBox.Render(preview))
+
+	// Outer container.
+	outer := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("8")).
+		Padding(0, 1)
+
+	rendered := outer.Render(combined)
+
+	// Status hint.
+	dim := lipgloss.NewStyle().Faint(true)
+	hint := dim.Render("  ↑/↓ navigate · Enter apply · Esc cancel")
+
+	full := rendered + "\n" + hint
+
+	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, full)
+}
+
 func (m *Model) applyFilter() {
 	query := strings.ToLower(m.filter)
 	m.filtered = nil
@@ -774,6 +983,7 @@ func (m Model) renderHelpOverlay() string {
   n          New notebook
   d          Delete notebook
   r          Rename notebook
+  t          Theme picker
   /          Search
   q          Quit
   ?          Toggle help
@@ -790,6 +1000,7 @@ func (m Model) renderHelpOverlay() string {
   d          Delete note
   r          Rename note
   c          Copy to clipboard
+  t          Theme picker
   /          Search
   Esc        Back to notebooks
   q          Quit
@@ -883,6 +1094,10 @@ func (m Model) View() string {
 
 	if m.viewMode {
 		return m.renderViewOverlay()
+	}
+
+	if m.themeMode {
+		return m.renderThemeOverlay()
 	}
 
 	if m.err != nil {

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -1223,3 +1223,263 @@ func TestBrowserViewAtL0IsNoop(t *testing.T) {
 		t.Error("expected viewMode to be false at L0")
 	}
 }
+
+func TestBrowserThemePickerOpen(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Press 't' to open theme picker at L0.
+	m = sendRune(t, m, 't')
+
+	if !m.themeMode {
+		t.Fatal("expected themeMode to be true after pressing 't'")
+	}
+	if len(m.themeStyles) == 0 {
+		t.Fatal("expected themeStyles to be populated")
+	}
+	if m.themeCursor != 0 {
+		t.Errorf("expected themeCursor at 0, got %d", m.themeCursor)
+	}
+	if m.themePreview == "" {
+		t.Error("expected themePreview to be non-empty")
+	}
+
+	view := m.View()
+	if !containsStr(view, "Glamour Style") {
+		t.Errorf("view should contain 'Glamour Style', got:\n%s", view)
+	}
+}
+
+func TestBrowserThemePickerOpenAtL1(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Enter notebook to reach L1.
+	m = sendKey(t, m, tea.KeyEnter)
+	if m.level != 1 {
+		t.Fatalf("expected level 1, got %d", m.level)
+	}
+
+	// Press 't' to open theme picker at L1.
+	m = sendRune(t, m, 't')
+
+	if !m.themeMode {
+		t.Fatal("expected themeMode to be true after pressing 't' at L1")
+	}
+}
+
+func TestBrowserThemePickerNavigate(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Open theme picker.
+	m = sendRune(t, m, 't')
+	if !m.themeMode {
+		t.Fatal("expected themeMode to be true")
+	}
+
+	initialPreview := m.themePreview
+
+	// Move down.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(Model)
+
+	if m.themeCursor != 1 {
+		t.Errorf("expected themeCursor at 1, got %d", m.themeCursor)
+	}
+
+	// Preview should update when cursor moves.
+	if m.themePreview == "" {
+		t.Error("expected themePreview to be non-empty after moving down")
+	}
+	// The preview for a different style may differ from the initial one.
+	_ = initialPreview // used to verify preview exists
+
+	// Move up back to first.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(Model)
+
+	if m.themeCursor != 0 {
+		t.Errorf("expected themeCursor at 0, got %d", m.themeCursor)
+	}
+
+	// Move up at top should not go negative.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(Model)
+
+	if m.themeCursor != 0 {
+		t.Errorf("expected themeCursor to stay at 0, got %d", m.themeCursor)
+	}
+}
+
+func TestBrowserThemePickerEscCancels(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Open theme picker.
+	m = sendRune(t, m, 't')
+	if !m.themeMode {
+		t.Fatal("expected themeMode to be true")
+	}
+
+	// Press Esc to cancel.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+
+	if m.themeMode {
+		t.Fatal("expected themeMode to be false after Esc")
+	}
+
+	// Should still be at same level (no navigation).
+	if m.level != 0 {
+		t.Errorf("expected level 0 after Esc, got %d", m.level)
+	}
+}
+
+func TestBrowserThemePickerQDismisses(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Open theme picker.
+	m = sendRune(t, m, 't')
+	if !m.themeMode {
+		t.Fatal("expected themeMode to be true")
+	}
+
+	// Press 'q' to dismiss (should not quit the app).
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	m = updated.(Model)
+
+	if m.themeMode {
+		t.Fatal("expected themeMode to be false after 'q'")
+	}
+	if m.quitting {
+		t.Error("'q' in theme picker should not quit the app")
+	}
+	if cmd != nil {
+		t.Error("expected no command from 'q' in theme picker")
+	}
+}
+
+func TestBrowserThemePickerTDismisses(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Open theme picker.
+	m = sendRune(t, m, 't')
+	if !m.themeMode {
+		t.Fatal("expected themeMode to be true")
+	}
+
+	// Press 't' again to dismiss (toggle).
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	m = updated.(Model)
+
+	if m.themeMode {
+		t.Fatal("expected themeMode to be false after 't' toggle")
+	}
+}
+
+func TestBrowserThemePickerDownClamps(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Open theme picker.
+	m = sendRune(t, m, 't')
+
+	// Move to last item.
+	for i := 0; i < len(m.themeStyles)+5; i++ {
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		m = updated.(Model)
+	}
+
+	if m.themeCursor != len(m.themeStyles)-1 {
+		t.Errorf("expected themeCursor at %d, got %d", len(m.themeStyles)-1, m.themeCursor)
+	}
+}
+
+func TestBrowserThemePickerStyles(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+	m = sendRune(t, m, 't')
+
+	expected := []string{"auto", "dark", "light", "dracula", "tokyo-night", "notty", "ascii", "pink"}
+	if len(m.themeStyles) != len(expected) {
+		t.Fatalf("expected %d styles, got %d", len(expected), len(m.themeStyles))
+	}
+	for i, s := range expected {
+		if m.themeStyles[i] != s {
+			t.Errorf("expected style[%d] = %q, got %q", i, s, m.themeStyles[i])
+		}
+	}
+}
+
+func TestBrowserThemePickerViewContent(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+	m = sendRune(t, m, 't')
+
+	view := m.View()
+	// Should contain the overlay with style names.
+	if !containsStr(view, "dark") {
+		t.Errorf("view should list 'dark' style, got:\n%s", view)
+	}
+	if !containsStr(view, "dracula") {
+		t.Errorf("view should list 'dracula' style, got:\n%s", view)
+	}
+	// Should contain navigation hint.
+	if !containsStr(view, "navigate") {
+		t.Errorf("view should contain navigation hint, got:\n%s", view)
+	}
+}
+
+func TestBrowserHelpShowsThemeKey(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Open help at L0.
+	m = sendRune(t, m, '?')
+	view := m.View()
+	if !containsStr(view, "Theme picker") {
+		t.Errorf("L0 help should mention 'Theme picker', got:\n%s", view)
+	}
+
+	// Close help, enter notebook, open help at L1.
+	m = sendRune(t, m, '?')
+	m = sendKey(t, m, tea.KeyEnter)
+	m = sendRune(t, m, '?')
+	view = m.View()
+	if !containsStr(view, "Theme picker") {
+		t.Errorf("L1 help should mention 'Theme picker', got:\n%s", view)
+	}
+}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -62,6 +62,37 @@ func SetGlamourStyle(style string) {
 	glamourStyleOverride = style
 }
 
+// RenderMarkdownWithStyle renders markdown using a specific named glamour style.
+// This is used by the theme picker to preview different styles without
+// changing the global glamour_style setting.
+func RenderMarkdownWithStyle(content string, width int, styleName string) string {
+	style, isFile := theme.ResolveGlamourStyle(styleName)
+	var styleOpt glamour.TermRendererOption
+	if isFile {
+		styleOpt = glamour.WithStylesFromJSONFile(style)
+	} else {
+		styleOpt = glamour.WithStandardStyle(style)
+	}
+
+	opts := []glamour.TermRendererOption{styleOpt}
+	if width > 0 {
+		opts = append(opts, glamour.WithWordWrap(width))
+	}
+
+	renderer, err := glamour.NewTermRenderer(opts...)
+	if err != nil {
+		return content
+	}
+
+	out, err := renderer.Render(content)
+	if err != nil {
+		return content
+	}
+
+	out = RenderAdmonitions(out)
+	return out
+}
+
 // resolveStyleOption returns the appropriate glamour TermRendererOption
 // based on the user's glamour_style config. It supports built-in style
 // names and custom JSON file paths.


### PR DESCRIPTION
## Summary

- Added theme picker overlay to TUI browser, accessible via `t` keybinding
- Split layout: style list on left, live-rendered markdown preview on right
- Supports all built-in glamour styles: auto, dark, light, dracula, tokyo-night, notty, ascii, pink
- Enter persists selection to `~/.config/notebook/config.toml` and applies immediately
- Esc cancels without changing anything
- Pre-selects the currently active style when opened
- Preview includes admonition rendering for accurate representation
- Added `RenderMarkdownWithStyle()` helper for per-style preview rendering
- 10 new browser tests covering open, navigate, dismiss, clamp, view content, help text

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test ./...` — all tests pass
- [x] Code review — blockers fixed (error handling, admonition preview, pre-select)
- [x] Reality check — implementation matches spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)