### PR TITLE
fix: arrow keys don't navigate slash command palette (Closes #135)

### DIFF
--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -715,35 +715,37 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// When palette is visible, intercept all keys.
 		if m.palette.visible {
-			switch msg.Type {
-			case tea.KeyUp:
+			switch msg.String() {
+			case "up":
 				m.palette.moveUp()
 				return m, nil
-			case tea.KeyDown:
+			case "down":
 				m.palette.moveDown()
 				return m, nil
-			case tea.KeyEnter:
+			case "enter":
 				if sel := m.palette.selected(); sel != nil {
 					m.applyPaletteSelection(sel.Type)
 				}
 				m.palette.close()
 				m.updateViewport()
 				return m, nil
-			case tea.KeyEsc:
+			case "esc":
 				m.palette.close()
 				m.updateViewport()
 				return m, nil
-			case tea.KeyBackspace:
+			case "backspace":
 				if !m.palette.deleteFilterRune() {
 					m.palette.close()
 					m.updateViewport()
 				}
 				return m, nil
-			case tea.KeyRunes:
-				for _, r := range msg.Runes {
-					m.palette.addFilterRune(r)
+			default:
+				if msg.Type == tea.KeyRunes {
+					for _, r := range msg.Runes {
+						m.palette.addFilterRune(r)
+					}
+					return m, nil
 				}
-				return m, nil
 			}
 			// Ignore other keys while palette is open.
 			return m, nil


### PR DESCRIPTION
## Summary
- Switch palette key interception from `msg.Type` to `msg.String()` matching
- Aligns with rest of editor's key handling style
- Fixes arrow keys being silently swallowed in some terminal configurations
- Rune handling moved to `default` case with inner `msg.Type == tea.KeyRunes` check

## Test plan
- [x] `go vet ./...` — clean
- [x] All 486 tests passing across 12 packages
- [x] Code review — no blockers
- [x] Reality check — all spec requirements pass
- [x] Security review — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)