### PR TITLE
fix: clear stale data on level transitions to prevent panic (Closes #93)

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -946,6 +946,8 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 		m.cursor = 0
 		m.filter = ""
 		m.filtering = false
+		m.notes = nil
+		m.filtered = nil
 		return m, m.loadNotes(m.currentBook)
 	}
 
@@ -965,6 +967,8 @@ func (m Model) handleEsc() (tea.Model, tea.Cmd) {
 		m.cursor = 0
 		m.filter = ""
 		m.filtering = false
+		m.notebooks = nil
+		m.filtered = nil
 		return m, m.loadNotebooks()
 	}
 	m.quitting = true


### PR DESCRIPTION
## Summary
- Clear `m.notes` and `m.filtered` in `handleEnter` when transitioning from level 0 → 1
- Clear `m.notebooks` and `m.filtered` in `handleEsc` when transitioning from level 1 → 0
- Prevents index-out-of-range panic caused by stale filtered indices from the previous level being used with the new level's data array

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/browser/...` — 43 passing (2 pre-existing failures unrelated to this change)
- [x] Code review — no blockers
- [x] Security review — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)