### PR TITLE
fix: remove notty and ascii from theme picker (Closes #85)

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -709,8 +709,6 @@ var availableThemeStyles = []string{
 	"light",
 	"dracula",
 	"tokyo-night",
-	"notty",
-	"ascii",
 	"pink",
 }
 

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -1428,7 +1428,7 @@ func TestBrowserThemePickerStyles(t *testing.T) {
 	m := initModel(t, s)
 	m = sendRune(t, m, 't')
 
-	expected := []string{"auto", "dark", "light", "dracula", "tokyo-night", "notty", "ascii", "pink"}
+	expected := []string{"auto", "dark", "light", "dracula", "tokyo-night", "pink"}
 	if len(m.themeStyles) != len(expected) {
 		t.Fatalf("expected %d styles, got %d", len(expected), len(m.themeStyles))
 	}


### PR DESCRIPTION
## Summary
- Removed `"notty"` and `"ascii"` from `availableThemeStyles` — they produced broken-looking previews in the TUI picker
- Updated `TestBrowserThemePickerStyles` to expect 6 styles instead of 8
- Both styles remain valid for CLI config (`notebook config set glamour_style notty`)

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./internal/browser/...` — 45 passing
- [x] Theme picker shows 6 styles: auto, dark, light, dracula, tokyo-night, pink

🤖 Generated with [Claude Code](https://claude.com/claude-code)