### PR TITLE
feat: auto-dismiss status messages after timeout (Closes #92)

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -65,6 +66,7 @@ type Model struct {
 
 	// Temporary status message shown in the status bar.
 	statusText string
+	statusGen  int // generation counter for auto-dismiss
 
 	// View mode fields (rendered markdown overlay).
 	viewMode    bool   // viewing a note's rendered markdown
@@ -108,6 +110,16 @@ func New(cfg Config) Model {
 // Selected returns the note selection if the user chose one, or nil.
 func (m Model) Selected() *Selection {
 	return m.selected
+}
+
+// scheduleStatusDismiss increments the generation counter and returns a tick
+// command that will clear the status text after statusTimeout.
+func (m *Model) scheduleStatusDismiss() tea.Cmd {
+	m.statusGen++
+	gen := m.statusGen
+	return tea.Tick(statusTimeout, func(t time.Time) tea.Msg {
+		return statusTimeoutMsg{generation: gen}
+	})
 }
 
 // notebooksLoadedMsg carries the loaded notebook list.
@@ -184,6 +196,14 @@ type reloadAndSelectMsg struct{ name string }
 // statusMsg carries a temporary status message for the status bar.
 type statusMsg struct{ text string }
 
+// statusTimeoutMsg is sent after the status auto-dismiss delay.
+// The generation field is compared against Model.statusGen to ensure
+// only the most recent status message is cleared.
+type statusTimeoutMsg struct{ generation int }
+
+// statusTimeout is the delay before auto-dismissing a transient status message.
+const statusTimeout = 4 * time.Second
+
 // viewLoadedMsg carries the note content to display in the view overlay.
 type viewLoadedMsg struct {
 	title   string
@@ -242,6 +262,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case statusMsg:
 		m.statusText = msg.text
+		return m, m.scheduleStatusDismiss()
+
+	case statusTimeoutMsg:
+		if msg.generation == m.statusGen {
+			m.statusText = ""
+		}
 		return m, nil
 
 	case viewLoadedMsg:
@@ -870,15 +896,15 @@ func (m Model) handleThemeKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			cfg, err := config.Load()
 			if err != nil {
 				m.statusText = fmt.Sprintf("Config load error: %s", err)
-				return m, nil
+				return m, m.scheduleStatusDismiss()
 			}
 			if err := config.Set(&cfg, "glamour_style", selected); err != nil {
 				m.statusText = fmt.Sprintf("Config error: %s", err)
-				return m, nil
+				return m, m.scheduleStatusDismiss()
 			}
 			if err := config.Save(cfg); err != nil {
 				m.statusText = fmt.Sprintf("Config save error: %s", err)
-				return m, nil
+				return m, m.scheduleStatusDismiss()
 			}
 			render.SetGlamourStyle(selected)
 			m.statusText = fmt.Sprintf("Theme set to %q", selected)
@@ -894,20 +920,20 @@ func (m Model) handleThemeKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			cfg, err := config.Load()
 			if err != nil {
 				m.statusText = fmt.Sprintf("Config load error: %s", err)
-				return m, nil
+				return m, m.scheduleStatusDismiss()
 			}
 			if err := config.Set(&cfg, "ui_theme", selected.Name); err != nil {
 				m.statusText = fmt.Sprintf("Config error: %s", err)
-				return m, nil
+				return m, m.scheduleStatusDismiss()
 			}
 			if err := config.Save(cfg); err != nil {
 				m.statusText = fmt.Sprintf("Config save error: %s", err)
-				return m, nil
+				return m, m.scheduleStatusDismiss()
 			}
 			theme.SetTheme(selected)
 			m.statusText = fmt.Sprintf("UI theme set to %s", selected.Name)
 		}
-		return m, nil
+		return m, m.scheduleStatusDismiss()
 
 	case tea.KeyRunes:
 		if string(msg.Runes) == "q" || string(msg.Runes) == "t" {

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -40,6 +40,14 @@ type previewTickMsg struct{ seq int }
 // previewDebounce is the delay before re-rendering the preview after a text change.
 const previewDebounce = 150 * time.Millisecond
 
+// statusTimeoutMsg is sent after the status auto-dismiss delay.
+// The generation field is compared against Model.statusGen to ensure
+// only the most recent status message is cleared.
+type statusTimeoutMsg struct{ generation int }
+
+// statusTimeout is the delay before auto-dismissing a transient status message.
+const statusTimeout = 4 * time.Second
+
 // minSplitWidth is the minimum terminal width required to show the split pane.
 // Below this, the preview is auto-hidden.
 const minSplitWidth = 40
@@ -61,6 +69,7 @@ type Model struct {
 	preview        string
 	previewDirty   bool
 	previewSeq int
+	statusGen  int // generation counter for status auto-dismiss
 }
 
 type statusKind int
@@ -158,6 +167,16 @@ func (m *Model) renderPreview() {
 	}
 	m.preview = render.RenderMarkdown(content, pw)
 	m.previewDirty = false
+}
+
+// scheduleStatusDismiss increments the generation counter and returns a tick
+// command that will clear the status after statusTimeout.
+func (m *Model) scheduleStatusDismiss() tea.Cmd {
+	m.statusGen++
+	gen := m.statusGen
+	return tea.Tick(statusTimeout, func(t time.Time) tea.Msg {
+		return statusTimeoutMsg{generation: gen}
+	})
 }
 
 // schedulePreviewTick increments the sequence counter and returns a tick command.
@@ -261,6 +280,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case previewTickMsg:
 		if msg.seq == m.previewSeq && m.previewDirty {
 			m.renderPreview()
+		}
+		return m, nil
+
+	case statusTimeoutMsg:
+		if msg.generation == m.statusGen {
+			m.status = ""
+			m.statusStyle = statusNone
 		}
 		return m, nil
 
@@ -372,7 +398,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.initial = msg.content
 		m.status = "Saved"
 		m.statusStyle = statusSuccess
-		return m, nil
+		return m, m.scheduleStatusDismiss()
 
 	case savedQuitMsg:
 		m.initial = msg.content
@@ -382,7 +408,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case saveErrMsg:
 		m.status = fmt.Sprintf("Save failed: %s", msg.err)
 		m.statusStyle = statusError
-		return m, nil
+		return m, m.scheduleStatusDismiss()
 	}
 
 	// Track content before the textarea processes the message so we can


### PR DESCRIPTION
## Summary
- Added `statusTimeoutMsg` with generation counter in both browser and editor
- Status messages auto-dismiss after 4 seconds via `tea.Tick`
- Interactive prompts (quit confirm, input mode) excluded from auto-dismiss
- Existing clear-on-keypress behavior preserved as fallback

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./...` — all tests pass
- [x] Status messages auto-clear after timeout
- [x] Quit prompt does not auto-clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)