### PR TITLE
fix: correct theme picker overlay height to prevent top clipping (Closes #84)

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -832,7 +832,7 @@ func (m Model) renderThemeOverlay() string {
 
 	// Clamp preview lines to fit the overlay height.
 	previewLines := strings.Split(m.themePreview, "\n")
-	maxPreview := h - 6
+	maxPreview := h - 8
 	if maxPreview < 1 {
 		maxPreview = 1
 	}
@@ -862,7 +862,8 @@ func (m Model) renderThemeOverlay() string {
 	outer := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color("8")).
-		Padding(0, 1)
+		Padding(0, 1).
+		MaxHeight(h - 2)
 
 	rendered := outer.Render(combined)
 

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -31,6 +31,7 @@ func setupTestStore(t *testing.T, books map[string][]string) *storage.Store {
 // initModel creates a Model and processes the Init command to load data.
 func initModel(t *testing.T, s *storage.Store) Model {
 	t.Helper()
+	t.Setenv("HOME", t.TempDir())
 	m := New(Config{
 		Store:    s,
 		EditNote: func(book, note string) error { return nil },


### PR DESCRIPTION
## Summary
- Changed `maxPreview` from `h - 6` to `h - 8` to account for all vertical chrome: outer border (2) + pane padding (2) + preview border (2) + hint line (2)
- Added `MaxHeight(h - 2)` on the outer container as a defensive clamp
- Fixed test isolation by setting HOME to a temp dir so config.Load() doesn't read the developer's real settings

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./internal/browser/...` — 45 passing (0 failures, fixed 2 pre-existing)
- [x] Code review — height math verified correct
- [x] Security review — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)