### PR TITLE
fix: save cursor position across navigation + Ctrl+C force quit

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -13,13 +13,16 @@ import (
 // re-enters after the editor exits.
 func runBrowser() error {
 	var lastBook string
+	var lastCursor, lastSavedCursor int
 	for {
 		m := browser.New(browser.Config{
 			Store: store,
 			EditNote: func(book, note string) error {
 				return editNote(nil, book, note)
 			},
-			InitialBook: lastBook,
+			InitialBook:        lastBook,
+			InitialCursor:      lastCursor,
+			InitialSavedCursor: lastSavedCursor,
 		})
 
 		p := tea.NewProgram(m, tea.WithAltScreen())
@@ -37,6 +40,8 @@ func runBrowser() error {
 
 		// Launch editor for the selected note.
 		lastBook = sel.Book
+		lastCursor = final.Cursor()
+		lastSavedCursor = final.SavedCursor()
 		if err := editNote(os.Stderr, sel.Book, sel.Note); err != nil {
 			return fmt.Errorf("edit note: %w", err)
 		}

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -23,9 +23,11 @@ type EditFunc func(book, note string) error
 
 // Config holds the dependencies needed by the browser.
 type Config struct {
-	Store       *storage.Store
-	EditNote    EditFunc
-	InitialBook string // if set, start at L1 in this notebook
+	Store         *storage.Store
+	EditNote      EditFunc
+	InitialBook        string // if set, start at L1 in this notebook
+	InitialCursor      int    // cursor position to restore within the initial view
+	InitialSavedCursor int    // L0 cursor to restore when returning from L1
 }
 
 // Selection represents a note the user chose to open.
@@ -43,6 +45,7 @@ type Model struct {
 	notes       []model.Note
 	currentBook string // selected notebook name
 	cursor      int    // current selection index
+	savedCursor int    // notebook-level cursor restored on Esc
 	filter       string // fuzzy search filter text
 	filtering    bool   // whether filter mode is active
 	filterCursor int    // cursor position within filter
@@ -104,12 +107,24 @@ func New(cfg Config) Model {
 		m.level = 1
 		m.currentBook = cfg.InitialBook
 	}
+	m.cursor = cfg.InitialCursor
+	m.savedCursor = cfg.InitialSavedCursor
 	return m
 }
 
 // Selected returns the note selection if the user chose one, or nil.
 func (m Model) Selected() *Selection {
 	return m.selected
+}
+
+// Cursor returns the current cursor position.
+func (m Model) Cursor() int {
+	return m.cursor
+}
+
+// SavedCursor returns the saved L0 cursor position.
+func (m Model) SavedCursor() int {
+	return m.savedCursor
 }
 
 // scheduleStatusDismiss increments the generation counter and returns a tick
@@ -1199,6 +1214,7 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 	if m.level == 0 {
 		m.currentBook = m.notebooks[idx].name
 		m.level = 1
+		m.savedCursor = m.cursor
 		m.cursor = 0
 		m.filter = ""
 		m.filtering = false
@@ -1220,7 +1236,7 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 func (m Model) handleEsc() (tea.Model, tea.Cmd) {
 	if m.level == 1 {
 		m.level = 0
-		m.cursor = 0
+		m.cursor = m.savedCursor
 		m.filter = ""
 		m.filtering = false
 		m.notebooks = nil

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -318,7 +318,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// No save function configured — just quit.
 				m.quitting = true
 				return m, tea.Quit
-			case "n", "N":
+			case "n", "N", "ctrl+c":
 				m.quitting = true
 				return m, tea.Quit
 			case "esc":
@@ -384,12 +384,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 
 		case "ctrl+c":
-			if m.modified() {
-				m.quitPrompt = true
-				m.status = "Save before quitting? [Y/n/Esc]"
-				m.statusStyle = statusWarning
-				return m, nil
-			}
 			m.quitting = true
 			return m, tea.Quit
 		}

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -182,7 +182,7 @@ func TestQuitPromptCancel(t *testing.T) {
 	}
 }
 
-func TestCtrlCPromptsWhenModified(t *testing.T) {
+func TestCtrlCForceQuitsWhenModified(t *testing.T) {
 	m := New(Config{Title: "test", Content: "hello"})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = updated.(Model)
@@ -191,18 +191,15 @@ func TestCtrlCPromptsWhenModified(t *testing.T) {
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
 	m = updated.(Model)
 
-	// Ctrl+C with unsaved changes should prompt, not quit.
+	// Ctrl+C should force quit even with unsaved changes.
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
 	m = updated.(Model)
 
-	if cmd != nil {
-		t.Fatal("Ctrl+C with unsaved changes should not return a command")
+	if cmd == nil {
+		t.Fatal("Ctrl+C should return a quit command")
 	}
-	if !m.quitPrompt {
-		t.Fatal("expected quitPrompt to be true")
-	}
-	if m.quitting {
-		t.Fatal("should not be quitting yet")
+	if !m.quitting {
+		t.Fatal("expected quitting to be true")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Cursor position saved when navigating L0→L1→L0 via `savedCursor` field
- Cursor position preserved across editor round-trip via `InitialCursor` + `InitialSavedCursor` in Config
- Ctrl+C force quits without save prompt (matching help text), including during quit prompt
- Updated test to verify force-quit behavior

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./...` — all tests pass
- [x] Enter notebook, navigate to item 3, press Esc — cursor stays on item 3
- [x] Select note 5, edit, exit editor — cursor returns to note 5
- [x] Ctrl+C always exits immediately, even with unsaved changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)