### PR TITLE
feat: block type definition and markdown parser (Closes #119)

### DIFF
--- a/internal/block/block.go
+++ b/internal/block/block.go
@@ -1,0 +1,31 @@
+// Package block defines the Block type and BlockType constants used to
+// represent parsed markdown content as a sequence of typed blocks.
+//
+// This package is pure data — it has no TUI or rendering dependencies and
+// is safe to use from tests, CLI tools, or any other context.
+package block
+
+// BlockType enumerates the kinds of content blocks that a markdown document
+// can contain.
+type BlockType int
+
+const (
+	Paragraph    BlockType = iota // plain text paragraph
+	Heading1                      // # heading
+	Heading2                      // ## heading
+	Heading3                      // ### heading
+	BulletList                    // - or * list item
+	NumberedList                  // 1. numbered list item
+	Checklist                     // - [ ] or - [x] checklist item
+	CodeBlock                     // fenced code block (``` ... ```)
+	Quote                         // > block quote
+	Divider                       // ---, ***, or ___
+)
+
+// Block holds a single parsed content block.
+type Block struct {
+	Type     BlockType // kind of block
+	Content  string    // text content without markdown prefix
+	Language string    // code block language hint (CodeBlock only)
+	Checked  bool      // whether checklist item is checked (Checklist only)
+}

--- a/internal/block/parse.go
+++ b/internal/block/parse.go
@@ -1,0 +1,233 @@
+package block
+
+import "strings"
+
+// Parse splits a markdown document into a sequence of Blocks. It walks the
+// input line by line, recognising headings, lists, checklists, code fences,
+// block quotes, dividers, and paragraphs. Consecutive paragraph lines and
+// consecutive quote lines are merged into single blocks. Blank lines produce
+// empty Paragraph blocks to preserve vertical spacing.
+//
+// An unclosed code fence (no closing ```) treats all remaining lines as code
+// block content.
+func Parse(markdown string) []Block {
+	// Special case: completely empty input.
+	if markdown == "" {
+		return []Block{{Type: Paragraph, Content: ""}}
+	}
+
+	lines := strings.Split(markdown, "\n")
+	var blocks []Block
+
+	i := 0
+	for i < len(lines) {
+		line := lines[i]
+
+		// --- Code fence ---
+		if strings.HasPrefix(line, "```") {
+			lang := strings.TrimSpace(strings.TrimPrefix(line, "```"))
+			var contentLines []string
+			i++
+			for i < len(lines) {
+				if strings.HasPrefix(lines[i], "```") {
+					i++ // skip closing fence
+					break
+				}
+				contentLines = append(contentLines, lines[i])
+				i++
+			}
+			blocks = append(blocks, Block{
+				Type:     CodeBlock,
+				Content:  strings.Join(contentLines, "\n"),
+				Language: lang,
+			})
+			continue
+		}
+
+		// --- Blank line ---
+		if line == "" {
+			blocks = append(blocks, Block{Type: Paragraph, Content: ""})
+			i++
+			continue
+		}
+
+		// --- Divider (---, ***, ___) ---
+		if isDivider(line) {
+			blocks = append(blocks, Block{Type: Divider})
+			i++
+			continue
+		}
+
+		// --- Headings ---
+		if strings.HasPrefix(line, "### ") {
+			blocks = append(blocks, Block{
+				Type:    Heading3,
+				Content: strings.TrimPrefix(line, "### "),
+			})
+			i++
+			continue
+		}
+		if strings.HasPrefix(line, "## ") {
+			blocks = append(blocks, Block{
+				Type:    Heading2,
+				Content: strings.TrimPrefix(line, "## "),
+			})
+			i++
+			continue
+		}
+		if strings.HasPrefix(line, "# ") {
+			blocks = append(blocks, Block{
+				Type:    Heading1,
+				Content: strings.TrimPrefix(line, "# "),
+			})
+			i++
+			continue
+		}
+
+		// --- Checklist items ---
+		if strings.HasPrefix(line, "- [x] ") || strings.HasPrefix(line, "- [X] ") {
+			blocks = append(blocks, Block{
+				Type:    Checklist,
+				Content: line[6:],
+				Checked: true,
+			})
+			i++
+			continue
+		}
+		if strings.HasPrefix(line, "- [ ] ") {
+			blocks = append(blocks, Block{
+				Type:    Checklist,
+				Content: line[6:],
+				Checked: false,
+			})
+			i++
+			continue
+		}
+
+		// --- Bullet list items ---
+		if strings.HasPrefix(line, "- ") || strings.HasPrefix(line, "* ") {
+			blocks = append(blocks, Block{
+				Type:    BulletList,
+				Content: line[2:],
+			})
+			i++
+			continue
+		}
+
+		// --- Numbered list items ---
+		if isNumberedItem(line) {
+			_, content := parseNumberedItem(line)
+			blocks = append(blocks, Block{
+				Type:    NumberedList,
+				Content: content,
+			})
+			i++
+			continue
+		}
+
+		// --- Block quotes ---
+		if strings.HasPrefix(line, "> ") || line == ">" {
+			var quoteLines []string
+			for i < len(lines) {
+				if strings.HasPrefix(lines[i], "> ") {
+					quoteLines = append(quoteLines, strings.TrimPrefix(lines[i], "> "))
+				} else if lines[i] == ">" {
+					quoteLines = append(quoteLines, "")
+				} else {
+					break
+				}
+				i++
+			}
+			blocks = append(blocks, Block{
+				Type:    Quote,
+				Content: strings.Join(quoteLines, "\n"),
+			})
+			continue
+		}
+
+		// --- Paragraph (merge consecutive non-special lines) ---
+		var paraLines []string
+		for i < len(lines) {
+			l := lines[i]
+			if l == "" ||
+				strings.HasPrefix(l, "```") ||
+				strings.HasPrefix(l, "# ") ||
+				strings.HasPrefix(l, "## ") ||
+				strings.HasPrefix(l, "### ") ||
+				strings.HasPrefix(l, "- ") ||
+				strings.HasPrefix(l, "* ") ||
+				strings.HasPrefix(l, "> ") || l == ">" ||
+				strings.HasPrefix(l, "- [ ] ") ||
+				strings.HasPrefix(l, "- [x] ") ||
+				strings.HasPrefix(l, "- [X] ") ||
+				isNumberedItem(l) ||
+				isDivider(l) {
+				break
+			}
+			paraLines = append(paraLines, l)
+			i++
+		}
+		blocks = append(blocks, Block{
+			Type:    Paragraph,
+			Content: strings.Join(paraLines, "\n"),
+		})
+	}
+
+	return blocks
+}
+
+// isDivider reports whether a line is a thematic break (---, ***, or ___).
+func isDivider(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	if len(trimmed) < 3 {
+		return false
+	}
+	switch {
+	case allSameChar(trimmed, '-'):
+		return true
+	case allSameChar(trimmed, '*'):
+		return true
+	case allSameChar(trimmed, '_'):
+		return true
+	}
+	return false
+}
+
+// allSameChar reports whether s consists entirely of character c.
+func allSameChar(s string, c byte) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] != c {
+			return false
+		}
+	}
+	return true
+}
+
+// isNumberedItem reports whether a line starts with one or more ASCII digits
+// followed by ". " (dot-space).
+func isNumberedItem(line string) bool {
+	if len(line) == 0 {
+		return false
+	}
+	i := 0
+	for i < len(line) && line[i] >= '0' && line[i] <= '9' {
+		i++
+	}
+	if i == 0 {
+		return false
+	}
+	return strings.HasPrefix(line[i:], ". ")
+}
+
+// parseNumberedItem splits "123. text" into the number prefix and text.
+// Returns empty strings if line does not match the pattern.
+func parseNumberedItem(line string) (prefix, content string) {
+	i := 0
+	for i < len(line) && line[i] >= '0' && line[i] <= '9' {
+		i++
+	}
+	if i == 0 || i+2 > len(line) || line[i] != '.' || line[i+1] != ' ' {
+		return "", ""
+	}
+	return line[:i], line[i+2:]
+}

