### PR TITLE
feat: recent notes, editor polish, and cursor fixes (Closes #158)

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -43,12 +43,21 @@ func runBrowser() error {
 			return nil
 		}
 
-		// Launch editor for the selected note.
-		lastBook = sel.Book
 		lastCursor = final.Cursor()
 		lastSavedCursor = final.SavedCursor()
-		if err := editNote(os.Stderr, sel.Book, sel.Note); err != nil {
-			return fmt.Errorf("edit note: %w", err)
+
+		// External file selection from recents.
+		if sel.FilePath != "" {
+			lastBook = ""
+			if err := openFile(sel.FilePath); err != nil {
+				return fmt.Errorf("open file: %w", err)
+			}
+		} else {
+			// Launch editor for the selected note.
+			lastBook = sel.Book
+			if err := editNote(os.Stderr, sel.Book, sel.Note); err != nil {
+				return fmt.Errorf("edit note: %w", err)
+			}
 		}
 
 		// Loop back to re-enter the browser.

--- a/cmd/dispatcher.go
+++ b/cmd/dispatcher.go
@@ -6,10 +6,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/oobagi/notebook/internal/clipboard"
 	"github.com/oobagi/notebook/internal/editor"
+	"github.com/oobagi/notebook/internal/recents"
 	"github.com/oobagi/notebook/internal/storage"
 	"github.com/spf13/cobra"
 )
@@ -206,7 +208,17 @@ func editNote(w io.Writer, book, note string) error {
 		FileSize: fileSize,
 		Content:  n.Content,
 		Save: func(content string) error {
-			return store.UpdateNote(book, note, content)
+			if err := store.UpdateNote(book, note, content); err != nil {
+				return err
+			}
+			// Record in recents (best-effort, never block save).
+			_ = recents.Record(recents.DefaultPath(), recents.Entry{
+				Type:       "store",
+				Notebook:   book,
+				Name:       note,
+				LastEdited: time.Now(),
+			})
+			return nil
 		},
 	}
 

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -5,9 +5,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/oobagi/notebook/internal/editor"
+	"github.com/oobagi/notebook/internal/recents"
 )
 
 // textFileExtensions lists file extensions treated as directly openable text files.
@@ -57,7 +59,16 @@ func openFile(path string) error {
 		FileSize: info.Size(),
 		Content:  string(data),
 		Save: func(content string) error {
-			return os.WriteFile(absPath, []byte(content), originalMode)
+			if err := os.WriteFile(absPath, []byte(content), originalMode); err != nil {
+				return err
+			}
+			// Record in recents (best-effort, never block save).
+			_ = recents.Record(recents.DefaultPath(), recents.Entry{
+				Type:       "external",
+				Path:       absPath,
+				LastEdited: time.Now(),
+			})
+			return nil
 		},
 	}
 

--- a/cmd/recent.go
+++ b/cmd/recent.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/oobagi/notebook/internal/recents"
+	"github.com/oobagi/notebook/internal/storage"
+	"github.com/spf13/cobra"
+)
+
+var recentCmd = &cobra.Command{
+	Use:   "recent",
+	Short: "List recently edited notes",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		w := cmd.OutOrStdout()
+
+		entries, err := recents.Load(recents.DefaultPath())
+		if err != nil {
+			return fmt.Errorf("load recents: %w", err)
+		}
+
+		// Prune stale entries whose files no longer exist.
+		entries = recents.Prune(entries, store.Root)
+		// Persist the pruned list (best-effort).
+		_ = recents.Save(recents.DefaultPath(), entries)
+
+		if len(entries) == 0 {
+			fmt.Fprintln(w, "  No recent notes.")
+			fmt.Fprintln(w)
+			fmt.Fprintln(w, "  Notes appear here after you edit and save them.")
+			return nil
+		}
+
+		var rows [][]string
+		for _, e := range entries {
+			var label, timeStr string
+			switch e.Type {
+			case "store":
+				label = storage.DisplayName(e.Notebook) + " \u203A " + storage.DisplayName(e.Name)
+			case "external":
+				label = shortenHome(e.Path)
+			default:
+				continue
+			}
+			timeStr = relativeTime(e.LastEdited)
+			rows = append(rows, []string{label, timeStr})
+		}
+
+		for _, line := range alignColumns(rows) {
+			fmt.Fprintln(w, line)
+		}
+		return nil
+	},
+}
+
+var recentClearCmd = &cobra.Command{
+	Use:   "clear",
+	Short: "Clear the recent notes list",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		w := cmd.OutOrStdout()
+
+		if err := recents.Save(recents.DefaultPath(), nil); err != nil {
+			return fmt.Errorf("clear recents: %w", err)
+		}
+
+		printSuccess(w, "Cleared recent notes")
+		return nil
+	},
+}
+
+// shortenHome replaces the home directory prefix with ~/ for display.
+func shortenHome(path string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if strings.HasPrefix(path, home) {
+		return "~" + path[len(home):]
+	}
+	return path
+}
+
+func init() {
+	recentCmd.AddCommand(recentClearCmd)
+	rootCmd.AddCommand(recentCmd)
+}

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -12,6 +12,7 @@ import (
 	"github.com/oobagi/notebook/internal/clipboard"
 	"github.com/oobagi/notebook/internal/config"
 	"github.com/oobagi/notebook/internal/model"
+	"github.com/oobagi/notebook/internal/recents"
 	"github.com/oobagi/notebook/internal/storage"
 	"github.com/oobagi/notebook/internal/theme"
 )
