### PR TITLE
fix: H1 block text and cursor hide when selected (Closes #143)

### DIFF
--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -113,7 +113,7 @@ func newTextareaForBlock(b block.Block, width int) textarea.Model {
 	ta := textarea.New()
 	ta.SetValue(b.Content)
 	ta.ShowLineNumbers = false
-	ta.SetWidth(width)
+	ta.SetWidth(width - 2)
 
 	// Code blocks and paragraphs are multi-line; others are single-line.
 	switch b.Type {
@@ -175,7 +175,7 @@ func (m *Model) resizeTextareas() {
 		w = defaultWidth
 	}
 	for i := range m.textareas {
-		m.textareas[i].SetWidth(w)
+		m.textareas[i].SetWidth(w - 2)
 	}
 	// Update viewport dimensions (reserve 1 line for status bar).
 	h := m.height - 1


### PR DESCRIPTION
## Summary
- Subtract 2 from textarea width in `newTextareaForBlock` and `resizeTextareas` to account for the active-block indicator (`▎ `) prepended by `renderActiveBlock`
- Fixes H1 blocks (and all styled blocks) becoming invisible when selected due to ANSI escape code overflow

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — 494 passing
- [x] Code review — correct, minimal fix at both SetWidth call sites
- [x] Reality check — implementation matches issue spec
- [x] Security review — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)