### PR TITLE
feat: add UI theme tab to theme picker overlay (Closes #90)

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -77,6 +77,11 @@ type Model struct {
 	themeCursor  int      // current selection in theme list
 	themePreview string   // rendered preview for currently highlighted style
 	darkTerminal bool     // true when terminal has dark background
+
+	// Theme picker tab fields (0=glamour style, 1=UI theme).
+	themeTab       int    // active tab in theme picker
+	uiThemeCursor  int    // cursor in UI theme preset list
+	uiThemePreview string // preview for highlighted UI preset
 }
 
 // notebookItem holds pre-fetched metadata for a notebook.
@@ -750,10 +755,11 @@ var styleHints = map[string]string{
 
 func (m Model) startThemePicker() (tea.Model, tea.Cmd) {
 	m.themeMode = true
+	m.themeTab = 0
 	m.themeStyles = availableThemeStyles
 	m.themeCursor = 0
 	m.darkTerminal = lipgloss.HasDarkBackground()
-	// Pre-select the currently active style if set.
+	// Pre-select the currently active glamour style if set.
 	if cfg, err := config.Load(); err == nil && cfg.GlamourStyle != "" {
 		for i, s := range availableThemeStyles {
 			if s == cfg.GlamourStyle {
@@ -763,6 +769,21 @@ func (m Model) startThemePicker() (tea.Model, tea.Cmd) {
 		}
 	}
 	m.themePreview = m.renderThemePreview(m.themeStyles[m.themeCursor])
+
+	// Initialize UI theme cursor to match current config value.
+	m.uiThemeCursor = 0
+	presets := theme.Presets()
+	if cfg, err := config.Load(); err == nil && cfg.UITheme != "" {
+		for i, p := range presets {
+			if p.Name == cfg.UITheme {
+				m.uiThemeCursor = i
+				break
+			}
+		}
+	}
+	if len(presets) > 0 {
+		m.uiThemePreview = m.renderUIThemePreview(presets[m.uiThemeCursor].Name)
+	}
 	return m, nil
 }
 
@@ -772,40 +793,93 @@ func (m Model) handleThemeKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.themeMode = false
 		return m, nil
 
+	case tea.KeyTab:
+		// Toggle between glamour (0) and UI theme (1) tabs.
+		if m.themeTab == 0 {
+			m.themeTab = 1
+		} else {
+			m.themeTab = 0
+		}
+		return m, nil
+
 	case tea.KeyUp:
-		if m.themeCursor > 0 {
-			m.themeCursor--
-			m.themePreview = m.renderThemePreview(m.themeStyles[m.themeCursor])
+		if m.themeTab == 0 {
+			if m.themeCursor > 0 {
+				m.themeCursor--
+				m.themePreview = m.renderThemePreview(m.themeStyles[m.themeCursor])
+			}
+		} else {
+			if m.uiThemeCursor > 0 {
+				m.uiThemeCursor--
+				presets := theme.Presets()
+				if len(presets) > 0 {
+					m.uiThemePreview = m.renderUIThemePreview(presets[m.uiThemeCursor].Name)
+				}
+			}
 		}
 		return m, nil
 
 	case tea.KeyDown:
-		if m.themeCursor < len(m.themeStyles)-1 {
-			m.themeCursor++
-			m.themePreview = m.renderThemePreview(m.themeStyles[m.themeCursor])
+		if m.themeTab == 0 {
+			if m.themeCursor < len(m.themeStyles)-1 {
+				m.themeCursor++
+				m.themePreview = m.renderThemePreview(m.themeStyles[m.themeCursor])
+			}
+		} else {
+			presets := theme.Presets()
+			if m.uiThemeCursor < len(presets)-1 {
+				m.uiThemeCursor++
+				m.uiThemePreview = m.renderUIThemePreview(presets[m.uiThemeCursor].Name)
+			}
 		}
 		return m, nil
 
 	case tea.KeyEnter:
-		selected := m.themeStyles[m.themeCursor]
-		m.themeMode = false
+		if m.themeTab == 0 {
+			selected := m.themeStyles[m.themeCursor]
+			m.themeMode = false
 
-		// Persist to config and apply.
-		cfg, err := config.Load()
-		if err != nil {
-			m.statusText = fmt.Sprintf("Config load error: %s", err)
-			return m, nil
+			// Persist to config and apply.
+			cfg, err := config.Load()
+			if err != nil {
+				m.statusText = fmt.Sprintf("Config load error: %s", err)
+				return m, nil
+			}
+			if err := config.Set(&cfg, "glamour_style", selected); err != nil {
+				m.statusText = fmt.Sprintf("Config error: %s", err)
+				return m, nil
+			}
+			if err := config.Save(cfg); err != nil {
+				m.statusText = fmt.Sprintf("Config save error: %s", err)
+				return m, nil
+			}
+			render.SetGlamourStyle(selected)
+			m.statusText = fmt.Sprintf("Theme set to %q", selected)
+		} else {
+			presets := theme.Presets()
+			if len(presets) == 0 {
+				return m, nil
+			}
+			selected := presets[m.uiThemeCursor]
+			m.themeMode = false
+
+			// Persist to config and apply.
+			cfg, err := config.Load()
+			if err != nil {
+				m.statusText = fmt.Sprintf("Config load error: %s", err)
+				return m, nil
+			}
+			if err := config.Set(&cfg, "ui_theme", selected.Name); err != nil {
+				m.statusText = fmt.Sprintf("Config error: %s", err)
+				return m, nil
+			}
+			if err := config.Save(cfg); err != nil {
+				m.statusText = fmt.Sprintf("Config save error: %s", err)
+				return m, nil
+			}
+			theme.SetTheme(selected)
+			m.statusText = fmt.Sprintf("UI theme set to %s", selected.Name)
 		}
-		if err := config.Set(&cfg, "glamour_style", selected); err != nil {
-			m.statusText = fmt.Sprintf("Config error: %s", err)
-			return m, nil
-		}
-		if err := config.Save(cfg); err != nil {
-			m.statusText = fmt.Sprintf("Config save error: %s", err)
-			return m, nil
-		}
-		render.SetGlamourStyle(selected)
-		m.statusText = fmt.Sprintf("Theme set to %q", selected)
 		return m, nil
 
 	case tea.KeyRunes:
@@ -831,6 +905,35 @@ func (m Model) renderThemePreview(styleName string) string {
 	return render.RenderMarkdownWithStyle(themePreviewSample, previewWidth, styleName)
 }
 
+// renderUIThemePreview generates a mock TUI chrome preview for a UI theme preset.
+func (m Model) renderUIThemePreview(presetName string) string {
+	preset, ok := theme.PresetByName(presetName)
+	if !ok {
+		return "(unknown preset)"
+	}
+
+	accent := lipgloss.NewStyle().Foreground(lipgloss.Color(preset.Accent))
+	border := lipgloss.NewStyle().Foreground(lipgloss.Color(preset.Border))
+	statusStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(preset.StatusFg)).
+		Background(lipgloss.Color(preset.StatusBg))
+
+	var b strings.Builder
+	b.WriteString(border.Render("\u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510"))
+	b.WriteString("\n")
+	b.WriteString(border.Render("\u2502") + " " + accent.Render("\u25cf") + " My notebook   " + border.Render("\u2502"))
+	b.WriteString("\n")
+	b.WriteString(border.Render("\u2502") + "   Another note   " + border.Render("\u2502"))
+	b.WriteString("\n")
+	b.WriteString(border.Render("\u2502") + "   Third item     " + border.Render("\u2502"))
+	b.WriteString("\n")
+	b.WriteString(border.Render("\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518"))
+	b.WriteString("\n")
+	b.WriteString("  " + statusStyle.Render(" Status: saved \u2713 "))
+
+	return b.String()
+}
+
 // renderThemeOverlay builds the theme picker overlay with style list and preview.
 func (m Model) renderThemeOverlay() string {
 	w := m.width
@@ -842,54 +945,92 @@ func (m Model) renderThemeOverlay() string {
 		h = 24
 	}
 
-	// Left pane: style list.
-	listWidth := 30
-	var left strings.Builder
 	bold := lipgloss.NewStyle().Bold(true)
 	dim := lipgloss.NewStyle().Faint(true)
-	left.WriteString(bold.Render("  Glamour Style"))
-	left.WriteString("\n")
-	left.WriteString("  ─────────────────\n")
 
-	for i, s := range m.themeStyles {
-		hint := styleHints[s]
-		hintStr := ""
-		if hint != "" {
-			hintStr = " " + dim.Render(hint)
+	// Tab bar.
+	var tabBar strings.Builder
+	glamourTab := "Glamour Style"
+	uiTab := "UI Theme"
+	if m.themeTab == 0 {
+		tabBar.WriteString("  " + bold.Render("["+glamourTab+"]"))
+		tabBar.WriteString("  " + dim.Render("["+uiTab+"]"))
+	} else {
+		tabBar.WriteString("  " + dim.Render("["+glamourTab+"]"))
+		tabBar.WriteString("  " + bold.Render("["+uiTab+"]"))
+	}
+	tabBar.WriteString("\n")
+	tabBar.WriteString("  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n")
+
+	// Left pane: list for active tab.
+	listWidth := 30
+	var left strings.Builder
+	left.WriteString(tabBar.String())
+
+	if m.themeTab == 0 {
+		// Glamour style list.
+		for i, s := range m.themeStyles {
+			hint := styleHints[s]
+			hintStr := ""
+			if hint != "" {
+				hintStr = " " + dim.Render(hint)
+			}
+			if i == m.themeCursor {
+				sel := lipgloss.NewStyle().Foreground(lipgloss.Color(theme.Current().Accent))
+				left.WriteString(fmt.Sprintf("  %s %s%s\n", sel.Render("\u25cf"), sel.Render(s), hintStr))
+			} else {
+				left.WriteString(fmt.Sprintf("    %s%s\n", s, hintStr))
+			}
 		}
-		if i == m.themeCursor {
-			sel := lipgloss.NewStyle().Foreground(lipgloss.Color(theme.Current().Accent))
-			left.WriteString(fmt.Sprintf("  %s %s%s\n", sel.Render("●"), sel.Render(s), hintStr))
-		} else {
-			left.WriteString(fmt.Sprintf("    %s%s\n", s, hintStr))
+
+		// Show warning when highlighted style conflicts with terminal background.
+		if cur := m.themeStyles[m.themeCursor]; cur != "auto" {
+			curHint := styleHints[cur]
+			conflict := false
+			if m.darkTerminal && curHint == "(light bg)" {
+				conflict = true
+			}
+			if !m.darkTerminal && curHint == "(dark bg)" {
+				conflict = true
+			}
+			if conflict {
+				left.WriteString("\n")
+				left.WriteString(dim.Render("  \u26a0 May be hard to read\n    on your terminal"))
+				left.WriteString("\n")
+			}
+		}
+	} else {
+		// UI theme preset list.
+		presets := theme.Presets()
+		for i, p := range presets {
+			bgHint := ""
+			if p.Background != "" {
+				bgHint = " " + dim.Render("("+p.Background+" bg)")
+			}
+			if i == m.uiThemeCursor {
+				sel := lipgloss.NewStyle().Foreground(lipgloss.Color(theme.Current().Accent))
+				left.WriteString(fmt.Sprintf("  %s %s%s\n", sel.Render("\u25cf"), sel.Render(p.Name), bgHint))
+			} else {
+				left.WriteString(fmt.Sprintf("    %s%s\n", p.Name, bgHint))
+			}
 		}
 	}
 
-	// Show warning when highlighted style conflicts with terminal background.
-	if cur := m.themeStyles[m.themeCursor]; cur != "auto" {
-		curHint := styleHints[cur]
-		conflict := false
-		if m.darkTerminal && curHint == "(light bg)" {
-			conflict = true
-		}
-		if !m.darkTerminal && curHint == "(dark bg)" {
-			conflict = true
-		}
-		if conflict {
-			left.WriteString("\n")
-			left.WriteString(dim.Render("  \u26a0 May be hard to read\n    on your terminal"))
-			left.WriteString("\n")
-		}
-	}
-
-	// Right pane: markdown preview.
+	// Right pane: preview for active tab.
 	previewWidth := w - listWidth - 10
 	if previewWidth < 20 {
 		previewWidth = 20
 	}
 
+	var previewContent string
+	if m.themeTab == 0 {
+		previewContent = m.themePreview
+	} else {
+		previewContent = m.uiThemePreview
+	}
+
 	// Clamp preview lines to fit the overlay height.
-	previewLines := strings.Split(m.themePreview, "\n")
+	previewLines := strings.Split(previewContent, "\n")
 	maxPreview := h - 8
 	if maxPreview < 1 {
 		maxPreview = 1
@@ -926,7 +1067,7 @@ func (m Model) renderThemeOverlay() string {
 	rendered := outer.Render(combined)
 
 	// Status hint.
-	statusHint := dim.Render("  ↑/↓ navigate · Enter apply · Esc cancel")
+	statusHint := dim.Render("  \u2191/\u2193 navigate \u00b7 Tab switch \u00b7 Enter apply \u00b7 Esc cancel")
 
 	full := rendered + "\n" + statusHint
 

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -1588,3 +1588,202 @@ func TestThemePickerConflictWarning(t *testing.T) {
 		t.Errorf("auto style should never show conflict warning, got:\n%s", view)
 	}
 }
+
+func TestThemeTabSwitching(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Open theme picker.
+	m = sendRune(t, m, 't')
+	if !m.themeMode {
+		t.Fatal("expected themeMode to be true")
+	}
+
+	// Should start on tab 0 (glamour).
+	if m.themeTab != 0 {
+		t.Errorf("expected themeTab 0, got %d", m.themeTab)
+	}
+
+	// Press Tab to switch to UI theme tab.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+
+	if m.themeTab != 1 {
+		t.Errorf("expected themeTab 1 after Tab, got %d", m.themeTab)
+	}
+
+	// Press Tab again to switch back.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+
+	if m.themeTab != 0 {
+		t.Errorf("expected themeTab 0 after second Tab, got %d", m.themeTab)
+	}
+}
+
+func TestUIThemeCursorNavigation(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Open theme picker and switch to UI theme tab.
+	m = sendRune(t, m, 't')
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+
+	if m.themeTab != 1 {
+		t.Fatalf("expected themeTab 1, got %d", m.themeTab)
+	}
+
+	// Initial cursor should be at 0.
+	if m.uiThemeCursor != 0 {
+		t.Errorf("expected uiThemeCursor 0, got %d", m.uiThemeCursor)
+	}
+
+	// Move down.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(Model)
+
+	if m.uiThemeCursor != 1 {
+		t.Errorf("expected uiThemeCursor 1 after down, got %d", m.uiThemeCursor)
+	}
+
+	// Move up back to 0.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(Model)
+
+	if m.uiThemeCursor != 0 {
+		t.Errorf("expected uiThemeCursor 0 after up, got %d", m.uiThemeCursor)
+	}
+
+	// Move up at top should clamp.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(Model)
+
+	if m.uiThemeCursor != 0 {
+		t.Errorf("expected uiThemeCursor to stay at 0, got %d", m.uiThemeCursor)
+	}
+}
+
+func TestUIThemeSelectDoesNotPanic(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+
+	// Open theme picker, switch to UI theme tab, press Enter.
+	m = sendRune(t, m, 't')
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+
+	// Press Enter to select UI theme — should not panic.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+
+	if m.themeMode {
+		t.Error("expected themeMode to be false after Enter")
+	}
+
+	if !containsStr(m.statusText, "UI theme set to") {
+		t.Errorf("expected status to contain 'UI theme set to', got %q", m.statusText)
+	}
+}
+
+func TestThemePickerTabBarInView(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+	m = sendRune(t, m, 't')
+
+	view := m.View()
+	if !containsStr(view, "Glamour Style") {
+		t.Errorf("view should contain 'Glamour Style' tab, got:\n%s", view)
+	}
+	if !containsStr(view, "UI Theme") {
+		t.Errorf("view should contain 'UI Theme' tab, got:\n%s", view)
+	}
+	if !containsStr(view, "Tab switch") {
+		t.Errorf("view should contain 'Tab switch' hint, got:\n%s", view)
+	}
+}
+
+func TestThemePickerUIThemeTabView(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+	m = sendRune(t, m, 't')
+
+	// Switch to UI theme tab.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+
+	view := m.View()
+	// Should show preset names (dark, light, ocean, etc.).
+	if !containsStr(view, "dark") {
+		t.Errorf("UI theme tab should show 'dark' preset, got:\n%s", view)
+	}
+	if !containsStr(view, "ocean") {
+		t.Errorf("UI theme tab should show 'ocean' preset, got:\n%s", view)
+	}
+}
+
+func TestThemePickerUIThemePreviewContent(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+	m = sendRune(t, m, 't')
+
+	// Switch to UI theme tab.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+
+	view := m.View()
+	// The mock TUI preview should contain these elements.
+	if !containsStr(view, "My notebook") {
+		t.Errorf("UI theme preview should contain 'My notebook', got:\n%s", view)
+	}
+	if !containsStr(view, "Status: saved") {
+		t.Errorf("UI theme preview should contain 'Status: saved', got:\n%s", view)
+	}
+}
+
+func TestGlamourTabNavigationUnaffectedByUIThemeCursor(t *testing.T) {
+	s := setupTestStore(t, map[string][]string{
+		"work": {"todo"},
+	})
+
+	m := initModel(t, s)
+	m = sendRune(t, m, 't')
+
+	// Move glamour cursor down.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(Model)
+	glamourPos := m.themeCursor
+
+	// Switch to UI theme tab and move.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(Model)
+
+	// Switch back to glamour tab.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+
+	// Glamour cursor should be preserved.
+	if m.themeCursor != glamourPos {
+		t.Errorf("expected glamour themeCursor to be %d, got %d", glamourPos, m.themeCursor)
+	}
+}


### PR DESCRIPTION
## Summary
- Added second tab to theme picker: [Glamour Style] [UI Theme]
- Tab key switches between tabs; Up/Down navigates active list
- UI theme tab lists all presets from `theme.Presets()` with background hints
- Preview pane shows mock TUI chrome rendered with preset colors
- Enter on UI theme tab saves to config and applies immediately
- 7 new tests for tab switching, cursor navigation, and selection

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./...` — all 363 tests pass
- [x] Tab key switches between Glamour Style and UI Theme tabs
- [x] Selecting a UI theme applies and persists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)