### PR TITLE
feat: embed community Glamour styles into the binary (Closes #94)

### DIFF
--- a/styles/community/catppuccin-mocha.json
+++ b/styles/community/catppuccin-mocha.json
@@ -1,0 +1,57 @@
+{
+  "document": {
+    "color": "#CDD6F4",
+    "margin": 2
+  },
+  "heading": {
+    "bold": true,
+    "color": "#89B4FA"
+  },
+  "h1": {
+    "prefix": "# ",
+    "bold": true,
+    "color": "#89B4FA"
+  },
+  "h2": {
+    "prefix": "## ",
+    "bold": true,
+    "color": "#CBA6F7"
+  },
+  "h3": {
+    "prefix": "### ",
+    "bold": true,
+    "color": "#A6E3A1"
+  },
+  "code": {
+    "color": "#F9E2AF"
+  },
+  "code_block": {
+    "color": "#F9E2AF",
+    "margin": 2,
+    "chroma": {
+      "theme": "catppuccin-mocha"
+    }
+  },
+  "link": {
+    "color": "#89DCEB",
+    "underline": true
+  },
+  "link_text": {
+    "color": "#F5C2E7",
+    "bold": true
+  },
+  "strong": {
+    "bold": true,
+    "color": "#F38BA8"
+  },
+  "emph": {
+    "italic": true,
+    "color": "#F5C2E7"
+  },
+  "list": {
+    "level_indent": 2
+  },
+  "item": {
+    "block_prefix": "\u2022 "
+  }
+}

--- a/styles/community/gruvbox.json
+++ b/styles/community/gruvbox.json
@@ -1,0 +1,57 @@
+{
+  "document": {
+    "color": "#EBDBB2",
+    "margin": 2
+  },
+  "heading": {
+    "bold": true,
+    "color": "#FE8019"
+  },
+  "h1": {
+    "prefix": "# ",
+    "bold": true,
+    "color": "#FE8019"
+  },
+  "h2": {
+    "prefix": "## ",
+    "bold": true,
+    "color": "#8EC07C"
+  },
+  "h3": {
+    "prefix": "### ",
+    "bold": true,
+    "color": "#B8BB26"
+  },
+  "code": {
+    "color": "#FABD2F"
+  },
+  "code_block": {
+    "color": "#FABD2F",
+    "margin": 2,
+    "chroma": {
+      "theme": "gruvbox"
+    }
+  },
+  "link": {
+    "color": "#83A598",
+    "underline": true
+  },
+  "link_text": {
+    "color": "#D3869B",
+    "bold": true
+  },
+  "strong": {
+    "bold": true,
+    "color": "#FB4934"
+  },
+  "emph": {
+    "italic": true,
+    "color": "#D3869B"
+  },
+  "list": {
+    "level_indent": 2
+  },
+  "item": {
+    "block_prefix": "\u2022 "
+  }
+}

--- a/styles/community/nord.json
+++ b/styles/community/nord.json
@@ -1,0 +1,57 @@
+{
+  "document": {
+    "color": "#D8DEE9",
+    "margin": 2
+  },
+  "heading": {
+    "bold": true,
+    "color": "#88C0D0"
+  },
+  "h1": {
+    "prefix": "# ",
+    "bold": true,
+    "color": "#88C0D0"
+  },
+  "h2": {
+    "prefix": "## ",
+    "bold": true,
+    "color": "#81A1C1"
+  },
+  "h3": {
+    "prefix": "### ",
+    "bold": true,
+    "color": "#5E81AC"
+  },
+  "code": {
+    "color": "#EBCB8B"
+  },
+  "code_block": {
+    "color": "#EBCB8B",
+    "margin": 2,
+    "chroma": {
+      "theme": "nord"
+    }
+  },
+  "link": {
+    "color": "#8FBCBB",
+    "underline": true
+  },
+  "link_text": {
+    "color": "#A3BE8C",
+    "bold": true
+  },
+  "strong": {
+    "bold": true,
+    "color": "#BF616A"
+  },
+  "emph": {
+    "italic": true,
+    "color": "#B48EAD"
+  },
+  "list": {
+    "level_indent": 2
+  },
+  "item": {
+    "block_prefix": "\u2022 "
+  }
+}

--- a/styles/community/solarized-dark.json
+++ b/styles/community/solarized-dark.json
@@ -1,0 +1,57 @@
+{
+  "document": {
+    "color": "#839496",
+    "margin": 2
+  },
+  "heading": {
+    "bold": true,
+    "color": "#268BD2"
+  },
+  "h1": {
+    "prefix": "# ",
+    "bold": true,
+    "color": "#268BD2"
+  },
+  "h2": {
+    "prefix": "## ",
+    "bold": true,
+    "color": "#2AA198"
+  },
+  "h3": {
+    "prefix": "### ",
+    "bold": true,
+    "color": "#859900"
+  },
+  "code": {
+    "color": "#B58900"
+  },
+  "code_block": {
+    "color": "#B58900",
+    "margin": 2,
+    "chroma": {
+      "theme": "solarized-dark"
+    }
+  },
+  "link": {
+    "color": "#2AA198",
+    "underline": true
+  },
+  "link_text": {
+    "color": "#6C71C4",
+    "bold": true
+  },
+  "strong": {
+    "bold": true,
+    "color": "#CB4B16"
+  },
+  "emph": {
+    "italic": true,
+    "color": "#D33682"
+  },
+  "list": {
+    "level_indent": 2
+  },
+  "item": {
+    "block_prefix": "\u2022 "
+  }
+}

--- a/styles/embed.go
+++ b/styles/embed.go
@@ -1,0 +1,55 @@
+// Package styles provides embedded community Glamour style definitions.
+//
+// The JSON files live under community/ and are compiled into the binary
+// via go:embed so no external file access is needed at runtime.
+package styles
+
+import (
+	"embed"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+)
+
+//go:embed community/*.json
+var communityFS embed.FS
+
+// List returns the names of all embedded community styles, sorted
+// alphabetically. Names are the JSON filenames without the .json extension
+// (e.g. "gruvbox", "nord").
+func List() []string {
+	entries, err := communityFS.ReadDir("community")
+	if err != nil {
+		return nil
+	}
+
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasSuffix(name, ".json") {
+			names = append(names, strings.TrimSuffix(name, ".json"))
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Load returns the raw JSON bytes of the named community style.
+// The name should not include the .json extension.
+func Load(name string) ([]byte, error) {
+	data, err := communityFS.ReadFile(path.Join("community", name+".json"))
+	if err != nil {
+		return nil, fmt.Errorf("community style %q not found", name)
+	}
+	return data, nil
+}
+
+// Has reports whether a community style with the given name exists.
+func Has(name string) bool {
+	_, err := communityFS.ReadFile(path.Join("community", name+".json"))
+	return err == nil
+}

--- a/styles/embed_test.go
+++ b/styles/embed_test.go
@@ -1,0 +1,68 @@
+package styles
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestList(t *testing.T) {
+	names := List()
+
+	want := []string{"catppuccin-mocha", "gruvbox", "nord", "solarized-dark"}
+	if len(names) != len(want) {
+		t.Fatalf("List() returned %d names, want %d: %v", len(names), len(want), names)
+	}
+	for i, name := range names {
+		if name != want[i] {
+			t.Errorf("List()[%d] = %q, want %q", i, name, want[i])
+		}
+	}
+}
+
+func TestLoad(t *testing.T) {
+	for _, name := range List() {
+		t.Run(name, func(t *testing.T) {
+			data, err := Load(name)
+			if err != nil {
+				t.Fatalf("Load(%q) error: %v", name, err)
+			}
+			if len(data) == 0 {
+				t.Fatalf("Load(%q) returned empty data", name)
+			}
+
+			// Verify it is valid JSON.
+			var obj map[string]interface{}
+			if err := json.Unmarshal(data, &obj); err != nil {
+				t.Fatalf("Load(%q) returned invalid JSON: %v", name, err)
+			}
+
+			// Verify expected top-level keys exist.
+			for _, key := range []string{"document", "heading", "h1", "code_block"} {
+				if _, ok := obj[key]; !ok {
+					t.Errorf("Load(%q) JSON missing expected key %q", name, key)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadNotFound(t *testing.T) {
+	_, err := Load("nonexistent-style")
+	if err == nil {
+		t.Fatal("Load(\"nonexistent-style\") should return an error")
+	}
+}
+
+func TestHas(t *testing.T) {
+	// Existing styles should return true.
+	for _, name := range List() {
+		if !Has(name) {
+			t.Errorf("Has(%q) = false, want true", name)
+		}
+	}
+
+	// Nonexistent style should return false.
+	if Has("nonexistent-style") {
+		t.Error("Has(\"nonexistent-style\") = true, want false")
+	}
+}


### PR DESCRIPTION
## Summary
- Created `styles/` package with `go:embed community/*.json` directive
- Seeded 4 community styles: solarized-dark, gruvbox, catppuccin-mocha, nord
- Exported `List()`, `Load()`, and `Has()` functions
- Each JSON file is a valid Glamour StyleConfig with palette-specific colors

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./...` — all 371 tests pass
- [x] `List()` returns 4 sorted names
- [x] `Load("gruvbox")` returns valid JSON with expected keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)