### PR TITLE
fix: Cmd+Backspace is a no-op after Ctrl+U removal (Closes #144)

### DIFF
--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -692,6 +692,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.swapBlocks(1)
 			m.updateViewport()
 			return m, nil
+
+		case "ctrl+u":
+			if m.handleBackspace() {
+				m.updateViewport()
+				return m, nil
+			}
+			m.textareas[m.active], _ = m.textareas[m.active].Update(tea.KeyMsg{Type: tea.KeyBackspace})
+			m.updateViewport()
+			return m, nil
 		}
 
 	case savedMsg:


### PR DESCRIPTION
## Summary
- Route `ctrl+u` (macOS Cmd+Backspace) to existing `handleBackspace()` for block merge/delete at position 0
- Forward a synthetic backspace to the textarea for mid-line character deletion when cursor is not at position 0
- Does NOT re-add the old `deleteToLineStart()` behavior or add ctrl+u to help overlay

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — 494 passing
- [x] Code review — correct placement, handles both empty and non-empty blocks
- [x] Reality check — all spec tasks addressed
- [x] Security review — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)