### PR TITLE
feat: show dark/light background hints in theme picker (Closes #86)

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -74,6 +74,7 @@ type Model struct {
 	themeStyles  []string // available glamour style names
 	themeCursor  int      // current selection in theme list
 	themePreview string   // rendered preview for currently highlighted style
+	darkTerminal bool     // true when terminal has dark background
 }
 
 // notebookItem holds pre-fetched metadata for a notebook.
@@ -712,10 +713,21 @@ var availableThemeStyles = []string{
 	"pink",
 }
 
+// styleHints maps each style name to its intended background compatibility.
+var styleHints = map[string]string{
+	"auto":        "",
+	"dark":        "(dark bg)",
+	"light":       "(light bg)",
+	"dracula":     "(dark bg)",
+	"tokyo-night": "(dark bg)",
+	"pink":        "(dark bg)",
+}
+
 func (m Model) startThemePicker() (tea.Model, tea.Cmd) {
 	m.themeMode = true
 	m.themeStyles = availableThemeStyles
 	m.themeCursor = 0
+	m.darkTerminal = lipgloss.HasDarkBackground()
 	// Pre-select the currently active style if set.
 	if cfg, err := config.Load(); err == nil && cfg.GlamourStyle != "" {
 		for i, s := range availableThemeStyles {
@@ -806,19 +818,42 @@ func (m Model) renderThemeOverlay() string {
 	}
 
 	// Left pane: style list.
-	listWidth := 22
+	listWidth := 30
 	var left strings.Builder
 	bold := lipgloss.NewStyle().Bold(true)
+	dim := lipgloss.NewStyle().Faint(true)
 	left.WriteString(bold.Render("  Glamour Style"))
 	left.WriteString("\n")
 	left.WriteString("  ─────────────────\n")
 
 	for i, s := range m.themeStyles {
+		hint := styleHints[s]
+		hintStr := ""
+		if hint != "" {
+			hintStr = " " + dim.Render(hint)
+		}
 		if i == m.themeCursor {
 			sel := lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
-			left.WriteString(fmt.Sprintf("  %s %s\n", sel.Render("●"), sel.Render(s)))
+			left.WriteString(fmt.Sprintf("  %s %s%s\n", sel.Render("●"), sel.Render(s), hintStr))
 		} else {
-			left.WriteString(fmt.Sprintf("    %s\n", s))
+			left.WriteString(fmt.Sprintf("    %s%s\n", s, hintStr))
+		}
+	}
+
+	// Show warning when highlighted style conflicts with terminal background.
+	if cur := m.themeStyles[m.themeCursor]; cur != "auto" {
+		curHint := styleHints[cur]
+		conflict := false
+		if m.darkTerminal && curHint == "(light bg)" {
+			conflict = true
+		}
+		if !m.darkTerminal && curHint == "(dark bg)" {
+			conflict = true
+		}
+		if conflict {
+			left.WriteString("\n")
+			left.WriteString(dim.Render("  \u26a0 May be hard to read\n    on your terminal"))
+			left.WriteString("\n")
 		}
 	}
 
@@ -866,10 +901,9 @@ func (m Model) renderThemeOverlay() string {
 	rendered := outer.Render(combined)
 
 	// Status hint.
-	dim := lipgloss.NewStyle().Faint(true)
-	hint := dim.Render("  ↑/↓ navigate · Enter apply · Esc cancel")
+	statusHint := dim.Render("  ↑/↓ navigate · Enter apply · Esc cancel")
 
-	full := rendered + "\n" + hint
+	full := rendered + "\n" + statusHint
 
 	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, full)
 }

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -1484,3 +1484,107 @@ func TestBrowserHelpShowsThemeKey(t *testing.T) {
 		t.Errorf("L1 help should mention 'Theme picker', got:\n%s", view)
 	}
 }
+
+func TestStyleHintsMap(t *testing.T) {
+	// Every entry in availableThemeStyles must have an entry in styleHints.
+	for _, s := range availableThemeStyles {
+		if _, ok := styleHints[s]; !ok {
+			t.Errorf("styleHints missing entry for %q", s)
+		}
+	}
+
+	// "auto" should have an empty hint.
+	if styleHints["auto"] != "" {
+		t.Errorf("expected empty hint for auto, got %q", styleHints["auto"])
+	}
+
+	// Dark-background styles should have "(dark bg)" hint.
+	for _, s := range []string{"dark", "dracula", "tokyo-night", "pink"} {
+		if styleHints[s] != "(dark bg)" {
+			t.Errorf("expected %q hint to be \"(dark bg)\", got %q", s, styleHints[s])
+		}
+	}
+
+	// Light-background style should have "(light bg)" hint.
+	if styleHints["light"] != "(light bg)" {
+		t.Errorf("expected light hint to be \"(light bg)\", got %q", styleHints["light"])
+	}
+}
+
+func TestThemePickerShowsHints(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+	m = sendRune(t, m, 't')
+
+	view := m.View()
+	if !containsStr(view, "(dark bg)") {
+		t.Errorf("view should contain '(dark bg)' hint, got:\n%s", view)
+	}
+	if !containsStr(view, "(light bg)") {
+		t.Errorf("view should contain '(light bg)' hint, got:\n%s", view)
+	}
+}
+
+func TestThemePickerDarkTerminalField(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+	m = sendRune(t, m, 't')
+
+	// darkTerminal should be set without panicking.
+	_ = m.darkTerminal
+}
+
+func TestThemePickerConflictWarning(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+	m = sendRune(t, m, 't')
+
+	// Move cursor to "light" (index 2).
+	for i := 0; i < 2; i++ {
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		m = updated.(Model)
+	}
+	if m.themeStyles[m.themeCursor] != "light" {
+		t.Fatalf("expected cursor on 'light', got %q", m.themeStyles[m.themeCursor])
+	}
+
+	view := m.View()
+	if m.darkTerminal {
+		if !containsStr(view, "May be hard to read") {
+			t.Errorf("expected conflict warning for light style on dark terminal, got:\n%s", view)
+		}
+	}
+
+	// Move cursor to "dark" (index 1).
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(Model)
+	if m.themeStyles[m.themeCursor] != "dark" {
+		t.Fatalf("expected cursor on 'dark', got %q", m.themeStyles[m.themeCursor])
+	}
+	view = m.View()
+	if !m.darkTerminal {
+		if !containsStr(view, "May be hard to read") {
+			t.Errorf("expected conflict warning for dark style on light terminal, got:\n%s", view)
+		}
+	}
+
+	// Move cursor to "auto" (index 0) — no conflict ever.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(Model)
+	if m.themeStyles[m.themeCursor] != "auto" {
+		t.Fatalf("expected cursor on 'auto', got %q", m.themeStyles[m.themeCursor])
+	}
+	view = m.View()
+	if containsStr(view, "May be hard to read") {
+		t.Errorf("auto style should never show conflict warning, got:\n%s", view)
+	}
+}


### PR DESCRIPTION
## Summary
- Added `styleHints` map associating each style with its target background
- Rendered dimmed hint text next to style names in the picker (e.g., "dracula (dark bg)")
- Detects terminal background via `lipgloss.HasDarkBackground()` on picker open
- Shows "May be hard to read on your terminal" warning when style conflicts with terminal
- Widened left pane from 22 to 30 columns to fit hints
- Added 4 new tests: hint map validation, hint rendering, dark terminal field, conflict warning

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./internal/browser/...` — 49 passing
- [x] Each style shows background hint (except "auto")
- [x] Warning appears for conflicting styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)