### PR TITLE
fix: Ctrl+D checkbox toggle in editor (Closes #118)

### DIFF
--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -267,6 +267,44 @@ func (m *Model) pasteLine() {
 	}
 }
 
+// toggleCheckbox toggles a markdown checkbox on the current line.
+// It converts "- [ ] " to "- [x] " and vice versa, and similarly for
+// asterisk bullets ("* [ ] " / "* [x] "). If the current line does not
+// contain a checkbox pattern, the method is a no-op.
+func (m *Model) toggleCheckbox() {
+	value := m.textarea.Value()
+	lines := strings.Split(value, "\n")
+
+	line := m.cursorLine()
+	if line < 0 || line >= len(lines) {
+		return
+	}
+
+	cur := lines[line]
+	var updated string
+	switch {
+	case strings.Contains(cur, "- [ ] "):
+		updated = strings.Replace(cur, "- [ ] ", "- [x] ", 1)
+	case strings.Contains(cur, "- [x] "):
+		updated = strings.Replace(cur, "- [x] ", "- [ ] ", 1)
+	case strings.Contains(cur, "* [ ] "):
+		updated = strings.Replace(cur, "* [ ] ", "* [x] ", 1)
+	case strings.Contains(cur, "* [x] "):
+		updated = strings.Replace(cur, "* [x] ", "* [ ] ", 1)
+	default:
+		return // not a checkbox line — no-op
+	}
+
+	lines[line] = updated
+	m.textarea.SetValue(strings.Join(lines, "\n"))
+
+	// Restore cursor to the same line.
+	m.textarea.SetCursor(0)
+	for m.textarea.Line() < line {
+		m.textarea.CursorDown()
+	}
+}
+
 // deleteToLineStart removes all text from the cursor to the start of the
 // current line. If the cursor is already at the start of the line, this is a
 // no-op.
@@ -390,6 +428,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.previewDirty = true
 			return m, m.schedulePreviewTick()
 
+		case "ctrl+d":
+			m.toggleCheckbox()
+			m.previewDirty = true
+			return m, m.schedulePreviewTick()
+
 		case "ctrl+y":
 			m.pasteLine()
 			m.previewDirty = true
@@ -476,6 +519,7 @@ func (m Model) renderHelpOverlay() string {
   Ctrl+K    Cut line
   Ctrl+Y    Paste line
   Ctrl+U    Delete to line start
+  Ctrl+D    Toggle checkbox
 
   Press Ctrl+G or Esc to close`
 

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -580,6 +580,7 @@ func TestHelpViewContainsKeybindings(t *testing.T) {
 		"Ctrl+K", "Cut line",
 		"Ctrl+Y", "Paste line",
 		"Ctrl+U", "Delete to line start",
+		"Ctrl+D", "Toggle checkbox",
 	}
 	for _, kb := range keybindings {
 		if !containsPlainText(view, kb) {
@@ -804,6 +805,92 @@ func TestCtrlEIsNoOp(t *testing.T) {
 	}
 	if m.quitPrompt {
 		t.Fatal("Ctrl+E should not show quit prompt")
+	}
+}
+
+func TestCtrlDTogglesCheckboxUncheckedToChecked(t *testing.T) {
+	m := New(Config{Title: "test", Content: "- [ ] buy milk"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+	m = updated.(Model)
+
+	content := m.Content()
+	if content != "- [x] buy milk" {
+		t.Fatalf("expected %q, got %q", "- [x] buy milk", content)
+	}
+}
+
+func TestCtrlDTogglesCheckboxCheckedToUnchecked(t *testing.T) {
+	m := New(Config{Title: "test", Content: "- [x] buy milk"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+	m = updated.(Model)
+
+	content := m.Content()
+	if content != "- [ ] buy milk" {
+		t.Fatalf("expected %q, got %q", "- [ ] buy milk", content)
+	}
+}
+
+func TestCtrlDNoOpOnNonCheckboxLine(t *testing.T) {
+	m := New(Config{Title: "test", Content: "just a normal line"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	contentBefore := m.Content()
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+	m = updated.(Model)
+
+	if m.Content() != contentBefore {
+		t.Fatalf("Ctrl+D on non-checkbox line should be no-op, got %q", m.Content())
+	}
+}
+
+func TestCtrlDTogglesAsteriskCheckbox(t *testing.T) {
+	m := New(Config{Title: "test", Content: "* [ ] task one"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Toggle unchecked to checked.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+	m = updated.(Model)
+
+	content := m.Content()
+	if content != "* [x] task one" {
+		t.Fatalf("expected %q, got %q", "* [x] task one", content)
+	}
+
+	// Toggle checked back to unchecked.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+	m = updated.(Model)
+
+	content = m.Content()
+	if content != "* [ ] task one" {
+		t.Fatalf("expected %q, got %q", "* [ ] task one", content)
+	}
+}
+
+func TestHelpContainsToggleCheckbox(t *testing.T) {
+	m := New(Config{Title: "test", Content: "hello"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Show help.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlG})
+	m = updated.(Model)
+
+	view := m.View()
+
+	if !containsPlainText(view, "Ctrl+D") {
+		t.Fatal("help overlay should contain Ctrl+D keybinding")
+	}
+	if !containsPlainText(view, "Toggle checkbox") {
+		t.Fatal("help overlay should contain 'Toggle checkbox' description")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `toggleCheckbox()` method that swaps `- [ ]` ↔ `- [x]` and `* [ ]` ↔ `* [x]` on the current line
- Add `Ctrl+D` keybinding to trigger the toggle
- Non-checkbox lines are a no-op
- Update help overlay with new keybinding
- Add 5 new tests covering checked/unchecked, asterisk bullets, no-op, and help overlay

## Test plan
- [x] `go build` — compiles cleanly
- [x] `go vet` — no issues
- [x] `go test ./...` — all 393 tests pass
- [x] Code review — no blockers
- [x] Reality check — matches spec
- [x] Security review — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)