### PR TITLE
fix: Cmd+Backspace delete-to-line-start in editor (Closes #117)

### DIFF
--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -267,6 +267,44 @@ func (m *Model) pasteLine() {
 	}
 }
 
+// deleteToLineStart removes all text from the cursor to the start of the
+// current line. If the cursor is already at the start of the line, this is a
+// no-op.
+func (m *Model) deleteToLineStart() {
+	value := m.textarea.Value()
+	lines := strings.Split(value, "\n")
+
+	line := m.cursorLine()
+	if line < 0 || line >= len(lines) {
+		return
+	}
+
+	col := m.textarea.LineInfo().ColumnOffset
+	if col <= 0 {
+		return
+	}
+
+	// Remove everything before the cursor on the current line.
+	// ColumnOffset counts rune positions (not display width), so convert to
+	// rune slice for correct slicing of multi-byte/double-width characters.
+	runes := []rune(lines[line])
+	if col > len(runes) {
+		col = len(runes)
+	}
+	lines[line] = string(runes[col:])
+
+	m.textarea.SetValue(strings.Join(lines, "\n"))
+
+	// Reposition the cursor to the target line, column 0.
+	m.textarea.SetCursor(0)
+	for m.textarea.Line() > line {
+		m.textarea.CursorUp()
+	}
+	for m.textarea.Line() < line {
+		m.textarea.CursorDown()
+	}
+}
+
 // Update handles messages and updates the model.
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
@@ -348,6 +386,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.schedulePreviewTick()
 
 		case "ctrl+u":
+			m.deleteToLineStart()
+			m.previewDirty = true
+			return m, m.schedulePreviewTick()
+
+		case "ctrl+y":
 			m.pasteLine()
 			m.previewDirty = true
 			return m, m.schedulePreviewTick()
@@ -431,7 +474,8 @@ func (m Model) renderHelpOverlay() string {
   Ctrl+P    Toggle preview
   Ctrl+G    Toggle this help
   Ctrl+K    Cut line
-  Ctrl+U    Paste line
+  Ctrl+Y    Paste line
+  Ctrl+U    Delete to line start
 
   Press Ctrl+G or Esc to close`
 

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -578,7 +578,8 @@ func TestHelpViewContainsKeybindings(t *testing.T) {
 		"Ctrl+P", "Toggle preview",
 		"Ctrl+G", "Toggle this help",
 		"Ctrl+K", "Cut line",
-		"Ctrl+U", "Paste line",
+		"Ctrl+Y", "Paste line",
+		"Ctrl+U", "Delete to line start",
 	}
 	for _, kb := range keybindings {
 		if !containsPlainText(view, kb) {
@@ -633,7 +634,7 @@ func TestCtrlKCutsLine(t *testing.T) {
 	}
 }
 
-func TestCtrlUPastesLine(t *testing.T) {
+func TestCtrlYPastesLine(t *testing.T) {
 	m := New(Config{Title: "test", Content: "line1\nline2\nline3"})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = updated.(Model)
@@ -646,8 +647,8 @@ func TestCtrlUPastesLine(t *testing.T) {
 		t.Fatalf("clipboard should be %q, got %q", "line3", m.clipboard)
 	}
 
-	// Now paste — should re-insert line3.
-	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlU})
+	// Now paste with Ctrl+Y — should re-insert line3.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlY})
 	m = updated.(Model)
 
 	content := m.Content()
@@ -659,7 +660,7 @@ func TestCtrlUPastesLine(t *testing.T) {
 	}
 }
 
-func TestCtrlUNopWithEmptyClipboard(t *testing.T) {
+func TestCtrlYNopWithEmptyClipboard(t *testing.T) {
 	m := New(Config{Title: "test", Content: "line1\nline2"})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = updated.(Model)
@@ -667,11 +668,72 @@ func TestCtrlUNopWithEmptyClipboard(t *testing.T) {
 	contentBefore := m.Content()
 
 	// Paste with empty clipboard — should be a no-op.
-	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlU})
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlY})
 	m = updated.(Model)
 
 	if m.Content() != contentBefore {
 		t.Fatal("paste with empty clipboard should not change content")
+	}
+}
+
+func TestCtrlUDeletesToLineStart(t *testing.T) {
+	m := New(Config{Title: "test", Content: "hello world"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// The textarea cursor starts at the end of the content.
+	// Ctrl+U should delete everything before the cursor on the current line.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlU})
+	m = updated.(Model)
+
+	content := m.Content()
+	if content != "" {
+		t.Fatalf("Ctrl+U at end of line should delete entire line content, got %q", content)
+	}
+}
+
+func TestCtrlUDeletesToLineStartMultiline(t *testing.T) {
+	m := New(Config{Title: "test", Content: "line1\nhello world\nline3"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Move cursor to line 1 (middle line). The cursor starts at the end
+	// of the last line. Move up twice to get to line 0, then down once
+	// to get to line 1.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(Model)
+
+	// Now we should be on line 1 ("hello world"). Ctrl+U should delete
+	// everything before cursor on this line, leaving other lines intact.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlU})
+	m = updated.(Model)
+
+	content := m.Content()
+	if !strings.Contains(content, "line1") {
+		t.Fatal("line1 should remain after Ctrl+U on a different line")
+	}
+	if !strings.Contains(content, "line3") {
+		t.Fatal("line3 should remain after Ctrl+U on a different line")
+	}
+}
+
+func TestCtrlUNoOpAtLineStart(t *testing.T) {
+	m := New(Config{Title: "test", Content: "hello"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Move cursor to the start of the line.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyHome})
+	m = updated.(Model)
+
+	contentBefore := m.Content()
+
+	// Ctrl+U at start of line should be a no-op.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlU})
+	m = updated.(Model)
+
+	if m.Content() != contentBefore {
+		t.Fatalf("Ctrl+U at start of line should be no-op, got %q", m.Content())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `deleteToLineStart()` method using `ColumnOffset` for correct rune-based slicing (handles CJK/double-width characters)
- Rebind Ctrl+U from paste-line to delete-to-line-start (standard Unix/macOS terminal convention)
- Move paste-line to Ctrl+Y (standard yank convention)
- Update help overlay text and all affected tests
- Add 3 new tests: single-line deletion, multiline deletion, no-op at line start

## Test plan
- [x] `go build` — compiles cleanly
- [x] `go vet` — no issues
- [x] `go test ./...` — all tests pass
- [x] Code review — blocker (CharOffset→ColumnOffset) fixed
- [x] Reality check — matches issue spec
- [x] Security review — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)