### PR TITLE
feat: / command palette for block type insertion (Closes #123)

### DIFF
--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -61,6 +61,7 @@ type Model struct {
 	clipboard   string // line-level clipboard for Ctrl+Y
 	blockClip   *block.Block // block-level clipboard for Ctrl+K block cut
 	statusGen   int    // generation counter for status auto-dismiss
+	palette     palette // "/" command palette for block type insertion
 }
 
 type statusKind int
@@ -104,6 +105,7 @@ func New(cfg Config) Model {
 		initial:   cfg.Content,
 		width:     defaultWidth,
 		height:    defaultHeight,
+		palette:   newPalette(),
 	}
 }
 
@@ -605,6 +607,36 @@ func (m *Model) pasteLine() {
 	}
 }
 
+// applyPaletteSelection changes the active block's type to the selected
+// palette item type. Special handling is applied for dividers and code blocks.
+func (m *Model) applyPaletteSelection(bt block.BlockType) {
+	if m.active < 0 || m.active >= len(m.blocks) {
+		return
+	}
+
+	m.blocks[m.active].Type = bt
+
+	switch bt {
+	case block.Divider:
+		// Dividers have no editable content.
+		m.blocks[m.active].Content = ""
+		m.textareas[m.active].SetValue("")
+	case block.CodeBlock:
+		// Reconfigure textarea for multi-line editing.
+		m.textareas[m.active].SetHeight(3)
+	default:
+		if isMultiLine(bt) {
+			lines := strings.Count(m.textareas[m.active].Value(), "\n") + 1
+			if lines < 3 {
+				lines = 3
+			}
+			m.textareas[m.active].SetHeight(lines)
+		} else {
+			m.textareas[m.active].SetHeight(1)
+		}
+	}
+}
+
 // isAtFirstLine returns true if the cursor is on the first line of the
 // active textarea.
 func (m Model) isAtFirstLine() bool {
@@ -678,6 +710,42 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.statusStyle = statusNone
 				return m, nil
 			}
+			return m, nil
+		}
+
+		// When palette is visible, intercept all keys.
+		if m.palette.visible {
+			switch msg.Type {
+			case tea.KeyUp:
+				m.palette.moveUp()
+				return m, nil
+			case tea.KeyDown:
+				m.palette.moveDown()
+				return m, nil
+			case tea.KeyEnter:
+				if sel := m.palette.selected(); sel != nil {
+					m.applyPaletteSelection(sel.Type)
+				}
+				m.palette.close()
+				m.updateViewport()
+				return m, nil
+			case tea.KeyEsc:
+				m.palette.close()
+				m.updateViewport()
+				return m, nil
+			case tea.KeyBackspace:
+				if !m.palette.deleteFilterRune() {
+					m.palette.close()
+					m.updateViewport()
+				}
+				return m, nil
+			case tea.KeyRunes:
+				for _, r := range msg.Runes {
+					m.palette.addFilterRune(r)
+				}
+				return m, nil
+			}
+			// Ignore other keys while palette is open.
 			return m, nil
 		}
 