--- a/internal/block/parse_test.go
+++ b/internal/block/parse_test.go
@@ -1,0 +1,287 @@
+package block
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect []Block
+	}{
+		{
+			name:  "empty document",
+			input: "",
+			expect: []Block{
+				{Type: Paragraph, Content: ""},
+			},
+		},
+		{
+			name:  "heading 1",
+			input: "# Hello",
+			expect: []Block{
+				{Type: Heading1, Content: "Hello"},
+			},
+		},
+		{
+			name:  "heading 2",
+			input: "## Subtitle",
+			expect: []Block{
+				{Type: Heading2, Content: "Subtitle"},
+			},
+		},
+		{
+			name:  "heading 3",
+			input: "### Details",
+			expect: []Block{
+				{Type: Heading3, Content: "Details"},
+			},
+		},
+		{
+			name:  "bullet list with dash",
+			input: "- item one\n- item two",
+			expect: []Block{
+				{Type: BulletList, Content: "item one"},
+				{Type: BulletList, Content: "item two"},
+			},
+		},
+		{
+			name:  "bullet list with asterisk",
+			input: "* first\n* second",
+			expect: []Block{
+				{Type: BulletList, Content: "first"},
+				{Type: BulletList, Content: "second"},
+			},
+		},
+		{
+			name:  "numbered list",
+			input: "1. first\n2. second\n10. tenth",
+			expect: []Block{
+				{Type: NumberedList, Content: "first"},
+				{Type: NumberedList, Content: "second"},
+				{Type: NumberedList, Content: "tenth"},
+			},
+		},
+		{
+			name:  "checklist unchecked",
+			input: "- [ ] todo item",
+			expect: []Block{
+				{Type: Checklist, Content: "todo item", Checked: false},
+			},
+		},
+		{
+			name:  "checklist checked",
+			input: "- [x] done item",
+			expect: []Block{
+				{Type: Checklist, Content: "done item", Checked: true},
+			},
+		},
+		{
+			name:  "checklist checked uppercase X",
+			input: "- [X] also done",
+			expect: []Block{
+				{Type: Checklist, Content: "also done", Checked: true},
+			},
+		},
+		{
+			name:  "code block with language",
+			input: "```go\nfmt.Println(\"hello\")\n```",
+			expect: []Block{
+				{Type: CodeBlock, Content: "fmt.Println(\"hello\")", Language: "go"},
+			},
+		},
+		{
+			name:  "code block without language",
+			input: "```\nsome code\n```",
+			expect: []Block{
+				{Type: CodeBlock, Content: "some code", Language: ""},
+			},
+		},
+		{
+			name:  "code block preserves markdown syntax inside",
+			input: "```\n# not a heading\n- not a list\n> not a quote\n```",
+			expect: []Block{
+				{Type: CodeBlock, Content: "# not a heading\n- not a list\n> not a quote", Language: ""},
+			},
+		},
+		{
+			name:  "code block multiline",
+			input: "```python\ndef hello():\n    print(\"hi\")\n\nreturn 42\n```",
+			expect: []Block{
+				{Type: CodeBlock, Content: "def hello():\n    print(\"hi\")\n\nreturn 42", Language: "python"},
+			},
+		},
+		{
+			name:  "single line quote",
+			input: "> a wise saying",
+			expect: []Block{
+				{Type: Quote, Content: "a wise saying"},
+			},
+		},
+		{
+			name:  "multi-line quote merges",
+			input: "> line one\n> line two\n> line three",
+			expect: []Block{
+				{Type: Quote, Content: "line one\nline two\nline three"},
+			},
+		},
+		{
+			name:  "divider with dashes",
+			input: "---",
+			expect: []Block{
+				{Type: Divider},
+			},
+		},
+		{
+			name:  "divider with asterisks",
+			input: "***",
+			expect: []Block{
+				{Type: Divider},
+			},
+		},
+		{
+			name:  "divider with underscores",
+			input: "___",
+			expect: []Block{
+				{Type: Divider},
+			},
+		},
+		{
+			name:  "paragraph merges consecutive lines",
+			input: "hello world\nthis is a paragraph\nwith three lines",
+			expect: []Block{
+				{Type: Paragraph, Content: "hello world\nthis is a paragraph\nwith three lines"},
+			},
+		},
+		{
+			name:  "blank line produces empty paragraph",
+			input: "text above\n\ntext below",
+			expect: []Block{
+				{Type: Paragraph, Content: "text above"},
+				{Type: Paragraph, Content: ""},
+				{Type: Paragraph, Content: "text below"},
+			},
+		},
+		{
+			name:  "consecutive blank lines preserved",
+			input: "top\n\n\nbottom",
+			expect: []Block{
+				{Type: Paragraph, Content: "top"},
+				{Type: Paragraph, Content: ""},
+				{Type: Paragraph, Content: ""},
+				{Type: Paragraph, Content: "bottom"},
+			},
+		},
+		{
+			name:  "mixed content document",
+			input: "# Title\n\nSome intro text.\n\n## Section\n\n- bullet one\n- bullet two\n\n1. step one\n2. step two\n\n> a quote\n\n---\n\n```go\nfunc main() {}\n```\n\n- [ ] task\n- [x] done",
+			expect: []Block{
+				{Type: Heading1, Content: "Title"},
+				{Type: Paragraph, Content: ""},
+				{Type: Paragraph, Content: "Some intro text."},
+				{Type: Paragraph, Content: ""},
+				{Type: Heading2, Content: "Section"},
+				{Type: Paragraph, Content: ""},
+				{Type: BulletList, Content: "bullet one"},
+				{Type: BulletList, Content: "bullet two"},
+				{Type: Paragraph, Content: ""},
+				{Type: NumberedList, Content: "step one"},
+				{Type: NumberedList, Content: "step two"},
+				{Type: Paragraph, Content: ""},
+				{Type: Quote, Content: "a quote"},
+				{Type: Paragraph, Content: ""},
+				{Type: Divider},
+				{Type: Paragraph, Content: ""},
+				{Type: CodeBlock, Content: "func main() {}", Language: "go"},
+				{Type: Paragraph, Content: ""},
+				{Type: Checklist, Content: "task", Checked: false},
+				{Type: Checklist, Content: "done", Checked: true},
+			},
+		},
+		{
+			name:  "long divider",
+			input: "-----",
+			expect: []Block{
+				{Type: Divider},
+			},
+		},
+		{
+			name:  "bare quote marker",
+			input: ">",
+			expect: []Block{
+				{Type: Quote, Content: ""},
+			},
+		},
+		{
+			name:  "unclosed code fence treats rest as code",
+			input: "```go\nfunc main() {}\nmore code",
+			expect: []Block{
+				{Type: CodeBlock, Content: "func main() {}\nmore code", Language: "go"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Parse(tt.input)
+			if len(got) != len(tt.expect) {
+				t.Fatalf("block count: got %d, want %d\ngot:  %s\nwant: %s",
+					len(got), len(tt.expect), formatBlocks(got), formatBlocks(tt.expect))
+			}
+			for i := range tt.expect {
+				if got[i].Type != tt.expect[i].Type {
+					t.Errorf("block[%d].Type: got %d, want %d", i, got[i].Type, tt.expect[i].Type)
+				}
+				if got[i].Content != tt.expect[i].Content {
+					t.Errorf("block[%d].Content: got %q, want %q", i, got[i].Content, tt.expect[i].Content)
+				}
+				if got[i].Language != tt.expect[i].Language {
+					t.Errorf("block[%d].Language: got %q, want %q", i, got[i].Language, tt.expect[i].Language)
+				}
+				if got[i].Checked != tt.expect[i].Checked {
+					t.Errorf("block[%d].Checked: got %v, want %v", i, got[i].Checked, tt.expect[i].Checked)
+				}
+			}
+		})
+	}
+}
+
+// formatBlocks is a test helper that formats blocks for readable failure output.
+func formatBlocks(blocks []Block) string {
+	var b strings.Builder
+	for i, bl := range blocks {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString("{")
+		switch bl.Type {
+		case Paragraph:
+			b.WriteString("Paragraph")
+		case Heading1:
+			b.WriteString("Heading1")
+		case Heading2:
+			b.WriteString("Heading2")
+		case Heading3:
+			b.WriteString("Heading3")
+		case BulletList:
+			b.WriteString("BulletList")
+		case NumberedList:
+			b.WriteString("NumberedList")
+		case Checklist:
+			b.WriteString("Checklist")
+		case CodeBlock:
+			b.WriteString("CodeBlock")
+		case Quote:
+			b.WriteString("Quote")
+		case Divider:
+			b.WriteString("Divider")
+		}
+		if bl.Content != "" {
+			b.WriteString(" " + bl.Content)
+		}
+		b.WriteString("}")
+	}
+	return b.String()
+}


### PR DESCRIPTION
## Summary
- Create `internal/block/` package — pure data, no TUI dependencies
- Define `BlockType` enum (10 types) and `Block` struct in `block.go`
- Implement `Parse(markdown string) []Block` in `parse.go` — handles headings, bullets, numbered lists, checklists, code fences (with unclosed fence handling), quotes, dividers, and paragraph merging
- 27 table-driven tests covering all block types, edge cases (unclosed code fence, bare quote marker, mixed content), and acceptance criteria

## Test plan
- [x] `go build ./...` — compiles cleanly
- [x] `go vet ./...` — no issues
- [x] `go test ./internal/block/` — 27/27 tests pass
- [x] `go test ./...` — all tests pass, no regressions
- [x] Code review — blockers fixed (safe parseNumberedItem bounds, ASCII-only digits, unclosed fence documented/tested)
- [x] Reality check — matches spec
- [x] Security review — no vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)