### PR TITLE
feat: wire theme colors into all lipgloss styles (Closes #89)

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -13,6 +13,7 @@ import (
 	"github.com/oobagi/notebook/internal/model"
 	"github.com/oobagi/notebook/internal/render"
 	"github.com/oobagi/notebook/internal/storage"
+	"github.com/oobagi/notebook/internal/theme"
 )
 
 // EditFunc is called when the user selects a note to edit.
@@ -857,7 +858,7 @@ func (m Model) renderThemeOverlay() string {
 			hintStr = " " + dim.Render(hint)
 		}
 		if i == m.themeCursor {
-			sel := lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+			sel := lipgloss.NewStyle().Foreground(lipgloss.Color(theme.Current().Accent))
 			left.WriteString(fmt.Sprintf("  %s %s%s\n", sel.Render("●"), sel.Render(s), hintStr))
 		} else {
 			left.WriteString(fmt.Sprintf("    %s%s\n", s, hintStr))
@@ -899,7 +900,7 @@ func (m Model) renderThemeOverlay() string {
 
 	previewBox := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("8")).
+		BorderForeground(lipgloss.Color(theme.Current().Border)).
 		Padding(0, 1).
 		Width(previewWidth)
 
@@ -918,7 +919,7 @@ func (m Model) renderThemeOverlay() string {
 	// Outer container.
 	outer := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("8")).
+		BorderForeground(lipgloss.Color(theme.Current().Border)).
 		Padding(0, 1).
 		MaxHeight(h - 2)
 
@@ -1081,7 +1082,7 @@ func (m Model) renderHelpOverlay() string {
 
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("8")).
+		BorderForeground(lipgloss.Color(theme.Current().Border)).
 		Padding(1, 2).
 		Width(36).
 		Align(lipgloss.Left)
@@ -1309,9 +1310,9 @@ func (m Model) formatNotebookLine(nb notebookItem, selected bool) string {
 	countStr := pluralize(nb.noteCount, "note", "notes")
 
 	if selected {
-		bulletStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("6")) // cyan
+		bulletStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(theme.Current().Accent))
 		bullet = bulletStyle.Render("\u25CF") + " "
-		nameStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+		nameStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(theme.Current().Accent))
 		name = nameStyle.Render(display)
 	}
 
@@ -1338,9 +1339,9 @@ func (m Model) formatNoteLine(n model.Note, selected bool) string {
 	}
 
 	if selected {
-		bulletStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+		bulletStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(theme.Current().Accent))
 		bullet = bulletStyle.Render("\u25CF") + " "
-		nameStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+		nameStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(theme.Current().Accent))
 		name = nameStyle.Render(display)
 	}
 

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -10,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/oobagi/notebook/internal/render"
+	"github.com/oobagi/notebook/internal/theme"
 )
 
 // Config holds the configuration for the editor.
@@ -425,7 +426,7 @@ func (m Model) renderHelpOverlay() string {
 
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("8")).
+		BorderForeground(lipgloss.Color(theme.Current().Border)).
 		Padding(1, 2).
 		Width(36).
 		Align(lipgloss.Left)
@@ -516,11 +517,11 @@ func (m Model) renderStatusBar() string {
 	style := lipgloss.NewStyle().Width(width)
 	switch m.statusStyle {
 	case statusSuccess:
-		style = style.Foreground(lipgloss.Color("2")) // green
+		style = style.Foreground(lipgloss.Color(theme.Current().Success))
 	case statusError:
-		style = style.Foreground(lipgloss.Color("1")) // red
+		style = style.Foreground(lipgloss.Color(theme.Current().Error))
 	case statusWarning:
-		style = style.Foreground(lipgloss.Color("3")) // yellow
+		style = style.Foreground(lipgloss.Color(theme.Current().Warning))
 	default:
 		style = style.Faint(true)
 	}


### PR DESCRIPTION
## Summary
- Replaced 9 hardcoded `lipgloss.Color("6")`/`("8")` in browser.go with `theme.Current().Accent`/`.Border`
- Replaced 4 hardcoded color numbers in editor.go with `.Border`/`.Success`/`.Error`/`.Warning`
- Zero hardcoded ANSI color numbers remain in UI code

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./...` — all tests pass
- [x] Dark preset matches current appearance (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)