@@ -785,6 +853,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if keyMsg, ok := msg.(tea.KeyMsg); ok {
 			bt := m.blocks[m.active].Type
 
+			// Handle "/" at position 0 to open the command palette.
+			if keyMsg.Type == tea.KeyRunes && len(keyMsg.Runes) == 1 && keyMsg.Runes[0] == '/' {
+				ta := &m.textareas[m.active]
+				if ta.Line() == 0 && ta.LineInfo().ColumnOffset == 0 && ta.Value() == "" {
+					m.palette.open(m.active)
+					m.updateViewport()
+					return m, nil
+				}
+			}
+
 			// Handle Enter key for block creation.
 			if keyMsg.Type == tea.KeyEnter {
 				if !isMultiLine(bt) {
@@ -866,10 +944,16 @@ func (m *Model) updateViewport() {
 }
 
 // renderAllBlocks renders each block and joins them vertically.
+// When the command palette is visible, it is rendered below the active block.
 func (m Model) renderAllBlocks() string {
 	var parts []string
 	for i := range m.blocks {
 		parts = append(parts, m.renderBlock(i))
+		if m.palette.visible && i == m.active {
+			if pv := m.palette.render(m.width); pv != "" {
+				parts = append(parts, pv)
+			}
+		}
 	}
 	return strings.Join(parts, "\n")
 }
@@ -906,6 +990,7 @@ func (m Model) renderHelpOverlay() string {
   Backspace Merge/delete block
   Alt+Up    Move block up
   Alt+Down  Move block down
+  /         Block type palette
 
   Press Ctrl+G or Esc to close`
 

--- a/internal/editor/palette.go
+++ b/internal/editor/palette.go
@@ -1,0 +1,202 @@
+package editor
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/oobagi/notebook/internal/block"
+	"github.com/oobagi/notebook/internal/theme"
+)
+
+// palette is the "/" command palette for changing a block's type.
+type palette struct {
+	visible  bool
+	items    []paletteItem
+	filtered []int  // indices into items matching current filter
+	filter   string // typed text after /
+	cursor   int    // selection in filtered list
+	blockIdx int    // which block triggered the palette
+}
+
+// paletteItem describes one entry in the palette.
+type paletteItem struct {
+	Label string
+	Type  block.BlockType
+	Icon  string
+}
+
+// defaultPaletteItems returns the full list of block-type entries.
+func defaultPaletteItems() []paletteItem {
+	return []paletteItem{
+		{Icon: "\u00b6", Label: "Paragraph", Type: block.Paragraph},
+		{Icon: "H1", Label: "Heading 1", Type: block.Heading1},
+		{Icon: "H2", Label: "Heading 2", Type: block.Heading2},
+		{Icon: "H3", Label: "Heading 3", Type: block.Heading3},
+		{Icon: "\u2022", Label: "Bullet List", Type: block.BulletList},
+		{Icon: "1.", Label: "Numbered List", Type: block.NumberedList},
+		{Icon: "\u2610", Label: "Checklist", Type: block.Checklist},
+		{Icon: "``", Label: "Code Block", Type: block.CodeBlock},
+		{Icon: ">", Label: "Quote", Type: block.Quote},
+		{Icon: "\u2014", Label: "Divider", Type: block.Divider},
+	}
+}
+
+// newPalette creates a palette with the default items and all indices visible.
+func newPalette() palette {
+	items := defaultPaletteItems()
+	filtered := make([]int, len(items))
+	for i := range items {
+		filtered[i] = i
+	}
+	return palette{
+		items:    items,
+		filtered: filtered,
+	}
+}
+
+// open makes the palette visible for the given block index and resets state.
+func (p *palette) open(blockIdx int) {
+	p.visible = true
+	p.blockIdx = blockIdx
+	p.filter = ""
+	p.cursor = 0
+	p.refilter()
+}
+
+// close hides the palette.
+func (p *palette) close() {
+	p.visible = false
+	p.filter = ""
+	p.cursor = 0
+}
+
+// refilter rebuilds the filtered index list based on the current filter text.
+func (p *palette) refilter() {
+	if p.filter == "" {
+		p.filtered = make([]int, len(p.items))
+		for i := range p.items {
+			p.filtered[i] = i
+		}
+		p.cursor = 0
+		return
+	}
+
+	lower := strings.ToLower(p.filter)
+	var result []int
+	for i, item := range p.items {
+		if strings.Contains(strings.ToLower(item.Label), lower) {
+			result = append(result, i)
+		}
+	}
+	p.filtered = result
+	if p.cursor >= len(p.filtered) {
+		p.cursor = len(p.filtered) - 1
+	}
+	if p.cursor < 0 {
+		p.cursor = 0
+	}
+}
+
+// addFilterRune appends a rune to the filter and refilters.
+func (p *palette) addFilterRune(r rune) {
+	p.filter += string(r)
+	p.refilter()
+}
+
+// deleteFilterRune removes the last rune from the filter. If the filter is
+// already empty, it returns false to signal the palette should close.
+func (p *palette) deleteFilterRune() bool {
+	if p.filter == "" {
+		return false
+	}
+	runes := []rune(p.filter)
+	p.filter = string(runes[:len(runes)-1])
+	p.refilter()
+	return true
+}
+
+// moveUp moves the cursor up in the filtered list.
+func (p *palette) moveUp() {
+	if p.cursor > 0 {
+		p.cursor--
+	}
+}
+
+// moveDown moves the cursor down in the filtered list.
+func (p *palette) moveDown() {
+	if p.cursor < len(p.filtered)-1 {
+		p.cursor++
+	}
+}
+
+// selected returns the currently highlighted item, or nil if none.
+func (p *palette) selected() *paletteItem {
+	if len(p.filtered) == 0 {
+		return nil
+	}
+	if p.cursor < 0 || p.cursor >= len(p.filtered) {
+		return nil
+	}
+	return &p.items[p.filtered[p.cursor]]
+}
+
+// render draws the palette as a floating box.
+func (p *palette) render(width int) string {
+	if !p.visible || len(p.filtered) == 0 {
+		return ""
+	}
+
+	th := theme.Current()
+
+	// Build rows.
+	var rows []string
+	for i, idx := range p.filtered {
+		item := p.items[idx]
+		icon := lipgloss.NewStyle().
+			Width(4).
+			Align(lipgloss.Right).
+			Foreground(lipgloss.Color(th.Muted)).
+			Render(item.Icon)
+
+		label := item.Label
+		if i == p.cursor {
+			label = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color(th.Accent)).
+				Render(label)
+			icon = lipgloss.NewStyle().
+				Width(4).
+				Align(lipgloss.Right).
+				Bold(true).
+				Foreground(lipgloss.Color(th.Accent)).
+				Render(item.Icon)
+		}
+
+		rows = append(rows, icon+" "+label)
+	}
+
+	content := strings.Join(rows, "\n")
+
+	// Filter display.
+	filterLine := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(th.Muted)).
+		Render("/" + p.filter)
+
+	body := filterLine + "\n" + content
+
+	boxWidth := 28
+	if boxWidth > width-4 {
+		boxWidth = width - 4
+	}
+	if boxWidth < 20 {
+		boxWidth = 20
+	}
+
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color(th.Border)).
+		Padding(0, 1).
+		Width(boxWidth)
+
+	return box.Render(body)
+}

--- a/internal/editor/palette_test.go
+++ b/internal/editor/palette_test.go
@@ -1,0 +1,301 @@
+package editor
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/oobagi/notebook/internal/block"
+)
+
+func TestSlashAtPos0OpensPalette(t *testing.T) {
+	m := New(Config{Title: "test", Content: ""})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// The first block is an empty paragraph with cursor at pos 0.
+	if m.palette.visible {
+		t.Fatal("palette should not be visible initially")
+	}
+
+	// Type "/" at position 0 of an empty block.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = updated.(Model)
+
+	if !m.palette.visible {
+		t.Fatal("palette should be visible after typing / at position 0 of an empty block")
+	}
+}
+
+func TestSlashMidLineDoesNotOpenPalette(t *testing.T) {
+	m := New(Config{Title: "test", Content: "hello"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Cursor is at end of "hello" (not pos 0) because textarea places cursor at end.
+	// Move cursor to end to be sure.
+	m.textareas[m.active].CursorEnd()
+
+	// Type "/".
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = updated.(Model)
+
+	if m.palette.visible {
+		t.Fatal("palette should not open when / is typed mid-line")
+	}
+}
+
+func TestPaletteFilterReducesList(t *testing.T) {
+	p := newPalette()
+	p.open(0)
+
+	allCount := len(p.filtered)
+	if allCount != len(p.items) {
+		t.Fatalf("expected all items visible initially, got %d", allCount)
+	}
+
+	// Type "hea" to filter.
+	p.addFilterRune('h')
+	p.addFilterRune('e')
+	p.addFilterRune('a')
+
+	if len(p.filtered) >= allCount {
+		t.Fatalf("filtered list should be smaller after typing 'hea', got %d", len(p.filtered))
+	}
+
+	// All filtered items should contain "hea" in their label.
+	for _, idx := range p.filtered {
+		item := p.items[idx]
+		if !containsPlainText(item.Label, "Heading") {
+			t.Fatalf("filtered item %q should contain 'Heading'", item.Label)
+		}
+	}
+}
+
+func TestPaletteEnterAppliesSelectedType(t *testing.T) {
+	m := New(Config{Title: "test", Content: ""})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Open palette.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = updated.(Model)
+
+	if !m.palette.visible {
+		t.Fatal("palette should be visible")
+	}
+
+	// Move cursor down to "Heading 1" (index 1 in the default list).
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(Model)
+
+	// Press Enter to select.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+
+	if m.palette.visible {
+		t.Fatal("palette should be closed after Enter")
+	}
+
+	if m.blocks[m.active].Type != block.Heading1 {
+		t.Fatalf("expected block type Heading1 (%d), got %d", block.Heading1, m.blocks[m.active].Type)
+	}
+}
+
+func TestPaletteEscClosesWithoutChanges(t *testing.T) {
+	m := New(Config{Title: "test", Content: ""})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	originalType := m.blocks[m.active].Type
+
+	// Open palette.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = updated.(Model)
+
+	if !m.palette.visible {
+		t.Fatal("palette should be visible")
+	}
+
+	// Move cursor to a different item.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(Model)
+
+	// Press Esc to cancel.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+
+	if m.palette.visible {
+		t.Fatal("palette should be closed after Esc")
+	}
+
+	if m.blocks[m.active].Type != originalType {
+		t.Fatalf("block type should be unchanged after Esc, expected %d, got %d", originalType, m.blocks[m.active].Type)
+	}
+}
+
+func TestPaletteContainsAllBlockTypes(t *testing.T) {
+	items := defaultPaletteItems()
+
+	expectedTypes := map[block.BlockType]bool{
+		block.Paragraph:    true,
+		block.Heading1:     true,
+		block.Heading2:     true,
+		block.Heading3:     true,
+		block.BulletList:   true,
+		block.NumberedList: true,
+		block.Checklist:    true,
+		block.CodeBlock:    true,
+		block.Quote:        true,
+		block.Divider:      true,
+	}
+
+	for _, item := range items {
+		delete(expectedTypes, item.Type)
+	}
+
+	if len(expectedTypes) != 0 {
+		t.Fatalf("palette is missing block types: %v", expectedTypes)
+	}
+}
+
+func TestPaletteUpDownNavigation(t *testing.T) {
+	p := newPalette()
+	p.open(0)
+
+	if p.cursor != 0 {
+		t.Fatalf("cursor should start at 0, got %d", p.cursor)
+	}
+
+	p.moveDown()
+	if p.cursor != 1 {
+		t.Fatalf("cursor should be 1 after moveDown, got %d", p.cursor)
+	}
+
+	p.moveDown()
+	if p.cursor != 2 {
+		t.Fatalf("cursor should be 2 after second moveDown, got %d", p.cursor)
+	}
+
+	p.moveUp()
+	if p.cursor != 1 {
+		t.Fatalf("cursor should be 1 after moveUp, got %d", p.cursor)
+	}
+
+	// Move up past the top.
+	p.moveUp()
+	p.moveUp()
+	if p.cursor != 0 {
+		t.Fatalf("cursor should not go below 0, got %d", p.cursor)
+	}
+}
+
+func TestPaletteDividerClearsContent(t *testing.T) {
+	m := New(Config{Title: "test", Content: ""})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Open palette.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = updated.(Model)
+
+	// Type "div" to filter to Divider.
+	for _, r := range "div" {
+		updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = updated.(Model)
+	}
+
+	// Select divider.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+
+	if m.blocks[m.active].Type != block.Divider {
+		t.Fatalf("expected Divider type, got %d", m.blocks[m.active].Type)
+	}
+
+	if m.blocks[m.active].Content != "" {
+		t.Fatalf("divider content should be empty, got %q", m.blocks[m.active].Content)
+	}
+}
+
+func TestPaletteRenderNotEmpty(t *testing.T) {
+	p := newPalette()
+	p.open(0)
+
+	rendered := p.render(80)
+	if rendered == "" {
+		t.Fatal("palette render should not be empty when visible")
+	}
+}
+
+func TestPaletteBackspaceOnEmptyFilterCloses(t *testing.T) {
+	p := newPalette()
+	p.open(0)
+
+	// Filter is empty, backspace should return false (close signal).
+	if p.deleteFilterRune() {
+		t.Fatal("deleteFilterRune should return false when filter is empty")
+	}
+}
+
+func TestPaletteBackspaceRemovesFilterChar(t *testing.T) {
+	p := newPalette()
+	p.open(0)
+
+	p.addFilterRune('h')
+	p.addFilterRune('e')
+
+	if p.filter != "he" {
+		t.Fatalf("filter should be 'he', got %q", p.filter)
+	}
+
+	if !p.deleteFilterRune() {
+		t.Fatal("deleteFilterRune should return true when filter is non-empty")
+	}
+
+	if p.filter != "h" {
+		t.Fatalf("filter should be 'h' after backspace, got %q", p.filter)
+	}
+}
+
+func TestPaletteBlocksTypingToTextarea(t *testing.T) {
+	m := New(Config{Title: "test", Content: ""})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Open palette.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = updated.(Model)
+
+	// Type characters while palette is open.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	m = updated.(Model)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'b'}})
+	m = updated.(Model)
+
+	// Characters should go to the palette filter, not the textarea.
+	if m.palette.filter != "ab" {
+		t.Fatalf("palette filter should be 'ab', got %q", m.palette.filter)
+	}
+
+	// Textarea should still be empty.
+	if m.textareas[m.active].Value() != "" {
+		t.Fatalf("textarea should remain empty while palette is open, got %q", m.textareas[m.active].Value())
+	}
+}
+
+func TestSlashOnNonEmptyBlockDoesNotOpenPalette(t *testing.T) {
+	m := New(Config{Title: "test", Content: "some text"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	// Move cursor to position 0.
+	m.textareas[m.active].CursorStart()
+
+	// Type "/" at position 0 of a non-empty block.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = updated.(Model)
+
+	if m.palette.visible {
+		t.Fatal("palette should not open when block has content, even at position 0")
+	}
+}


### PR DESCRIPTION
## Summary
- New `internal/editor/palette.go` — palette model with filter, navigation, and lipgloss rendering
- `/` at position 0 of empty block opens floating palette with all 10 block types
- Filter-as-you-type with case-insensitive substring matching
- Arrow nav, Enter applies, Esc cancels, Backspace on empty filter closes
- `applyPaletteSelection()` handles type changes including textarea height reconfiguration
- 13 new tests covering all palette behaviors and edge cases
- Help overlay updated

## Test plan
- [x] `go build` — compiles cleanly
- [x] `go vet` — no issues
- [x] `go test ./...` — 482 tests pass
- [x] Code review — no blockers, height fix applied
- [x] Reality check — all acceptance criteria met

🤖 Generated with [Claude Code](https://claude.com/claude-code)