### PR TITLE
feat: add ui_theme config key for UI color control (Closes #88)

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -27,6 +27,7 @@ var configCmd = &cobra.Command{
 		displayValue("theme", cfg.Theme)
 		displayValue("date_format", cfg.DateFormat)
 		displayValue("glamour_style", cfg.GlamourStyle)
+		displayValue("ui_theme", cfg.UITheme)
 
 		fmt.Fprintln(w)
 		fmt.Fprintf(w, "  Config file: %s\n", config.Path())
@@ -44,7 +45,7 @@ var configSetCmd = &cobra.Command{
 		key, value := args[0], args[1]
 
 		if !config.ValidKeys[key] {
-			return fmt.Errorf("unknown config key: %q (valid keys: storage_dir, editor, theme, date_format, glamour_style)", key)
+			return fmt.Errorf("unknown config key: %q (valid keys: storage_dir, editor, theme, date_format, glamour_style, ui_theme)", key)
 		}
 
 		// Load current config, apply change, save.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,12 @@ var rootCmd = &cobra.Command{
 		}
 
 		// Resolve the active theme from config (or auto-detect).
-		themeName := cfg.Theme
+		// ui_theme takes precedence over theme when set to a non-auto value,
+		// allowing users to control the TUI color palette independently.
+		themeName := cfg.UITheme
+		if themeName == "" || themeName == "auto" {
+			themeName = cfg.Theme
+		}
 		if themeName == "" {
 			themeName = "auto"
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	Theme        string `toml:"theme"`         // "auto", "dark", "light"
 	DateFormat   string `toml:"date_format"`   // "relative" or Go time format
 	GlamourStyle string `toml:"glamour_style"` // "auto", "dark", "light", "dracula", "tokyo-night", "notty", "ascii", "pink", or JSON file path
+	UITheme      string `toml:"ui_theme"`      // "auto" or any theme preset name; overrides TUI palette independently from glamour_style
 }
 
 // DefaultConfig returns the default configuration.
@@ -26,6 +27,7 @@ func DefaultConfig() Config {
 		Theme:        "auto",
 		DateFormat:   "relative",
 		GlamourStyle: "auto",
+		UITheme:      "auto",
 	}
 }
 
@@ -36,6 +38,7 @@ var ValidKeys = map[string]bool{
 	"theme":         true,
 	"date_format":   true,
 	"glamour_style": true,
+	"ui_theme":      true,
 }
 
 // Path returns the path to the config file: ~/.config/notebook/config.toml.
@@ -114,6 +117,8 @@ func Set(cfg *Config, key, value string) error {
 		cfg.DateFormat = value
 	case "glamour_style":
 		cfg.GlamourStyle = value
+	case "ui_theme":
+		cfg.UITheme = value
 	default:
 		return fmt.Errorf("unknown config key: %q", key)
 	}
@@ -133,6 +138,8 @@ func Get(cfg Config, key string) (string, error) {
 		return cfg.DateFormat, nil
 	case "glamour_style":
 		return cfg.GlamourStyle, nil
+	case "ui_theme":
+		return cfg.UITheme, nil
 	default:
 		return "", fmt.Errorf("unknown config key: %q", key)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -24,6 +24,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.GlamourStyle != "auto" {
 		t.Errorf("GlamourStyle = %q, want %q", cfg.GlamourStyle, "auto")
 	}
+	if cfg.UITheme != "auto" {
+		t.Errorf("UITheme = %q, want %q", cfg.UITheme, "auto")
+	}
 }
 
 func TestLoadNoFile(t *testing.T) {
@@ -49,6 +52,7 @@ editor = "nano"
 theme = "dark"
 date_format = "2006-01-02"
 glamour_style = "dracula"
+ui_theme = "ocean"
 `
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write test config: %v", err)
@@ -74,6 +78,9 @@ glamour_style = "dracula"
 	if cfg.GlamourStyle != "dracula" {
 		t.Errorf("GlamourStyle = %q, want %q", cfg.GlamourStyle, "dracula")
 	}
+	if cfg.UITheme != "ocean" {
+		t.Errorf("UITheme = %q, want %q", cfg.UITheme, "ocean")
+	}
 }
 
 func TestSaveAndLoad(t *testing.T) {
@@ -86,6 +93,7 @@ func TestSaveAndLoad(t *testing.T) {
 		Theme:        "light",
 		DateFormat:   "relative",
 		GlamourStyle: "tokyo-night",
+		UITheme:      "forest",
 	}
 
 	if err := SaveTo(cfg, path); err != nil {
@@ -126,6 +134,7 @@ func TestSetValidKeys(t *testing.T) {
 		{"theme", "dark", func() string { return cfg.Theme }},
 		{"date_format", "2006-01-02", func() string { return cfg.DateFormat }},
 		{"glamour_style", "dracula", func() string { return cfg.GlamourStyle }},
+		{"ui_theme", "ocean", func() string { return cfg.UITheme }},
 	}
 
 	for _, tt := range tests {
@@ -153,6 +162,7 @@ func TestGetValidKeys(t *testing.T) {
 		Theme:        "dark",
 		DateFormat:   "relative",
 		GlamourStyle: "dracula",
+		UITheme:      "sunset",
 	}
 
 	tests := []struct {
@@ -164,6 +174,7 @@ func TestGetValidKeys(t *testing.T) {
 		{"theme", "dark"},
 		{"date_format", "relative"},
 		{"glamour_style", "dracula"},
+		{"ui_theme", "sunset"},
 	}
 
 	for _, tt := range tests {
@@ -242,5 +253,38 @@ func TestLoadPartialConfig(t *testing.T) {
 	}
 	if cfg.GlamourStyle != "auto" {
 		t.Errorf("GlamourStyle = %q, want default %q", cfg.GlamourStyle, "auto")
+	}
+	if cfg.UITheme != "auto" {
+		t.Errorf("UITheme = %q, want default %q", cfg.UITheme, "auto")
+	}
+}
+
+func TestUIThemeSetGetRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	cfg := DefaultConfig()
+	if err := Set(&cfg, "ui_theme", "ocean"); err != nil {
+		t.Fatalf("Set ui_theme: %v", err)
+	}
+
+	got, err := Get(cfg, "ui_theme")
+	if err != nil {
+		t.Fatalf("Get ui_theme: %v", err)
+	}
+	if got != "ocean" {
+		t.Errorf("Get ui_theme = %q, want %q", got, "ocean")
+	}
+
+	if err := SaveTo(cfg, path); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	loaded, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if loaded.UITheme != "ocean" {
+		t.Errorf("after round-trip UITheme = %q, want %q", loaded.UITheme, "ocean")
 	}
 }


### PR DESCRIPTION
## Summary
- Added `UITheme` field to Config struct with `toml:"ui_theme"` tag, default `"auto"`
- Added to ValidKeys, Set(), Get(), and config display
- Wired into theme initialization in root.go — non-auto values resolve via `theme.FromName()`
- Added config tests for round-trip and default value

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./...` — all 356 tests pass
- [x] `notebook config set ui_theme ocean` persists correctly
- [x] Default "auto" preserves existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)