### PR TITLE
chore: remove Ctrl+U and Ctrl+D keybindings (Closes #136)

### DIFF
--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -58,7 +58,6 @@ type Model struct {
 	quitPrompt  bool
 	quitting    bool
 	showHelp    bool
-	clipboard   string // line-level clipboard for Ctrl+Y
 	blockClip   *block.Block // block-level clipboard for Ctrl+K block cut
 	statusGen   int    // generation counter for status auto-dismiss
 	palette     palette // "/" command palette for block type insertion
@@ -482,131 +481,6 @@ func (m *Model) cutBlock() {
 	m.textareas[m.active].Focus()
 }
 
-// toggleCheckbox toggles the Checked field on the active block if it is a
-// Checklist block. For non-checklist blocks, it is a no-op.
-func (m *Model) toggleCheckbox() {
-	if m.active < 0 || m.active >= len(m.blocks) {
-		return
-	}
-	if m.blocks[m.active].Type != block.Checklist {
-		return
-	}
-	m.blocks[m.active].Checked = !m.blocks[m.active].Checked
-}
-
-// deleteToLineStart removes all text from the cursor to the start of the
-// current line in the active textarea.
-func (m *Model) deleteToLineStart() {
-	if m.active < 0 || m.active >= len(m.textareas) {
-		return
-	}
-	ta := &m.textareas[m.active]
-	value := ta.Value()
-	lines := strings.Split(value, "\n")
-
-	line := ta.Line()
-	if line < 0 || line >= len(lines) {
-		return
-	}
-
-	col := ta.LineInfo().ColumnOffset
-	if col <= 0 {
-		return
-	}
-
-	runes := []rune(lines[line])
-	if col > len(runes) {
-		col = len(runes)
-	}
-	lines[line] = string(runes[col:])
-
-	ta.SetValue(strings.Join(lines, "\n"))
-
-	// Reposition cursor.
-	ta.SetCursor(0)
-	for ta.Line() > line {
-		ta.CursorUp()
-	}
-	for ta.Line() < line {
-		ta.CursorDown()
-	}
-}
-
-// cutLine removes the current line from the active textarea and stores it
-// in the line clipboard.
-func (m *Model) cutLine() string {
-	if m.active < 0 || m.active >= len(m.textareas) {
-		return ""
-	}
-	ta := &m.textareas[m.active]
-	value := ta.Value()
-	lines := strings.Split(value, "\n")
-
-	line := ta.Line()
-	if line < 0 || line >= len(lines) {
-		return ""
-	}
-
-	cut := lines[line]
-	newLines := make([]string, 0, len(lines)-1)
-	newLines = append(newLines, lines[:line]...)
-	newLines = append(newLines, lines[line+1:]...)
-
-	ta.SetValue(strings.Join(newLines, "\n"))
-
-	newLineCount := len(newLines)
-	targetLine := line
-	if targetLine >= newLineCount {
-		targetLine = newLineCount - 1
-	}
-	if targetLine < 0 {
-		targetLine = 0
-	}
-	ta.SetCursor(0)
-	for ta.Line() > targetLine {
-		ta.CursorUp()
-	}
-	for ta.Line() < targetLine {
-		ta.CursorDown()
-	}
-
-	return cut
-}
-
-// pasteLine inserts the line clipboard content at the current cursor line
-// in the active textarea.
-func (m *Model) pasteLine() {
-	if m.clipboard == "" {
-		return
-	}
-	if m.active < 0 || m.active >= len(m.textareas) {
-		return
-	}
-	ta := &m.textareas[m.active]
-	value := ta.Value()
-	lines := strings.Split(value, "\n")
-
-	line := ta.Line()
-	if line < 0 {
-		line = 0
-	}
-	if line > len(lines) {
-		line = len(lines)
-	}
-
-	newLines := make([]string, 0, len(lines)+1)
-	newLines = append(newLines, lines[:line]...)
-	newLines = append(newLines, m.clipboard)
-	newLines = append(newLines, lines[line:]...)
-
-	ta.SetValue(strings.Join(newLines, "\n"))
-
-	ta.SetCursor(0)
-	for ta.Line() < line {
-		ta.CursorDown()
-	}
-}
-
 // applyPaletteSelection changes the active block's type to the selected
 // palette item type. Special handling is applied for dividers and code blocks.
 func (m *Model) applyPaletteSelection(bt block.BlockType) {
@@ -764,21 +638,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case "ctrl+k":
 			m.cutBlock()
-			m.updateViewport()
-			return m, nil
-
-		case "ctrl+u":
-			m.deleteToLineStart()
-			m.updateViewport()
-			return m, nil
-
-		case "ctrl+d":
-			m.toggleCheckbox()
-			m.updateViewport()
-			return m, nil
-
-		case "ctrl+y":
-			m.pasteLine()
 			m.updateViewport()
 			return m, nil
 
@@ -999,9 +858,6 @@ func (m Model) renderHelpOverlay() string {
   Ctrl+C    Force quit (no save)
   Ctrl+G    Toggle this help
   Ctrl+K    Cut block
-  Ctrl+Y    Paste line
-  Ctrl+U    Delete to line start
-  Ctrl+D    Toggle checkbox
   Enter     New block below
   Backspace Merge/delete block
   Alt+Up    Move block up

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -480,9 +480,6 @@ func TestHelpViewContainsKeybindings(t *testing.T) {
 		"Ctrl+C", "Force quit",
 		"Ctrl+G", "Toggle this help",
 		"Ctrl+K", "Cut block",
-		"Ctrl+Y", "Paste line",
-		"Ctrl+U", "Delete to line start",
-		"Ctrl+D", "Toggle checkbox",
 	}
 	for _, kb := range keybindings {
 		if !containsPlainText(view, kb) {
@@ -510,45 +507,6 @@ func TestHelpBlocksOtherKeys(t *testing.T) {
 	}
 	if !m.showHelp {
 		t.Fatal("help should still be showing")
-	}
-}
-
-func TestCtrlDTogglesCheckbox(t *testing.T) {
-	m := New(Config{Title: "test", Content: "- [ ] buy milk"})
-	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
-	m = updated.(Model)
-
-	// Toggle unchecked to checked.
-	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
-	m = updated.(Model)
-
-	content := m.Content()
-	if content != "- [x] buy milk" {
-		t.Fatalf("expected %q, got %q", "- [x] buy milk", content)
-	}
-
-	// Toggle checked back to unchecked.
-	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
-	m = updated.(Model)
-
-	content = m.Content()
-	if content != "- [ ] buy milk" {
-		t.Fatalf("expected %q, got %q", "- [ ] buy milk", content)
-	}
-}
-
-func TestCtrlDNoOpOnNonCheckboxBlock(t *testing.T) {
-	m := New(Config{Title: "test", Content: "just a normal line"})
-	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
-	m = updated.(Model)
-
-	contentBefore := m.Content()
-
-	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
-	m = updated.(Model)
-
-	if m.Content() != contentBefore {
-		t.Fatalf("Ctrl+D on non-checkbox block should be no-op, got %q", m.Content())
 	}
 }
 
@@ -671,24 +629,6 @@ func TestCtrlEIsNoOp(t *testing.T) {
 	}
 	if m.quitPrompt {
 		t.Fatal("Ctrl+E should not show quit prompt")
-	}
-}
-
-func TestHelpContainsToggleCheckbox(t *testing.T) {
-	m := New(Config{Title: "test", Content: "hello"})
-	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
-	m = updated.(Model)
-
-	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlG})
-	m = updated.(Model)
-
-	view := m.View()
-
-	if !containsPlainText(view, "Ctrl+D") {
-		t.Fatal("help overlay should contain Ctrl+D keybinding")
-	}
-	if !containsPlainText(view, "Toggle checkbox") {
-		t.Fatal("help overlay should contain 'Toggle checkbox' description")
 	}
 }
 
@@ -1154,7 +1094,7 @@ func TestHelpDoesNotContainStaleEntries(t *testing.T) {
 
 	view := m.View()
 
-	stale := []string{"Ctrl+P", "Ctrl+E"}
+	stale := []string{"Ctrl+P", "Ctrl+E", "Ctrl+U", "Ctrl+D", "Ctrl+Y"}
 	for _, s := range stale {
 		if containsPlainText(view, s) {
 			t.Fatalf("help overlay should NOT contain stale entry %q", s)


### PR DESCRIPTION
## Summary
- Remove Ctrl+U (delete to line start), Ctrl+D (toggle checkbox), Ctrl+Y (paste line) handlers
- Remove dead methods: `deleteToLineStart()`, `toggleCheckbox()`, `cutLine()`, `pasteLine()`
- Remove `clipboard` field from Model struct
- Update help overlay to remove all three entries
- Update tests: remove 3 test functions, add stale-entry guards for removed keys

## Test plan
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] All 483 tests passing (3 removed)
- [x] Code review — no blockers, no dangling references
- [x] Reality check — all 6 tasks verified complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)