### PR TITLE
feat: show community styles in theme picker (Closes #96)

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oobagi/notebook/internal/render"
 	"github.com/oobagi/notebook/internal/storage"
 	"github.com/oobagi/notebook/internal/theme"
+	"github.com/oobagi/notebook/styles"
 )
 
 // EditFunc is called when the user selects a note to edit.
@@ -733,35 +734,53 @@ fmt.Println("hello world")
 > This is an admonition note.
 `
 
-// availableThemeStyles lists the glamour style names shown in the picker.
-var availableThemeStyles = []string{
-	"auto",
-	"dark",
-	"light",
-	"dracula",
-	"tokyo-night",
-	"pink",
+// buildThemeStyles returns the glamour style names shown in the picker,
+// combining built-in styles with community styles separated by a divider.
+func buildThemeStyles() []string {
+	builtin := []string{"auto", "dark", "light", "dracula", "tokyo-night", "pink"}
+	community := styles.List() // returns sorted community names
+
+	result := make([]string, 0, len(builtin)+1+len(community))
+	result = append(result, builtin...)
+	if len(community) > 0 {
+		result = append(result, "---") // divider marker
+		result = append(result, community...)
+	}
+	return result
+}
+
+// buildStyleHints returns background compatibility hints for all styles.
+func buildStyleHints() map[string]string {
+	hints := map[string]string{
+		"auto":        "",
+		"dark":        "(dark bg)",
+		"light":       "(light bg)",
+		"dracula":     "(dark bg)",
+		"tokyo-night": "(dark bg)",
+		"pink":        "(dark bg)",
+	}
+	// All community styles are designed for dark backgrounds.
+	for _, name := range styles.List() {
+		hints[name] = "(dark bg)"
+	}
+	return hints
 }
 
 // styleHints maps each style name to its intended background compatibility.
-var styleHints = map[string]string{
-	"auto":        "",
-	"dark":        "(dark bg)",
-	"light":       "(light bg)",
-	"dracula":     "(dark bg)",
-	"tokyo-night": "(dark bg)",
-	"pink":        "(dark bg)",
-}
+var styleHints = buildStyleHints()
 
 func (m Model) startThemePicker() (tea.Model, tea.Cmd) {
 	m.themeMode = true
 	m.themeTab = 0
-	m.themeStyles = availableThemeStyles
+	m.themeStyles = buildThemeStyles()
 	m.themeCursor = 0
 	m.darkTerminal = lipgloss.HasDarkBackground()
 	// Pre-select the currently active glamour style if set.
 	if cfg, err := config.Load(); err == nil && cfg.GlamourStyle != "" {
-		for i, s := range availableThemeStyles {
+		for i, s := range m.themeStyles {
+			if s == "---" {
+				continue
+			}
 			if s == cfg.GlamourStyle {
 				m.themeCursor = i
 				break
@@ -806,6 +825,10 @@ func (m Model) handleThemeKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.themeTab == 0 {
 			if m.themeCursor > 0 {
 				m.themeCursor--
+				// Skip the divider.
+				if m.themeStyles[m.themeCursor] == "---" && m.themeCursor > 0 {
+					m.themeCursor--
+				}
 				m.themePreview = m.renderThemePreview(m.themeStyles[m.themeCursor])
 			}
 		} else {
@@ -823,6 +846,10 @@ func (m Model) handleThemeKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.themeTab == 0 {
 			if m.themeCursor < len(m.themeStyles)-1 {
 				m.themeCursor++
+				// Skip the divider.
+				if m.themeStyles[m.themeCursor] == "---" && m.themeCursor < len(m.themeStyles)-1 {
+					m.themeCursor++
+				}
 				m.themePreview = m.renderThemePreview(m.themeStyles[m.themeCursor])
 			}
 		} else {
@@ -970,6 +997,10 @@ func (m Model) renderThemeOverlay() string {
 	if m.themeTab == 0 {
 		// Glamour style list.
 		for i, s := range m.themeStyles {
+			if s == "---" {
+				left.WriteString(dim.Render("  ── community ──") + "\n")
+				continue
+			}
 			hint := styleHints[s]
 			hintStr := ""
 			if hint != "" {

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -7,6 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/oobagi/notebook/internal/storage"
+	"github.com/oobagi/notebook/styles"
 )
 
 // setupTestStore creates a temp directory with optional notebooks and notes.
@@ -1428,7 +1429,16 @@ func TestBrowserThemePickerStyles(t *testing.T) {
 	m := initModel(t, s)
 	m = sendRune(t, m, 't')
 
-	expected := []string{"auto", "dark", "light", "dracula", "tokyo-night", "pink"}
+	// Built-in styles come first, then "---" divider, then community styles.
+	builtin := []string{"auto", "dark", "light", "dracula", "tokyo-night", "pink"}
+	community := styles.List()
+	expected := make([]string, 0, len(builtin)+1+len(community))
+	expected = append(expected, builtin...)
+	if len(community) > 0 {
+		expected = append(expected, "---")
+		expected = append(expected, community...)
+	}
+
 	if len(m.themeStyles) != len(expected) {
 		t.Fatalf("expected %d styles, got %d", len(expected), len(m.themeStyles))
 	}
@@ -1486,8 +1496,11 @@ func TestBrowserHelpShowsThemeKey(t *testing.T) {
 }
 
 func TestStyleHintsMap(t *testing.T) {
-	// Every entry in availableThemeStyles must have an entry in styleHints.
-	for _, s := range availableThemeStyles {
+	// Every entry in buildThemeStyles must have an entry in styleHints (except the divider).
+	for _, s := range buildThemeStyles() {
+		if s == "---" {
+			continue
+		}
 		if _, ok := styleHints[s]; !ok {
 			t.Errorf("styleHints missing entry for %q", s)
 		}
@@ -1502,6 +1515,13 @@ func TestStyleHintsMap(t *testing.T) {
 	for _, s := range []string{"dark", "dracula", "tokyo-night", "pink"} {
 		if styleHints[s] != "(dark bg)" {
 			t.Errorf("expected %q hint to be \"(dark bg)\", got %q", s, styleHints[s])
+		}
+	}
+
+	// Community styles should also have "(dark bg)" hint.
+	for _, s := range styles.List() {
+		if styleHints[s] != "(dark bg)" {
+			t.Errorf("expected community style %q hint to be \"(dark bg)\", got %q", s, styleHints[s])
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Dynamic style list combines built-in + community styles with visual separator
- Cursor skips the "── community ──" divider during navigation
- Community styles show "(dark bg)" hints and render live markdown previews
- Updated tests to handle dynamic style list

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./...` — all tests pass
- [x] Community styles appear below divider in picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)