### PR TITLE
feat: checklist toggle, visual polish, help overlay update (Closes #124)

### DIFF
--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -1031,7 +1031,7 @@ func (m Model) renderStatusBar() string {
 	if m.status != "" {
 		right = m.status
 	} else {
-		right = "Ctrl+S save \u00B7 Ctrl+G help \u00B7 Ctrl+Q quit"
+		right = "/ for commands \u00B7 Ctrl+S save \u00B7 Ctrl+G help \u00B7 Ctrl+Q quit"
 	}
 
 	gap := width - lipgloss.Width(left) - lipgloss.Width(right)

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -1099,5 +1099,68 @@ func stripAnsi(s string) string {
 	return string(out)
 }
 
+func TestEmptyDocumentStartsWithOneParagraph(t *testing.T) {
+	m := New(Config{Title: "test", Content: ""})
+
+	if m.BlockCount() != 1 {
+		t.Fatalf("empty document should have exactly 1 block, got %d", m.BlockCount())
+	}
+
+	if m.blocks[0].Type != 0 { // block.Paragraph == 0
+		t.Fatalf("empty document should start with Paragraph block, got type %d", m.blocks[0].Type)
+	}
+
+	if m.blocks[0].Content != "" {
+		t.Fatalf("empty document paragraph should have empty content, got %q", m.blocks[0].Content)
+	}
+
+	if m.active != 0 {
+		t.Fatalf("active block should be 0, got %d", m.active)
+	}
+}
+
+func TestStatusBarContainsCommandsHint(t *testing.T) {
+	m := New(Config{Title: "test", Content: ""})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = updated.(Model)
+
+	view := m.View()
+	if !containsPlainText(view, "/ for commands") {
+		t.Fatal("status bar should contain '/ for commands' hint")
+	}
+}
+
+func TestHelpContainsBlockTypePalette(t *testing.T) {
+	m := New(Config{Title: "test", Content: "hello"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlG})
+	m = updated.(Model)
+
+	view := m.View()
+	if !containsPlainText(view, "Block type palette") {
+		t.Fatal("help overlay should contain 'Block type palette' for / keybinding")
+	}
+}
+
+func TestHelpDoesNotContainStaleEntries(t *testing.T) {
+	m := New(Config{Title: "test", Content: "hello"})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlG})
+	m = updated.(Model)
+
+	view := m.View()
+
+	stale := []string{"Ctrl+P", "Ctrl+E"}
+	for _, s := range stale {
+		if containsPlainText(view, s) {
+			t.Fatalf("help overlay should NOT contain stale entry %q", s)
+		}
+	}
+}
+
 // Verify strings import is used.
 var _ = strings.Contains

--- a/internal/editor/render.go
+++ b/internal/editor/render.go
@@ -31,7 +31,7 @@ func (m Model) renderBlock(idx int) string {
 }
 
 // renderActiveBlock renders the block that currently has focus, showing
-// the textarea for editing.
+// the textarea for editing with a left-margin accent indicator.
 func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 	if idx < 0 || idx >= len(m.textareas) {
 		return ""
@@ -40,26 +40,37 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 	ta := m.textareas[idx]
 	taView := ta.View()
 
+	th := theme.Current()
+	indicator := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(th.Accent)).
+		Render("\u258e")
+
+	var rendered string
+
 	switch b.Type {
 	case block.Heading1:
 		style := lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color(theme.Current().Accent))
-		return style.Render(taView)
+			Foreground(lipgloss.Color(th.Accent))
+		rendered = style.Render(taView)
+		// Add blank line above H1 unless it's the first block.
+		if idx > 0 {
+			rendered = "\n" + rendered
+		}
 
 	case block.Heading2:
 		style := lipgloss.NewStyle().Bold(true)
-		return style.Render(taView)
+		rendered = style.Render(taView)
 
 	case block.Heading3:
 		style := lipgloss.NewStyle().Bold(true).Faint(true)
-		return style.Render(taView)
+		rendered = style.Render(taView)
 
 	case block.BulletList:
 		prefix := lipgloss.NewStyle().
-			Foreground(lipgloss.Color(theme.Current().Muted)).
+			Foreground(lipgloss.Color(th.Muted)).
 			Render("  \u2022  ")
-		return prefix + taView
+		rendered = prefix + taView
 
 	case block.NumberedList:
 		num := 1
@@ -71,9 +82,9 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 			}
 		}
 		prefix := lipgloss.NewStyle().
-			Foreground(lipgloss.Color(theme.Current().Muted)).
+			Foreground(lipgloss.Color(th.Muted)).
 			Render(fmt.Sprintf("  %d. ", num))
-		return prefix + taView
+		rendered = prefix + taView
 
 	case block.Checklist:
 		var marker string
@@ -83,9 +94,9 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 			marker = "  \u2610 "
 		}
 		prefix := lipgloss.NewStyle().
-			Foreground(lipgloss.Color(theme.Current().Muted)).
+			Foreground(lipgloss.Color(th.Muted)).
 			Render(marker)
-		return prefix + taView
+		rendered = prefix + taView
 
 	case block.CodeBlock:
 		label := ""
@@ -97,20 +108,20 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 		border := lipgloss.NewStyle().
 			BorderLeft(true).
 			BorderStyle(lipgloss.NormalBorder()).
-			BorderForeground(lipgloss.Color(theme.Current().Border)).
+			BorderForeground(lipgloss.Color(th.Border)).
 			PaddingLeft(1)
-		return label + "\n" + border.Render(taView)
+		rendered = label + "\n" + border.Render(taView)
 
 	case block.Quote:
 		bar := lipgloss.NewStyle().
-			Foreground(lipgloss.Color(theme.Current().Muted)).
+			Foreground(lipgloss.Color(th.Muted)).
 			Render("\u2502 ")
 		// Prepend the bar to each line of the textarea view.
 		lines := strings.Split(taView, "\n")
 		for i, l := range lines {
 			lines[i] = bar + l
 		}
-		return strings.Join(lines, "\n")
+		rendered = strings.Join(lines, "\n")
 
 	case block.Divider:
 		w := m.width
@@ -120,13 +131,20 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 		if w > 40 {
 			w = 40
 		}
-		return lipgloss.NewStyle().
-			Foreground(lipgloss.Color(theme.Current().Muted)).
+		rendered = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(th.Muted)).
 			Render(strings.Repeat("\u2500", w))
 
 	default:
-		return taView
+		rendered = taView
 	}
+
+	// Prepend the accent-colored active block indicator to each line.
+	lines := strings.Split(rendered, "\n")
+	for i, l := range lines {
+		lines[i] = indicator + " " + l
+	}
+	return strings.Join(lines, "\n")
 }
 
 // renderInactiveBlock renders a block as styled static text (no cursor).


### PR DESCRIPTION
## Summary
- Active block indicator: accent-colored `▎` left-margin bar on focused block
- Spacing above H1 blocks for visual hierarchy
- `/ for commands` hint in default status bar
- Verified all help overlay keybindings are accurate (no stale entries)
- 4 new tests: empty document, status bar hint, help overlay completeness

## Test plan
- [x] `go build` — compiles cleanly
- [x] `go vet` — no issues
- [x] `go test ./...` — 486 tests pass
- [x] Ctrl+D toggle already working from prior implementation
- [x] Help overlay verified complete and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)