@@ -30,8 +31,9 @@ type Config struct {
 
 // Selection represents a note the user chose to open.
 type Selection struct {
-	Book string
-	Note string
+	Book     string
+	Note     string
+	FilePath string // non-empty for external file selections
 }
 
 // Model is the Bubble Tea model for the notebook/note browser.
@@ -68,6 +70,11 @@ type Model struct {
 	// Temporary status message shown in the status bar.
 	statusText string
 	statusGen  int // generation counter for auto-dismiss
+
+	// Recents view fields.
+	recentsView    bool            // whether recents tab is active at L0
+	recentEntries  []recents.Entry // loaded recent entries
+	filteredRecent []int           // indices into recentEntries after filtering
 
 	// Theme picker fields.
 	themeMode      bool   // theme picker overlay visible
@@ -132,6 +139,11 @@ type notesLoadedMsg struct {
 	notes []model.Note
 }
 
+// recentsLoadedMsg carries the loaded recents list.
+type recentsLoadedMsg struct {
+	entries []recents.Entry
+}
+
 // Init implements tea.Model.
 func (m Model) Init() tea.Cmd {
 	if m.level == 1 {
@@ -182,6 +194,20 @@ func (m Model) loadNotes(book string) tea.Cmd {
 			return errMsg{err}
 		}
 		return notesLoadedMsg{notes: notes}
+	}
+}
+
+func (m Model) loadRecents() tea.Cmd {
+	return func() tea.Msg {
+		entries, err := recents.Load(recents.DefaultPath())
+		if err != nil {
+			return errMsg{err}
+		}
+		// Prune stale entries once at load time.
+		entries = recents.Prune(entries, m.store.Root)
+		// Persist pruned list (best-effort).
+		_ = recents.Save(recents.DefaultPath(), entries)
+		return recentsLoadedMsg{entries: entries}
 	}
 }
 
@@ -241,7 +267,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case recentsLoadedMsg:
+		m.recentEntries = msg.entries
+		m.resetFilter()
+		return m, nil
+
 	case reloadMsg:
+		if m.recentsView {
+			return m, m.loadRecents()
+		}
 		if m.level == 0 {
 			return m, m.loadNotebooks()
 		}
@@ -317,6 +351,21 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	switch msg.Type {
+	case tea.KeyTab:
+		// Toggle between notebooks and recents at L0.
+		if m.level == 0 {
+			m.recentsView = !m.recentsView
+			m.cursor = 0
+			m.filter = ""
+			m.filtering = false
+			m.filtered = nil
+			if m.recentsView {
+				return m, m.loadRecents()
+			}
+			return m, m.loadNotebooks()
+		}
+		return m, nil
+
 	case tea.KeyUp:
 		if m.cursor > 0 {
 			m.cursor--
@@ -357,12 +406,15 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if s == "d" {
+			if m.recentsView {
+				return m.removeRecentEntry()
+			}
 			return m.startDelete()
 		}
-		if s == "r" {
+		if s == "r" && !m.recentsView {
 			return m.startRename()
 		}
-		if s == "n" {
+		if s == "n" && !m.recentsView {
 			return m.startCreate()
 		}
 		if s == "c" && m.level == 1 {
@@ -669,6 +721,29 @@ func (m Model) copyNote() (tea.Model, tea.Cmd) {
 	}
 }
 
+func (m Model) removeRecentEntry() (tea.Model, tea.Cmd) {
+	if len(m.filteredRecent) == 0 {
+		return m, nil
+	}
+	if m.cursor >= len(m.filteredRecent) {
+		return m, nil
+	}
+	idx := m.filteredRecent[m.cursor]
+	target := m.recentEntries[idx]
+
+	return m, func() tea.Msg {
+		entries, err := recents.Load(recents.DefaultPath())
+		if err != nil {
+			return statusMsg{fmt.Sprintf("Could not load recents: %s", err)}
+		}
+		entries = recents.Remove(entries, target)
+		if err := recents.Save(recents.DefaultPath(), entries); err != nil {
+			return statusMsg{fmt.Sprintf("Could not save recents: %s", err)}
+		}
+		return reloadMsg{}
+	}
+}
+
 func (m Model) startThemePicker() (tea.Model, tea.Cmd) {
 	m.themeMode = true
 
@@ -968,6 +1043,24 @@ func (m Model) renderThemeOverlay() string {
 
 func (m *Model) applyFilter() {
 	query := strings.ToLower(m.filter)
+
+	if m.recentsView {
+		m.filteredRecent = nil
+		for i, e := range m.recentEntries {
+			label := recentEntryLabel(e)
+			if query == "" || strings.Contains(strings.ToLower(label), query) {
+				m.filteredRecent = append(m.filteredRecent, i)
+			}
+		}
+		if m.cursor >= len(m.filteredRecent) {
+			m.cursor = len(m.filteredRecent) - 1
+		}
+		if m.cursor < 0 {
+			m.cursor = 0
+		}
+		return
+	}
+
 	m.filtered = nil
 
 	if m.level == 0 {
@@ -996,6 +1089,21 @@ func (m *Model) resetFilter() {
 	m.filter = ""
 	m.filtering = false
 	m.filtered = nil
+	m.filteredRecent = nil
+
+	if m.recentsView {
+		m.filteredRecent = make([]int, len(m.recentEntries))
+		for i := range m.recentEntries {
+			m.filteredRecent[i] = i
+		}
+		if m.cursor >= len(m.filteredRecent) {
+			m.cursor = len(m.filteredRecent) - 1
+		}
+		if m.cursor < 0 {
+			m.cursor = 0
+		}
+		return
+	}
 
 	if m.level == 0 {
 		m.filtered = make([]int, len(m.notebooks))
@@ -1018,10 +1126,37 @@ func (m *Model) resetFilter() {
 }
 
 func (m Model) listLen() int {
+	if m.recentsView {
+		return len(m.filteredRecent)
+	}
 	return len(m.filtered)
 }
 
 func (m Model) handleEnter() (tea.Model, tea.Cmd) {
+	// Handle recents view selection.
+	if m.recentsView {
+		if len(m.filteredRecent) == 0 {
+			return m, nil
+		}
+		if m.cursor >= len(m.filteredRecent) {
+			return m, nil
+		}
+		idx := m.filteredRecent[m.cursor]
+		entry := m.recentEntries[idx]
+		switch entry.Type {
+		case "store":
+			m.selected = &Selection{
+				Book: entry.Notebook,
+				Note: entry.Name,
+			}
+		case "external":
+			m.selected = &Selection{
+				FilePath: entry.Path,
+			}
+		}
+		return m, tea.Quit
+	}
+
 	if len(m.filtered) == 0 {
 		return m, nil
 	}
@@ -1054,6 +1189,15 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleEsc() (tea.Model, tea.Cmd) {
+	if m.recentsView {
+		m.recentsView = false
+		m.cursor = 0
+		m.filter = ""
+		m.filtering = false
+		m.filtered = nil
+		m.filteredRecent = nil
+		return m, m.loadNotebooks()
+	}
 	if m.level == 1 {
 		m.level = 0
 		m.cursor = m.savedCursor
@@ -1070,7 +1214,22 @@ func (m Model) handleEsc() (tea.Model, tea.Cmd) {
 // renderHelpOverlay builds the centered help panel.
 func (m Model) renderHelpOverlay() string {
 	var help string
-	if m.level == 0 {
+	if m.recentsView {
+		help = `  Keybindings
+  ───────────────────────────
+
+  ↑/↓       Navigate
+  Enter      Open note/file
+  d          Remove from recents
+  Tab        Switch to notebooks
+  t          Theme picker
+  /          Search
+  Esc        Back to notebooks
+  q          Quit
+  ?          Toggle help
+
+  Press ? or Esc to close`
+	} else if m.level == 0 {
 		help = `  Keybindings
   ───────────────────────────
 
@@ -1079,6 +1238,7 @@ func (m Model) renderHelpOverlay() string {
   n          New notebook
   d          Delete notebook
   r          Rename notebook
+  Tab        Switch to recents
   t          Theme picker
   /          Search
   q          Quit
@@ -1176,13 +1336,26 @@ func (m Model) View() string {
 
 func (m Model) renderBreadcrumb() string {
 	style := lipgloss.NewStyle().Bold(true).Padding(0, 1)
-	if m.level == 0 {
-		return style.Render("notebook")
+	dim := lipgloss.NewStyle().Faint(true)
+
+	if m.recentsView {
+		active := style.Render("Recent")
+		inactive := dim.Render("Notebooks")
+		return fmt.Sprintf(" %s  %s", active, inactive)
 	}
-	return style.Render(fmt.Sprintf("notebook \u203A %s", storage.DisplayName(m.currentBook)))
+
+	if m.level == 0 {
+		active := style.Render("Notebooks")
+		inactive := dim.Render("Recent")
+		return fmt.Sprintf(" %s  %s", active, inactive)
+	}
+	return fmt.Sprintf(" %s", style.Render(fmt.Sprintf("notebook \u203A %s", storage.DisplayName(m.currentBook))))
 }
 
 func (m Model) renderContent(maxLines int) string {
+	if m.recentsView {
+		return m.renderRecentList(maxLines)
+	}
 	if m.level == 0 {
 		return m.renderNotebookList(maxLines)
 	}
@@ -1239,6 +1412,102 @@ func (m Model) renderNoteList(maxLines int) string {
 	}
 
 	return b.String()
+}
+
+func (m Model) renderRecentList(maxLines int) string {
+	if len(m.recentEntries) == 0 {
+		return m.renderEmptyRecents()
+	}
+
+	if len(m.filteredRecent) == 0 && m.filtering {
+		return "  No matches\n"
+	}
+
+	var b strings.Builder
+	visible := m.visibleRange(len(m.filteredRecent), maxLines)
+
+	for vi, fi := range visible {
+		idx := m.filteredRecent[fi]
+		e := m.recentEntries[idx]
+		selected := fi == m.cursor
+		line := m.formatRecentLine(e, selected)
+		b.WriteString(line)
+		if vi < len(visible)-1 {
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
+}
+
+func (m Model) formatRecentLine(e recents.Entry, selected bool) string {
+	bullet := "  "
+	label := recentEntryLabel(e)
+	display := label
+	timeStr := relativeTime(e.LastEdited)
+
+	if selected {
+		bulletStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(theme.Current().Accent))
+		bullet = bulletStyle.Render("\u25CF") + " "
+		nameStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(theme.Current().Accent))
+		display = nameStyle.Render(label)
+	}
+
+	return fmt.Sprintf("%s%s    %s",
+		padRight(bullet, 2),
+		padRight(display, m.recentNameColWidth()),
+		timeStr,
+	)
+}
+
+func (m Model) recentNameColWidth() int {
+	maxLen := 0
+	for _, e := range m.recentEntries {
+		if dl := len(recentEntryLabel(e)); dl > maxLen {
+			maxLen = dl
+		}
+	}
+	if maxLen < 10 {
+		maxLen = 10
+	}
+	return maxLen
+}
+
+// recentEntryLabel returns the display label for a recent entry.
+func recentEntryLabel(e recents.Entry) string {
+	switch e.Type {
+	case "store":
+		return storage.DisplayName(e.Notebook) + " \u203A " + storage.DisplayName(e.Name)
+	case "external":
+		return shortenHome(e.Path)
+	}
+	return ""
+}
+
+// shortenHome replaces the home directory prefix with ~/ for display.
+func shortenHome(path string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if strings.HasPrefix(path, home) {
+		return "~" + path[len(home):]
+	}
+	return path
+}
+
+func (m Model) renderEmptyRecents() string {
+	w := m.width
+	if w <= 0 {
+		w = 80
+	}
+	h := m.height - 4
+	if h < 1 {
+		h = 1
+	}
+	dim := lipgloss.NewStyle().Faint(true)
+	msg := "No recent notes.\n\nNotes appear here after you edit and save them."
+	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, dim.Render(msg))
 }
 
 // visibleRange returns the slice of filtered indices to display,
@@ -1408,6 +1677,14 @@ func (m Model) renderStatusBar() string {
 			after = after[1:]
 		}
 		return dim.Render("  Filter: "+before) + cursor.Render(cursorChar) + dim.Render(after+" \u00B7 Esc clear \u00B7 Enter select")
+	}
+
+	if m.recentsView {
+		return dim.Render("  \u2191/\u2193 navigate \u00B7 Enter open \u00B7 d remove \u00B7 Tab notebooks \u00B7 / search \u00B7 q quit \u00B7 ? help")
+	}
+
+	if m.level == 0 {
+		return dim.Render("  \u2191/\u2193 navigate \u00B7 Enter open \u00B7 Tab recents \u00B7 / search \u00B7 q quit \u00B7 ? help")
 	}
 
 	return dim.Render("  \u2191/\u2193 navigate \u00B7 Enter open \u00B7 / search \u00B7 Esc back \u00B7 q quit \u00B7 ? help")

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -374,9 +374,6 @@ func (m *Model) mergeBlockUp(idx int) {
 	// Sync content from textarea.
 	currentContent := m.textareas[idx].Value()
 	prevContent := m.textareas[idx-1].Value()
-	// Remember the merge point (end of previous content).
-	mergeCol := len([]rune(prevContent))
-
 	// Merge content: concatenate directly (no added newline), matching
 	// Notion/Google Docs behavior where backspace joins text on the same line.
 	merged := prevContent + currentContent
@@ -385,9 +382,10 @@ func (m *Model) mergeBlockUp(idx int) {
 	m.blocks[idx-1].Content = merged
 	m.textareas[idx-1].SetValue(merged)
 
-	// If the target block was empty, adopt the source block's type so that
-	// merging a heading into an empty paragraph preserves the heading type.
-	if prevContent == "" {
+	// If the target block was an empty paragraph, adopt the source block's
+	// type so that merging a heading into an empty paragraph preserves the
+	// heading type. Non-paragraph targets (e.g. list items) keep their type.
+	if prevContent == "" && m.blocks[idx-1].Type == block.Paragraph {
 		m.blocks[idx-1].Type = m.blocks[idx].Type
 		m.blocks[idx-1].Checked = m.blocks[idx].Checked
 	}
@@ -407,12 +405,21 @@ func (m *Model) mergeBlockUp(idx int) {
 	m.blocks = append(m.blocks[:idx], m.blocks[idx+1:]...)
 	m.textareas = append(m.textareas[:idx], m.textareas[idx+1:]...)
 
-	// Focus previous block and position cursor at merge point.
+	// Focus previous block and position cursor at the merge point.
 	m.active = idx - 1
 	m.cursorCmd = m.textareas[m.active].Focus()
 
-	// Position cursor at the merge point.
-	m.textareas[m.active].SetCursor(mergeCol)
+	// Navigate to the merge point: SetValue leaves the cursor at the end
+	// of the content. Walk up from the end to reach the target row (last
+	// line of prevContent), then set the column within that row.
+	mergedLines := strings.Split(merged, "\n")
+	prevLines := strings.Split(prevContent, "\n")
+	mergeRow := len(prevLines) - 1
+	rowsFromEnd := len(mergedLines) - 1 - mergeRow
+	for i := 0; i < rowsFromEnd; i++ {
+		m.textareas[m.active].CursorUp()
+	}
+	m.textareas[m.active].SetCursor(len([]rune(prevLines[mergeRow])))
 }
 
 // swapBlocks swaps the block at idx with the block at idx+delta (delta is
@@ -628,6 +635,7 @@ func (m *Model) handleBackspace() bool {
 		newTA := newTextareaForBlock(m.blocks[m.active], m.width)
 		newTA.SetValue(content)
 		m.cursorCmd = newTA.Focus()
+		newTA.SetCursor(0)
 		m.textareas[m.active] = newTA
 		return true
 	}
@@ -1230,7 +1238,7 @@ func (m Model) renderStatusBar() string {
 		width = 80
 	}
 
-	left := ""
+	left := " "
 	if !m.wordWrap {
 		left += " [no-wrap]"
 	}

--- a/internal/editor/render.go
+++ b/internal/editor/render.go
@@ -25,10 +25,10 @@ func (m Model) renderHeader() string {
 		width = 80
 	}
 
-	titleStyle := lipgloss.NewStyle().Bold(true)
+	titleStyle := lipgloss.NewStyle().Bold(true).PaddingLeft(1).PaddingRight(1)
 	metaStyle := lipgloss.NewStyle().Faint(true)
 
-	left := titleStyle.Render(m.config.Title)
+	left := " " + titleStyle.Render(m.config.Title)
 
 	var rightParts []string
 	if m.config.FilePath != "" {

--- a/internal/recents/recents.go
+++ b/internal/recents/recents.go
@@ -1,0 +1,159 @@
+package recents
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// MaxEntries is the maximum number of recent entries to keep.
+const MaxEntries = 50
+
+// Entry represents a recently edited note or file.
+type Entry struct {
+	Type       string    `json:"type"`                 // "store" or "external"
+	Notebook   string    `json:"notebook,omitempty"`    // store notes only
+	Name       string    `json:"name,omitempty"`        // store notes only
+	Path       string    `json:"path,omitempty"`        // external files only
+	LastEdited time.Time `json:"last_edited"`
+}
+
+// DefaultPath returns the default path to the recents file:
+// ~/.config/notebook/recent.json.
+func DefaultPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "notebook", "recent.json")
+}
+
+// Load reads the recents list from the given path.
+// If the file does not exist, an empty slice is returned without error.
+func Load(path string) ([]Entry, error) {
+	if path == "" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read recents: %w", err)
+	}
+
+	var entries []Entry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, fmt.Errorf("parse recents: %w", err)
+	}
+	return entries, nil
+}
+
+// Save writes the recents list to the given path, creating directories
+// as needed.
+func Save(path string, entries []Entry) error {
+	if path == "" {
+		return nil
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create recents directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode recents: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write recents: %w", err)
+	}
+	return nil
+}
+
+// Record upserts an entry into the recents list and saves to disk.
+// If an entry with the same identity already exists, it is updated
+// in place. The list is capped at MaxEntries.
+func Record(path string, entry Entry) error {
+	entries, err := Load(path)
+	if err != nil {
+		// Start fresh if the file is corrupted.
+		entries = nil
+	}
+
+	entries = upsert(entries, entry)
+	return Save(path, entries)
+}
+
+// Prune removes entries whose backing files no longer exist.
+// For "store" entries, the file is <storeRoot>/<notebook>/<name>.md.
+// For "external" entries, the file is entry.Path.
+func Prune(entries []Entry, storeRoot string) []Entry {
+	kept := make([]Entry, 0, len(entries))
+	for _, e := range entries {
+		switch e.Type {
+		case "store":
+			p := filepath.Join(storeRoot, e.Notebook, e.Name+".md")
+			if _, err := os.Stat(p); err == nil {
+				kept = append(kept, e)
+			}
+		case "external":
+			if _, err := os.Stat(e.Path); err == nil {
+				kept = append(kept, e)
+			}
+		default:
+			// Unknown type — drop it.
+		}
+	}
+	return kept
+}
+
+// Remove deletes a single entry from the list by identity match.
+func Remove(entries []Entry, target Entry) []Entry {
+	kept := make([]Entry, 0, len(entries))
+	for _, e := range entries {
+		if !sameIdentity(e, target) {
+			kept = append(kept, e)
+		}
+	}
+	return kept
+}
+
+// upsert adds or updates an entry, keeping the list sorted by
+// LastEdited descending (most recent first) and capped at MaxEntries.
+func upsert(entries []Entry, entry Entry) []Entry {
+	// Remove existing entry with same identity.
+	result := make([]Entry, 0, len(entries)+1)
+	for _, e := range entries {
+		if !sameIdentity(e, entry) {
+			result = append(result, e)
+		}
+	}
+
+	// Prepend the new/updated entry (most recent first).
+	result = append([]Entry{entry}, result...)
+
+	// Cap at MaxEntries.
+	if len(result) > MaxEntries {
+		result = result[:MaxEntries]
+	}
+	return result
+}
+
+// sameIdentity returns true if two entries refer to the same note or file.
+func sameIdentity(a, b Entry) bool {
+	if a.Type != b.Type {
+		return false
+	}
+	switch a.Type {
+	case "store":
+		return a.Notebook == b.Notebook && a.Name == b.Name
+	case "external":
+		return a.Path == b.Path
+	}
+	return false
+}

--- a/internal/recents/recents_test.go
+++ b/internal/recents/recents_test.go
@@ -1,0 +1,262 @@
+package recents
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "recent.json")
+
+	entries := []Entry{
+		{
+			Type:       "store",
+			Notebook:   "work",
+			Name:       "standup",
+			LastEdited: time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		},
+		{
+			Type:       "external",
+			Path:       "/tmp/todo.txt",
+			LastEdited: time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+		},
+	}
+
+	if err := Save(path, entries); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if len(loaded) != len(entries) {
+		t.Fatalf("got %d entries, want %d", len(loaded), len(entries))
+	}
+
+	if loaded[0].Type != "store" || loaded[0].Notebook != "work" || loaded[0].Name != "standup" {
+		t.Errorf("entry 0 mismatch: %+v", loaded[0])
+	}
+	if loaded[1].Type != "external" || loaded[1].Path != "/tmp/todo.txt" {
+		t.Errorf("entry 1 mismatch: %+v", loaded[1])
+	}
+}
+
+func TestLoadMissing(t *testing.T) {
+	entries, err := Load(filepath.Join(t.TempDir(), "nonexistent.json"))
+	if err != nil {
+		t.Fatalf("Load nonexistent: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected empty slice, got %d entries", len(entries))
+	}
+}
+
+func TestLoadEmptyPath(t *testing.T) {
+	entries, err := Load("")
+	if err != nil {
+		t.Fatalf("Load empty path: %v", err)
+	}
+	if entries != nil {
+		t.Errorf("expected nil, got %v", entries)
+	}
+}
+
+func TestUpsert(t *testing.T) {
+	now := time.Now()
+	entries := []Entry{
+		{Type: "store", Notebook: "work", Name: "standup", LastEdited: now.Add(-1 * time.Hour)},
+		{Type: "store", Notebook: "journal", Name: "today", LastEdited: now.Add(-2 * time.Hour)},
+	}
+
+	// Update existing entry — should move to front with new timestamp.
+	updated := Entry{Type: "store", Notebook: "work", Name: "standup", LastEdited: now}
+	result := upsert(entries, updated)
+
+	if len(result) != 2 {
+		t.Fatalf("got %d entries, want 2", len(result))
+	}
+	if result[0].Notebook != "work" || result[0].Name != "standup" {
+		t.Errorf("expected updated entry first, got %+v", result[0])
+	}
+	if !result[0].LastEdited.Equal(now) {
+		t.Errorf("timestamp not updated: got %v, want %v", result[0].LastEdited, now)
+	}
+}
+
+func TestUpsertNewEntry(t *testing.T) {
+	now := time.Now()
+	entries := []Entry{
+		{Type: "store", Notebook: "work", Name: "standup", LastEdited: now.Add(-1 * time.Hour)},
+	}
+
+	newEntry := Entry{Type: "external", Path: "/tmp/notes.md", LastEdited: now}
+	result := upsert(entries, newEntry)
+
+	if len(result) != 2 {
+		t.Fatalf("got %d entries, want 2", len(result))
+	}
+	if result[0].Type != "external" || result[0].Path != "/tmp/notes.md" {
+		t.Errorf("expected new entry first, got %+v", result[0])
+	}
+}
+
+func TestCap(t *testing.T) {
+	now := time.Now()
+	var entries []Entry
+	for i := 0; i < MaxEntries; i++ {
+		entries = append(entries, Entry{
+			Type:       "store",
+			Notebook:   "book",
+			Name:       "note-" + string(rune('a'+i%26)) + string(rune('0'+i/26)),
+			LastEdited: now.Add(-time.Duration(i) * time.Hour),
+		})
+	}
+
+	// Adding one more should cap at MaxEntries.
+	extra := Entry{Type: "external", Path: "/tmp/extra.txt", LastEdited: now}
+	result := upsert(entries, extra)
+
+	if len(result) != MaxEntries {
+		t.Errorf("got %d entries, want %d", len(result), MaxEntries)
+	}
+	if result[0].Type != "external" {
+		t.Errorf("expected new entry first, got %+v", result[0])
+	}
+}
+
+func TestPrune(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a real file for one store entry.
+	bookDir := filepath.Join(dir, "work")
+	if err := os.MkdirAll(bookDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bookDir, "standup.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a real external file.
+	extFile := filepath.Join(dir, "todo.txt")
+	if err := os.WriteFile(extFile, []byte("todo"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	entries := []Entry{
+		{Type: "store", Notebook: "work", Name: "standup", LastEdited: now},
+		{Type: "store", Notebook: "work", Name: "deleted-note", LastEdited: now},
+		{Type: "external", Path: extFile, LastEdited: now},
+		{Type: "external", Path: "/nonexistent/file.txt", LastEdited: now},
+	}
+
+	result := Prune(entries, dir)
+	if len(result) != 2 {
+		t.Fatalf("got %d entries after prune, want 2", len(result))
+	}
+	if result[0].Name != "standup" {
+		t.Errorf("expected standup, got %+v", result[0])
+	}
+	if result[1].Path != extFile {
+		t.Errorf("expected %s, got %+v", extFile, result[1])
+	}
+}
+
+func TestRemove(t *testing.T) {
+	now := time.Now()
+	entries := []Entry{
+		{Type: "store", Notebook: "work", Name: "standup", LastEdited: now},
+		{Type: "external", Path: "/tmp/todo.txt", LastEdited: now},
+		{Type: "store", Notebook: "journal", Name: "today", LastEdited: now},
+	}
+
+	result := Remove(entries, Entry{Type: "store", Notebook: "work", Name: "standup"})
+	if len(result) != 2 {
+		t.Fatalf("got %d entries, want 2", len(result))
+	}
+	if result[0].Type != "external" {
+		t.Errorf("expected external first, got %+v", result[0])
+	}
+}
+
+func TestRecord(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "recent.json")
+
+	now := time.Now()
+	entry := Entry{Type: "store", Notebook: "work", Name: "standup", LastEdited: now}
+
+	if err := Record(path, entry); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	entries, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	if entries[0].Notebook != "work" || entries[0].Name != "standup" {
+		t.Errorf("entry mismatch: %+v", entries[0])
+	}
+}
+
+func TestSameIdentity(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b Entry
+		want bool
+	}{
+		{
+			"same store entry",
+			Entry{Type: "store", Notebook: "work", Name: "standup"},
+			Entry{Type: "store", Notebook: "work", Name: "standup"},
+			true,
+		},
+		{
+			"different store name",
+			Entry{Type: "store", Notebook: "work", Name: "standup"},
+			Entry{Type: "store", Notebook: "work", Name: "retro"},
+			false,
+		},
+		{
+			"different store notebook",
+			Entry{Type: "store", Notebook: "work", Name: "standup"},
+			Entry{Type: "store", Notebook: "journal", Name: "standup"},
+			false,
+		},
+		{
+			"same external path",
+			Entry{Type: "external", Path: "/tmp/a.txt"},
+			Entry{Type: "external", Path: "/tmp/a.txt"},
+			true,
+		},
+		{
+			"different external path",
+			Entry{Type: "external", Path: "/tmp/a.txt"},
+			Entry{Type: "external", Path: "/tmp/b.txt"},
+			false,
+		},
+		{
+			"different types",
+			Entry{Type: "store", Notebook: "work", Name: "standup"},
+			Entry{Type: "external", Path: "/tmp/a.txt"},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sameIdentity(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("sameIdentity(%+v, %+v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Recent notes tracking** — new `internal/recents` package with JSON-backed list at `~/.config/notebook/recent.json`, `notebook recent` and `notebook recent clear` CLI commands, recents tab in TUI browser (Tab to toggle, d to remove, Enter to open)
- **Editor UI consistency** — aligned editor header and status bar padding with browser breadcrumb spacing
- **Cursor fix: backspace merge** — cursor now lands at the merge point instead of jumping to end, works for all block types including multi-line (code blocks, quotes)
- **Cursor fix: list conversion** — backspace on list item at position 0 now keeps cursor at start
- **Cursor fix: empty list merge** — backspace into an empty list item preserves the list type instead of converting to paragraph

## Test plan

- [ ] Edit a store note → verify it appears in `notebook recent`
- [ ] Edit an external file → verify it appears in `notebook recent`
- [ ] `notebook recent clear` → verify list is emptied
- [ ] TUI browser: Tab toggles between Notebooks and Recent tabs
- [ ] TUI browser: selecting a recent entry opens it in the editor
- [ ] TUI browser: d on a recent entry removes it from the list
- [ ] Stale entries (deleted files) pruned on display
- [ ] Backspace at position 0 of a paragraph merges up with cursor at merge point
- [ ] Backspace at position 0 of a code block merges up with cursor at merge point
- [ ] Backspace at position 0 of a list item converts to paragraph with cursor at start
- [ ] Backspace into empty list item appends content, keeps list type
- [ ] All tests pass, go vet clean (542 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)