### PR TITLE
feat: wire community styles into ResolveGlamourStyle (Closes #95)

### DIFF
--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -1,10 +1,12 @@
 package render
 
 import (
+	"log"
 	"os"
 
 	"github.com/charmbracelet/glamour"
 	"github.com/oobagi/notebook/internal/theme"
+	"github.com/oobagi/notebook/styles"
 	"golang.org/x/term"
 )
 
@@ -66,13 +68,8 @@ func SetGlamourStyle(style string) {
 // This is used by the theme picker to preview different styles without
 // changing the global glamour_style setting.
 func RenderMarkdownWithStyle(content string, width int, styleName string) string {
-	style, isFile := theme.ResolveGlamourStyle(styleName)
-	var styleOpt glamour.TermRendererOption
-	if isFile {
-		styleOpt = glamour.WithStylesFromJSONFile(style)
-	} else {
-		styleOpt = glamour.WithStandardStyle(style)
-	}
+	style, source := theme.ResolveGlamourStyle(styleName)
+	styleOpt := styleOptionFromSource(style, source)
 
 	opts := []glamour.TermRendererOption{styleOpt}
 	if width > 0 {
@@ -95,11 +92,26 @@ func RenderMarkdownWithStyle(content string, width int, styleName string) string
 
 // resolveStyleOption returns the appropriate glamour TermRendererOption
 // based on the user's glamour_style config. It supports built-in style
-// names and custom JSON file paths.
+// names, community styles, and custom JSON file paths.
 func resolveStyleOption() glamour.TermRendererOption {
-	style, isFile := theme.ResolveGlamourStyle(glamourStyleOverride)
-	if isFile {
+	style, source := theme.ResolveGlamourStyle(glamourStyleOverride)
+	return styleOptionFromSource(style, source)
+}
+
+// styleOptionFromSource converts a resolved style name and source into the
+// corresponding glamour TermRendererOption.
+func styleOptionFromSource(style string, source theme.StyleSource) glamour.TermRendererOption {
+	switch source {
+	case theme.StyleFile:
 		return glamour.WithStylesFromJSONFile(style)
+	case theme.StyleCommunity:
+		data, err := styles.Load(style)
+		if err != nil {
+			log.Printf("failed to load community style %q: %v", style, err)
+			return glamour.WithStandardStyle("dark")
+		}
+		return glamour.WithStylesFromJSONBytes(data)
+	default:
+		return glamour.WithStandardStyle(style)
 	}
-	return glamour.WithStandardStyle(style)
 }

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -68,3 +68,18 @@ func TestRenderMarkdownCustomWidth(t *testing.T) {
 		t.Errorf("expected 'Narrow' in output, got %q", out)
 	}
 }
+
+func TestRenderMarkdownWithCommunityStyle(t *testing.T) {
+	md := "# Community Style\n\nRendered with an embedded community style."
+	out := RenderMarkdownWithStyle(md, 80, "gruvbox")
+	if out == "" {
+		t.Fatal("expected non-empty output")
+	}
+	// ANSI escape codes may split words, so check each word individually.
+	if !strings.Contains(out, "Community") {
+		t.Errorf("expected 'Community' in output, got %q", out)
+	}
+	if !strings.Contains(out, "embedded") {
+		t.Errorf("expected 'embedded' in output, got %q", out)
+	}
+}

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/oobagi/notebook/styles"
 )
 
 // allPresets holds every named preset in display order.
@@ -217,32 +218,50 @@ var builtinGlamourStyles = map[string]bool{
 	"pink":        true,
 }
 
+// StyleSource indicates how a resolved glamour style should be loaded.
+type StyleSource int
+
+const (
+	// StyleBuiltin means the style is a glamour built-in name (e.g. "dark", "dracula").
+	StyleBuiltin StyleSource = iota
+	// StyleFile means the style is an absolute file path to a JSON style file.
+	StyleFile
+	// StyleCommunity means the style is an embedded community style name.
+	StyleCommunity
+)
+
 // ResolveGlamourStyle determines the glamour style to use based on the
 // user's glamour_style config value and the active theme. The returned
-// string is either a built-in style name or an absolute path to a JSON
-// style file. The boolean indicates whether the result is a file path.
+// string is either a built-in style name, an embedded community style
+// name, or an absolute path to a JSON style file. The StyleSource
+// indicates which kind of value was returned.
 //
 // When glamourCfg is empty or "auto", the theme's own GlamourStyle is used
 // (which is "dark" or "light" depending on terminal detection).
-func ResolveGlamourStyle(glamourCfg string) (style string, isFilePath bool) {
+func ResolveGlamourStyle(glamourCfg string) (style string, source StyleSource) {
 	glamourCfg = strings.TrimSpace(glamourCfg)
 
 	// Empty or "auto" — defer to the active theme's default glamour style.
 	if glamourCfg == "" || glamourCfg == "auto" {
-		return current.GlamourStyle, false
+		return current.GlamourStyle, StyleBuiltin
 	}
 
 	// A known built-in style name.
 	if builtinGlamourStyles[glamourCfg] {
-		return glamourCfg, false
+		return glamourCfg, StyleBuiltin
+	}
+
+	// An embedded community style.
+	if styles.Has(glamourCfg) {
+		return glamourCfg, StyleCommunity
 	}
 
 	// Treat as a file path to a custom JSON style. If the file exists,
 	// return the path; otherwise fall back to the theme default.
 	if _, err := os.Stat(glamourCfg); err == nil {
-		return glamourCfg, true
+		return glamourCfg, StyleFile
 	}
 
 	// Unknown value — fall back to theme default.
-	return current.GlamourStyle, false
+	return current.GlamourStyle, StyleBuiltin
 }

--- a/internal/theme/theme_test.go
+++ b/internal/theme/theme_test.go
@@ -146,23 +146,23 @@ func TestPresetByNameNotFound(t *testing.T) {
 
 func TestResolveGlamourStyleAuto(t *testing.T) {
 	SetTheme(Dark)
-	style, isFile := ResolveGlamourStyle("auto")
+	style, source := ResolveGlamourStyle("auto")
 	if style != "dark" {
 		t.Errorf("ResolveGlamourStyle(\"auto\") = %q, want %q", style, "dark")
 	}
-	if isFile {
-		t.Error("expected isFile=false for auto")
+	if source != StyleBuiltin {
+		t.Errorf("expected source=StyleBuiltin for auto, got %d", source)
 	}
 }
 
 func TestResolveGlamourStyleEmpty(t *testing.T) {
 	SetTheme(Light)
-	style, isFile := ResolveGlamourStyle("")
+	style, source := ResolveGlamourStyle("")
 	if style != "light" {
 		t.Errorf("ResolveGlamourStyle(\"\") = %q, want %q", style, "light")
 	}
-	if isFile {
-		t.Error("expected isFile=false for empty")
+	if source != StyleBuiltin {
+		t.Errorf("expected source=StyleBuiltin for empty, got %d", source)
 	}
 }
 
@@ -172,14 +172,26 @@ func TestResolveGlamourStyleBuiltin(t *testing.T) {
 	builtins := []string{"dark", "light", "dracula", "tokyo-night", "notty", "ascii", "pink"}
 	for _, name := range builtins {
 		t.Run(name, func(t *testing.T) {
-			style, isFile := ResolveGlamourStyle(name)
+			style, source := ResolveGlamourStyle(name)
 			if style != name {
 				t.Errorf("ResolveGlamourStyle(%q) = %q, want %q", name, style, name)
 			}
-			if isFile {
-				t.Errorf("expected isFile=false for built-in %q", name)
+			if source != StyleBuiltin {
+				t.Errorf("expected source=StyleBuiltin for built-in %q, got %d", name, source)
 			}
 		})
+	}
+}
+
+func TestResolveGlamourStyleCommunity(t *testing.T) {
+	SetTheme(Dark)
+
+	style, source := ResolveGlamourStyle("gruvbox")
+	if style != "gruvbox" {
+		t.Errorf("ResolveGlamourStyle(\"gruvbox\") = %q, want %q", style, "gruvbox")
+	}
+	if source != StyleCommunity {
+		t.Errorf("expected source=StyleCommunity for gruvbox, got %d", source)
 	}
 }
 
@@ -192,35 +204,35 @@ func TestResolveGlamourStyleCustomFile(t *testing.T) {
 		t.Fatalf("write custom style: %v", err)
 	}
 
-	style, isFile := ResolveGlamourStyle(jsonPath)
+	style, source := ResolveGlamourStyle(jsonPath)
 	if style != jsonPath {
 		t.Errorf("ResolveGlamourStyle(%q) = %q, want file path", jsonPath, style)
 	}
-	if !isFile {
-		t.Error("expected isFile=true for custom JSON file")
+	if source != StyleFile {
+		t.Errorf("expected source=StyleFile for custom JSON file, got %d", source)
 	}
 }
 
 func TestResolveGlamourStyleMissingFile(t *testing.T) {
 	SetTheme(Dark)
 
-	style, isFile := ResolveGlamourStyle("/nonexistent/style.json")
+	style, source := ResolveGlamourStyle("/nonexistent/style.json")
 	if style != "dark" {
 		t.Errorf("ResolveGlamourStyle with missing file = %q, want theme default %q", style, "dark")
 	}
-	if isFile {
-		t.Error("expected isFile=false for missing file")
+	if source != StyleBuiltin {
+		t.Errorf("expected source=StyleBuiltin for missing file, got %d", source)
 	}
 }
 
 func TestResolveGlamourStyleUnknownValue(t *testing.T) {
 	SetTheme(Light)
 
-	style, isFile := ResolveGlamourStyle("nonexistent-style")
+	style, source := ResolveGlamourStyle("nonexistent-style")
 	if style != "light" {
 		t.Errorf("ResolveGlamourStyle(\"nonexistent-style\") = %q, want theme default %q", style, "light")
 	}
-	if isFile {
-		t.Error("expected isFile=false for unknown value")
+	if source != StyleBuiltin {
+		t.Errorf("expected source=StyleBuiltin for unknown value, got %d", source)
 	}
 }


### PR DESCRIPTION
## Summary
- Added `StyleSource` type with `StyleBuiltin`, `StyleFile`, `StyleCommunity` constants
- Extended `ResolveGlamourStyle` to check community styles between built-in and file-path
- Updated render package to load embedded JSON bytes for community styles
- Updated all existing tests for new return type, added community style tests

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./...` — all 373 tests pass
- [x] `ResolveGlamourStyle("gruvbox")` returns StyleCommunity
- [x] Rendering with community style works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)