### PR TITLE
feat: seed a Welcome note on first launch (Closes #137)

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -12,6 +12,11 @@ import (
 // a note, the browser quits, the editor launches, and the browser
 // re-enters after the editor exits.
 func runBrowser() error {
+	// Seed the welcome note on first launch (no-op after the first time).
+	if err := store.EnsureWelcome(); err != nil {
+		return fmt.Errorf("seed welcome note: %w", err)
+	}
+
 	var lastBook string
 	var lastCursor, lastSavedCursor int
 	for {

--- a/internal/storage/welcome.go
+++ b/internal/storage/welcome.go
@@ -1,0 +1,93 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// welcomeContent is the markdown seeded into the "getting-started" notebook
+// on first launch. It showcases every block type the editor supports.
+const welcomeContent = `# Welcome to Notebook
+
+A simple, beautiful note-taking app for your terminal.
+
+## Block Types
+
+Your notes are made of blocks. Each block has a type. Press ` + "`/`" + ` in the editor to change a block's type. Here are all the types you can use:
+
+### Headings
+
+You're looking at three heading levels right now — H1, H2, and H3.
+
+- Bullet lists organize ideas without order
+- Each line starting with ` + "`-`" + ` becomes a bullet item
+- Nest your thoughts naturally
+
+1. Numbered lists add sequence
+2. Steps, rankings, priorities
+3. Each line starting with a number becomes an item
+
+- [x] Checklists track progress
+- [ ] Toggle items with the ` + "`/`" + ` palette
+- [ ] Try it — change this block's type
+
+> Quotes highlight important ideas or capture someone's words.
+
+---
+
+` + "```" + `
+Code blocks preserve formatting exactly.
+Great for snippets, commands, or ASCII art.
+` + "```" + `
+
+## Keyboard Shortcuts
+
+- **Ctrl+S** — Save
+- **Ctrl+Q** — Quit
+- **Ctrl+G** — Help overlay
+- **Ctrl+K** — Cut block
+- **Enter** — New block
+- **Backspace** — Merge with previous block (when at start)
+- **Alt+Up/Down** — Reorder blocks
+- **/** — Command palette (change block type)
+
+## Getting Started
+
+Create notebooks and notes from the main screen. Open this note in the editor to see how it's built — every block type above is something you can use in your own notes.`
+
+// markerFileName is the name of the hidden file that indicates the store
+// has already been initialised (so deleted welcome notes don't reappear).
+const markerFileName = ".initialized"
+
+// EnsureWelcome seeds a welcome note on first launch. It is safe to call
+// on every startup: if the marker file exists the function returns
+// immediately. A new welcome note is only created when the store contains
+// zero notebooks.
+func (s *Store) EnsureWelcome() error {
+	markerPath := filepath.Join(s.Root, markerFileName)
+
+	// Fast path: marker already exists — nothing to do.
+	if _, err := os.Stat(markerPath); err == nil {
+		return nil
+	}
+
+	// Ensure the root directory exists before listing notebooks.
+	if err := os.MkdirAll(s.Root, 0o755); err != nil {
+		return err
+	}
+
+	notebooks, err := s.ListNotebooks()
+	if err != nil {
+		return err
+	}
+
+	if len(notebooks) == 0 {
+		if err := s.CreateNote("getting-started", "welcome", welcomeContent); err != nil {
+			return err
+		}
+	}
+
+	// Write the marker regardless of whether we created the note, so we
+	// never attempt the seed again.
+	return os.WriteFile(markerPath, []byte("initialized\n"), 0o644)
+}

--- a/internal/storage/welcome_test.go
+++ b/internal/storage/welcome_test.go
@@ -1,0 +1,99 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oobagi/notebook/internal/block"
+)
+
+func TestEnsureWelcomeFirstLaunch(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	if err := store.EnsureWelcome(); err != nil {
+		t.Fatalf("EnsureWelcome: %v", err)
+	}
+
+	// Welcome note should exist.
+	note, err := store.GetNote("getting-started", "welcome")
+	if err != nil {
+		t.Fatalf("GetNote: %v", err)
+	}
+	if note.Content != welcomeContent {
+		t.Error("welcome note content does not match expected content")
+	}
+
+	// Marker file should exist.
+	marker := filepath.Join(store.Root, markerFileName)
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("marker file missing: %v", err)
+	}
+}
+
+func TestEnsureWelcomeSubsequentLaunch(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	// First launch — seeds the note.
+	if err := store.EnsureWelcome(); err != nil {
+		t.Fatalf("first EnsureWelcome: %v", err)
+	}
+
+	// Record notebook count after first launch.
+	notebooks, err := store.ListNotebooks()
+	if err != nil {
+		t.Fatalf("ListNotebooks: %v", err)
+	}
+	countBefore := len(notebooks)
+
+	// Second launch — should be a no-op.
+	if err := store.EnsureWelcome(); err != nil {
+		t.Fatalf("second EnsureWelcome: %v", err)
+	}
+
+	notebooks, err = store.ListNotebooks()
+	if err != nil {
+		t.Fatalf("ListNotebooks after second call: %v", err)
+	}
+	if len(notebooks) != countBefore {
+		t.Errorf("notebook count changed: got %d, want %d", len(notebooks), countBefore)
+	}
+}
+
+func TestEnsureWelcomeDeletedNoteDoesNotReappear(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	// First launch seeds the welcome note.
+	if err := store.EnsureWelcome(); err != nil {
+		t.Fatalf("EnsureWelcome: %v", err)
+	}
+
+	// User deletes the welcome note and the notebook.
+	if err := store.DeleteNotebook("getting-started"); err != nil {
+		t.Fatalf("DeleteNotebook: %v", err)
+	}
+
+	// Subsequent launch should NOT recreate it.
+	if err := store.EnsureWelcome(); err != nil {
+		t.Fatalf("EnsureWelcome after delete: %v", err)
+	}
+
+	notebooks, err := store.ListNotebooks()
+	if err != nil {
+		t.Fatalf("ListNotebooks: %v", err)
+	}
+	for _, nb := range notebooks {
+		if nb == "getting-started" {
+			t.Error("getting-started notebook reappeared after deletion")
+		}
+	}
+}
+
+func TestWelcomeNoteRoundTrips(t *testing.T) {
+	blocks := block.Parse(welcomeContent)
+	serialized := block.Serialize(blocks)
+
+	if serialized != welcomeContent {
+		t.Errorf("welcome content does not round-trip through Parse/Serialize\n--- got ---\n%s\n--- want ---\n%s", serialized, welcomeContent)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `EnsureWelcome()` method to Store that seeds a welcome note on first launch
- Welcome note showcases all 10 block types: paragraphs, H1/H2/H3, bullets, numbered lists, checklists, code blocks, quotes, dividers
- Uses `.initialized` marker file — deleted notes never reappear
- Wired into `runBrowser()` before TUI loop starts

## Test plan
- [x] `go vet ./...` — clean
- [x] All 494 tests passing (4 new)
- [x] TestEnsureWelcomeFirstLaunch — welcome note created with correct content
- [x] TestEnsureWelcomeSubsequentLaunch — idempotent
- [x] TestEnsureWelcomeDeletedNoteDoesNotReappear — marker prevents re-seeding
- [x] TestWelcomeNoteRoundTrips — Parse → Serialize round-trip verified
- [x] Code review, reality check, security review — all clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)