### PR TITLE
refactor: extract shared format package, DRY up recents

### DIFF
--- a/cmd/dispatcher.go
+++ b/cmd/dispatcher.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/oobagi/notebook/internal/clipboard"
 	"github.com/oobagi/notebook/internal/editor"
+	"github.com/oobagi/notebook/internal/format"
 	"github.com/oobagi/notebook/internal/recents"
 	"github.com/oobagi/notebook/internal/storage"
 	"github.com/spf13/cobra"
@@ -125,8 +125,8 @@ func listNotesInBook(w io.Writer, book string) error {
 		if err != nil {
 			return fmt.Errorf("stat note %q: %w", n.Name, err)
 		}
-		sizeStr := humanSize(info.Size())
-		timeStr := relativeTime(info.ModTime())
+		sizeStr := format.HumanSize(info.Size())
+		timeStr := format.RelativeTime(info.ModTime())
 		rows = append(rows, []string{n.Name, sizeStr, timeStr})
 	}
 
@@ -211,13 +211,7 @@ func editNote(w io.Writer, book, note string) error {
 			if err := store.UpdateNote(book, note, content); err != nil {
 				return err
 			}
-			// Record in recents (best-effort, never block save).
-			_ = recents.Record(recents.DefaultPath(), recents.Entry{
-				Type:       "store",
-				Notebook:   book,
-				Name:       note,
-				LastEdited: time.Now(),
-			})
+			recents.RecordStore(book, note)
 			return nil
 		},
 	}

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/oobagi/notebook/internal/editor"
@@ -62,12 +61,7 @@ func openFile(path string) error {
 			if err := os.WriteFile(absPath, []byte(content), originalMode); err != nil {
 				return err
 			}
-			// Record in recents (best-effort, never block save).
-			_ = recents.Record(recents.DefaultPath(), recents.Entry{
-				Type:       "external",
-				Path:       absPath,
-				LastEdited: time.Now(),
-			})
+			recents.RecordExternal(absPath)
 			return nil
 		},
 	}

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -3,71 +3,7 @@ package cmd
 import (
 	"fmt"
 	"strings"
-	"time"
 )
-
-// relativeTime returns a human-friendly relative timestamp string.
-// It follows the design system rules from docs/design.md.
-func relativeTime(t time.Time) string {
-	return relativeTimeFrom(t, time.Now())
-}
-
-// relativeTimeFrom returns a relative timestamp using the given reference time.
-// Exported logic for testing.
-func relativeTimeFrom(t time.Time, now time.Time) string {
-	d := now.Sub(t)
-	if d < 0 {
-		d = 0
-	}
-
-	switch {
-	case d < time.Minute:
-		return "just now"
-	case d < time.Hour:
-		m := int(d.Minutes())
-		return fmt.Sprintf("%dm ago", m)
-	case d < 24*time.Hour:
-		h := int(d.Hours())
-		return fmt.Sprintf("%dh ago", h)
-	case d < 7*24*time.Hour:
-		days := int(d.Hours() / 24)
-		return fmt.Sprintf("%dd ago", days)
-	case d < 30*24*time.Hour:
-		weeks := int(d.Hours() / 24 / 7)
-		return fmt.Sprintf("%dw ago", weeks)
-	default:
-		if t.Year() == now.Year() {
-			return t.Format("Jan 2")
-		}
-		return t.Format("Jan 2, 2006")
-	}
-}
-
-// humanSize formats a byte count into a human-readable string.
-func humanSize(bytes int64) string {
-	switch {
-	case bytes < 1024:
-		return fmt.Sprintf("%d B", bytes)
-	case bytes < 1024*1024:
-		kb := float64(bytes) / 1024
-		return formatFloat(kb) + " KB"
-	case bytes < 1024*1024*1024:
-		mb := float64(bytes) / (1024 * 1024)
-		return formatFloat(mb) + " MB"
-	default:
-		gb := float64(bytes) / (1024 * 1024 * 1024)
-		return formatFloat(gb) + " GB"
-	}
-}
-
-// formatFloat formats a float to one decimal place, dropping the ".0" suffix.
-func formatFloat(f float64) string {
-	s := fmt.Sprintf("%.1f", f)
-	if strings.HasSuffix(s, ".0") {
-		return s[:len(s)-2]
-	}
-	return s
-}
 
 // pluralize returns "1 note" or "3 notes" style strings.
 func pluralize(count int, singular, plural string) string {

--- a/cmd/format_test.go
+++ b/cmd/format_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"testing"
 	"time"
+
+	"github.com/oobagi/notebook/internal/format"
 )
 
 func TestRelativeTime(t *testing.T) {
@@ -35,9 +37,9 @@ func TestRelativeTime(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := relativeTimeFrom(tt.t, now)
+			got := format.RelativeTimeFrom(tt.t, now)
 			if got != tt.want {
-				t.Errorf("relativeTimeFrom(%v, now) = %q, want %q", tt.t, got, tt.want)
+				t.Errorf("RelativeTimeFrom(%v, now) = %q, want %q", tt.t, got, tt.want)
 			}
 		})
 	}
@@ -64,9 +66,9 @@ func TestHumanSize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := humanSize(tt.bytes)
+			got := format.HumanSize(tt.bytes)
 			if got != tt.want {
-				t.Errorf("humanSize(%d) = %q, want %q", tt.bytes, got, tt.want)
+				t.Errorf("HumanSize(%d) = %q, want %q", tt.bytes, got, tt.want)
 			}
 		})
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/oobagi/notebook/internal/format"
 	"github.com/spf13/cobra"
 )
 
@@ -47,7 +48,7 @@ var listCmd = &cobra.Command{
 			if modTime.IsZero() {
 				timeStr = "empty"
 			} else {
-				timeStr = relativeTime(modTime)
+				timeStr = format.RelativeTime(modTime)
 			}
 
 			rows = append(rows, []string{name, countStr, timeStr})

--- a/cmd/recent.go
+++ b/cmd/recent.go
@@ -2,9 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"strings"
 
+	"github.com/oobagi/notebook/internal/format"
 	"github.com/oobagi/notebook/internal/recents"
 	"github.com/oobagi/notebook/internal/storage"
 	"github.com/spf13/cobra"
@@ -17,15 +16,10 @@ var recentCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		w := cmd.OutOrStdout()
 
-		entries, err := recents.Load(recents.DefaultPath())
+		entries, err := recents.LoadPruned(store.Root)
 		if err != nil {
 			return fmt.Errorf("load recents: %w", err)
 		}
-
-		// Prune stale entries whose files no longer exist.
-		entries = recents.Prune(entries, store.Root)
-		// Persist the pruned list (best-effort).
-		_ = recents.Save(recents.DefaultPath(), entries)
 
 		if len(entries) == 0 {
 			fmt.Fprintln(w, "  No recent notes.")
@@ -36,17 +30,16 @@ var recentCmd = &cobra.Command{
 
 		var rows [][]string
 		for _, e := range entries {
-			var label, timeStr string
+			var label string
 			switch e.Type {
-			case "store":
+			case recents.TypeStore:
 				label = storage.DisplayName(e.Notebook) + " \u203A " + storage.DisplayName(e.Name)
-			case "external":
-				label = shortenHome(e.Path)
+			case recents.TypeExternal:
+				label = format.ShortenHome(e.Path)
 			default:
 				continue
 			}
-			timeStr = relativeTime(e.LastEdited)
-			rows = append(rows, []string{label, timeStr})
+			rows = append(rows, []string{label, format.RelativeTime(e.LastEdited)})
 		}
 
 		for _, line := range alignColumns(rows) {
@@ -70,18 +63,6 @@ var recentClearCmd = &cobra.Command{
 		printSuccess(w, "Cleared recent notes")
 		return nil
 	},
-}
-
-// shortenHome replaces the home directory prefix with ~/ for display.
-func shortenHome(path string) string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return path
-	}
-	if strings.HasPrefix(path, home) {
-		return "~" + path[len(home):]
-	}
-	return path
 }
 
 func init() {

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/oobagi/notebook/internal/clipboard"
 	"github.com/oobagi/notebook/internal/config"
+	"github.com/oobagi/notebook/internal/format"
 	"github.com/oobagi/notebook/internal/model"
 	"github.com/oobagi/notebook/internal/recents"
 	"github.com/oobagi/notebook/internal/storage"
@@ -174,7 +175,7 @@ func (m Model) loadNotebooks() tea.Cmd {
 			if modTime.IsZero() {
 				timeStr = "empty"
 			} else {
-				timeStr = relativeTime(modTime)
+				timeStr = format.RelativeTime(modTime)
 			}
 
 			items = append(items, notebookItem{
@@ -199,14 +200,10 @@ func (m Model) loadNotes(book string) tea.Cmd {
 
 func (m Model) loadRecents() tea.Cmd {
 	return func() tea.Msg {
-		entries, err := recents.Load(recents.DefaultPath())
+		entries, err := recents.LoadPruned(m.store.Root)
 		if err != nil {
 			return errMsg{err}
 		}
-		// Prune stale entries once at load time.
-		entries = recents.Prune(entries, m.store.Root)
-		// Persist pruned list (best-effort).
-		_ = recents.Save(recents.DefaultPath(), entries)
 		return recentsLoadedMsg{entries: entries}
 	}
 }
@@ -740,7 +737,7 @@ func (m Model) removeRecentEntry() (tea.Model, tea.Cmd) {
 		if err := recents.Save(recents.DefaultPath(), entries); err != nil {
 			return statusMsg{fmt.Sprintf("Could not save recents: %s", err)}
 		}
-		return reloadMsg{}
+		return recentsLoadedMsg{entries: entries}
 	}
 }
 
@@ -1144,12 +1141,12 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 		idx := m.filteredRecent[m.cursor]
 		entry := m.recentEntries[idx]
 		switch entry.Type {
-		case "store":
+		case recents.TypeStore:
 			m.selected = &Selection{
 				Book: entry.Notebook,
 				Note: entry.Name,
 			}
-		case "external":
+		case recents.TypeExternal:
 			m.selected = &Selection{
 				FilePath: entry.Path,
 			}
@@ -1444,7 +1441,7 @@ func (m Model) formatRecentLine(e recents.Entry, selected bool) string {
 	bullet := "  "
 	label := recentEntryLabel(e)
 	display := label
-	timeStr := relativeTime(e.LastEdited)
+	timeStr := format.RelativeTime(e.LastEdited)
 
 	if selected {
 		bulletStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(theme.Current().Accent))
@@ -1476,24 +1473,12 @@ func (m Model) recentNameColWidth() int {
 // recentEntryLabel returns the display label for a recent entry.
 func recentEntryLabel(e recents.Entry) string {
 	switch e.Type {
-	case "store":
+	case recents.TypeStore:
 		return storage.DisplayName(e.Notebook) + " \u203A " + storage.DisplayName(e.Name)
-	case "external":
-		return shortenHome(e.Path)
+	case recents.TypeExternal:
+		return format.ShortenHome(e.Path)
 	}
 	return ""
-}
-
-// shortenHome replaces the home directory prefix with ~/ for display.
-func shortenHome(path string) string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return path
-	}
-	if strings.HasPrefix(path, home) {
-		return "~" + path[len(home):]
-	}
-	return path
 }
 
 func (m Model) renderEmptyRecents() string {
@@ -1580,8 +1565,8 @@ func (m Model) formatNoteLine(n model.Note, selected bool) string {
 	info, err := os.Stat(p)
 	var sizeStr, timeStr string
 	if err == nil {
-		sizeStr = humanSize(info.Size())
-		timeStr = relativeTime(info.ModTime())
+		sizeStr = format.HumanSize(info.Size())
+		timeStr = format.RelativeTime(info.ModTime())
 	}
 
 	if selected {

--- a/internal/editor/render.go
+++ b/internal/editor/render.go
@@ -3,7 +3,6 @@ package editor
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/alecthomas/chroma/v2"
@@ -14,6 +13,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/oobagi/notebook/internal/block"
+	"github.com/oobagi/notebook/internal/format"
 	"github.com/oobagi/notebook/internal/theme"
 )
 
@@ -32,14 +32,11 @@ func (m Model) renderHeader() string {
 
 	var rightParts []string
 	if m.config.FilePath != "" {
-		displayPath := m.config.FilePath
-		if home, err := os.UserHomeDir(); err == nil {
-			displayPath = strings.Replace(displayPath, home, "~", 1)
-		}
+		displayPath := format.ShortenHome(m.config.FilePath)
 		rightParts = append(rightParts, displayPath)
 	}
 	if m.config.FileSize > 0 {
-		rightParts = append(rightParts, humanSize(m.config.FileSize))
+		rightParts = append(rightParts, format.HumanSize(m.config.FileSize))
 	}
 	right := metaStyle.Render(strings.Join(rightParts, " \u00B7 "))
 
@@ -48,7 +45,7 @@ func (m Model) renderHeader() string {
 	if gap < 2 {
 		// Drop the file path, keep just the size.
 		if m.config.FileSize > 0 {
-			right = metaStyle.Render(humanSize(m.config.FileSize))
+			right = metaStyle.Render(format.HumanSize(m.config.FileSize))
 		} else {
 			right = ""
 		}
@@ -61,32 +58,6 @@ func (m Model) renderHeader() string {
 	bar := left + strings.Repeat(" ", gap) + right
 
 	return lipgloss.NewStyle().Width(width).Render(bar)
-}
-
-// humanSize formats a byte count into a human-readable string.
-func humanSize(bytes int64) string {
-	switch {
-	case bytes < 1024:
-		return fmt.Sprintf("%d B", bytes)
-	case bytes < 1024*1024:
-		kb := float64(bytes) / 1024
-		return formatFloat(kb) + " KB"
-	case bytes < 1024*1024*1024:
-		mb := float64(bytes) / (1024 * 1024)
-		return formatFloat(mb) + " MB"
-	default:
-		gb := float64(bytes) / (1024 * 1024 * 1024)
-		return formatFloat(gb) + " GB"
-	}
-}
-
-// formatFloat formats a float to one decimal place, dropping the ".0" suffix.
-func formatFloat(f float64) string {
-	s := fmt.Sprintf("%.1f", f)
-	if strings.HasSuffix(s, ".0") {
-		return s[:len(s)-2]
-	}
-	return s
 }
 
 // renderBlock renders a single block. The active block shows its textarea;

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -1,18 +1,32 @@
-package browser
+package format
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 )
 
-// relativeTime returns a human-friendly relative timestamp string.
-func relativeTime(t time.Time) string {
-	return relativeTimeFrom(t, time.Now())
+// ShortenHome replaces the home directory prefix with ~/ for display.
+func ShortenHome(path string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if strings.HasPrefix(path, home) {
+		return "~" + path[len(home):]
+	}
+	return path
 }
 
-// relativeTimeFrom returns a relative timestamp using the given reference time.
-func relativeTimeFrom(t time.Time, now time.Time) string {
+// RelativeTime returns a human-friendly relative timestamp string.
+// It follows the design system rules from docs/design.md.
+func RelativeTime(t time.Time) string {
+	return RelativeTimeFrom(t, time.Now())
+}
+
+// RelativeTimeFrom returns a relative timestamp using the given reference time.
+func RelativeTimeFrom(t time.Time, now time.Time) string {
 	d := now.Sub(t)
 	if d < 0 {
 		d = 0
@@ -41,24 +55,25 @@ func relativeTimeFrom(t time.Time, now time.Time) string {
 	}
 }
 
-// humanSize formats a byte count into a human-readable string.
-func humanSize(bytes int64) string {
+// HumanSize formats a byte count into a human-readable string.
+func HumanSize(bytes int64) string {
 	switch {
 	case bytes < 1024:
 		return fmt.Sprintf("%d B", bytes)
 	case bytes < 1024*1024:
 		kb := float64(bytes) / 1024
-		return formatFloat(kb) + " KB"
+		return FormatFloat(kb) + " KB"
 	case bytes < 1024*1024*1024:
 		mb := float64(bytes) / (1024 * 1024)
-		return formatFloat(mb) + " MB"
+		return FormatFloat(mb) + " MB"
 	default:
 		gb := float64(bytes) / (1024 * 1024 * 1024)
-		return formatFloat(gb) + " GB"
+		return FormatFloat(gb) + " GB"
 	}
 }
 
-func formatFloat(f float64) string {
+// FormatFloat formats a float to one decimal place, dropping the ".0" suffix.
+func FormatFloat(f float64) string {
 	s := fmt.Sprintf("%.1f", f)
 	if strings.HasSuffix(s, ".0") {
 		return s[:len(s)-2]

--- a/internal/recents/recents.go
+++ b/internal/recents/recents.go
@@ -11,13 +11,50 @@ import (
 // MaxEntries is the maximum number of recent entries to keep.
 const MaxEntries = 50
 
+// Entry type constants.
+const (
+	TypeStore    = "store"
+	TypeExternal = "external"
+)
+
 // Entry represents a recently edited note or file.
 type Entry struct {
-	Type       string    `json:"type"`                 // "store" or "external"
+	Type       string    `json:"type"`                 // TypeStore or TypeExternal
 	Notebook   string    `json:"notebook,omitempty"`    // store notes only
 	Name       string    `json:"name,omitempty"`        // store notes only
 	Path       string    `json:"path,omitempty"`        // external files only
 	LastEdited time.Time `json:"last_edited"`
+}
+
+// RecordStore records a store note in the recents list (best-effort).
+func RecordStore(book, note string) {
+	_ = Record(DefaultPath(), Entry{
+		Type:       TypeStore,
+		Notebook:   book,
+		Name:       note,
+		LastEdited: time.Now(),
+	})
+}
+
+// RecordExternal records an external file in the recents list (best-effort).
+func RecordExternal(path string) {
+	_ = Record(DefaultPath(), Entry{
+		Type:       TypeExternal,
+		Path:       path,
+		LastEdited: time.Now(),
+	})
+}
+
+// LoadPruned loads the recents list, prunes stale entries, and persists the
+// pruned result. Returns the pruned list.
+func LoadPruned(storeRoot string) ([]Entry, error) {
+	entries, err := Load(DefaultPath())
+	if err != nil {
+		return nil, err
+	}
+	entries = Prune(entries, storeRoot)
+	_ = Save(DefaultPath(), entries)
+	return entries, nil
 }
 
 // DefaultPath returns the default path to the recents file:
@@ -96,17 +133,15 @@ func Prune(entries []Entry, storeRoot string) []Entry {
 	kept := make([]Entry, 0, len(entries))
 	for _, e := range entries {
 		switch e.Type {
-		case "store":
+		case TypeStore:
 			p := filepath.Join(storeRoot, e.Notebook, e.Name+".md")
 			if _, err := os.Stat(p); err == nil {
 				kept = append(kept, e)
 			}
-		case "external":
+		case TypeExternal:
 			if _, err := os.Stat(e.Path); err == nil {
 				kept = append(kept, e)
 			}
-		default:
-			// Unknown type — drop it.
 		}
 	}
 	return kept
@@ -126,18 +161,13 @@ func Remove(entries []Entry, target Entry) []Entry {
 // upsert adds or updates an entry, keeping the list sorted by
 // LastEdited descending (most recent first) and capped at MaxEntries.
 func upsert(entries []Entry, entry Entry) []Entry {
-	// Remove existing entry with same identity.
 	result := make([]Entry, 0, len(entries)+1)
 	for _, e := range entries {
 		if !sameIdentity(e, entry) {
 			result = append(result, e)
 		}
 	}
-
-	// Prepend the new/updated entry (most recent first).
 	result = append([]Entry{entry}, result...)
-
-	// Cap at MaxEntries.
 	if len(result) > MaxEntries {
 		result = result[:MaxEntries]
 	}
@@ -150,9 +180,9 @@ func sameIdentity(a, b Entry) bool {
 		return false
 	}
 	switch a.Type {
-	case "store":
+	case TypeStore:
 		return a.Notebook == b.Notebook && a.Name == b.Name
-	case "external":
+	case TypeExternal:
 		return a.Path == b.Path
 	}
 	return false

--- a/internal/recents/recents_test.go
+++ b/internal/recents/recents_test.go
@@ -13,13 +13,13 @@ func TestRoundTrip(t *testing.T) {
 
 	entries := []Entry{
 		{
-			Type:       "store",
+			Type:       TypeStore,
 			Notebook:   "work",
 			Name:       "standup",
 			LastEdited: time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
 		},
 		{
-			Type:       "external",
+			Type:       TypeExternal,
 			Path:       "/tmp/todo.txt",
 			LastEdited: time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
 		},
@@ -38,10 +38,10 @@ func TestRoundTrip(t *testing.T) {
 		t.Fatalf("got %d entries, want %d", len(loaded), len(entries))
 	}
 
-	if loaded[0].Type != "store" || loaded[0].Notebook != "work" || loaded[0].Name != "standup" {
+	if loaded[0].Type != TypeStore || loaded[0].Notebook != "work" || loaded[0].Name != "standup" {
 		t.Errorf("entry 0 mismatch: %+v", loaded[0])
 	}
-	if loaded[1].Type != "external" || loaded[1].Path != "/tmp/todo.txt" {
+	if loaded[1].Type != TypeExternal || loaded[1].Path != "/tmp/todo.txt" {
 		t.Errorf("entry 1 mismatch: %+v", loaded[1])
 	}
 }
@@ -69,12 +69,12 @@ func TestLoadEmptyPath(t *testing.T) {
 func TestUpsert(t *testing.T) {
 	now := time.Now()
 	entries := []Entry{
-		{Type: "store", Notebook: "work", Name: "standup", LastEdited: now.Add(-1 * time.Hour)},
-		{Type: "store", Notebook: "journal", Name: "today", LastEdited: now.Add(-2 * time.Hour)},
+		{Type: TypeStore, Notebook: "work", Name: "standup", LastEdited: now.Add(-1 * time.Hour)},
+		{Type: TypeStore, Notebook: "journal", Name: "today", LastEdited: now.Add(-2 * time.Hour)},
 	}
 
 	// Update existing entry — should move to front with new timestamp.
-	updated := Entry{Type: "store", Notebook: "work", Name: "standup", LastEdited: now}
+	updated := Entry{Type: TypeStore, Notebook: "work", Name: "standup", LastEdited: now}
 	result := upsert(entries, updated)
 
 	if len(result) != 2 {
@@ -91,16 +91,16 @@ func TestUpsert(t *testing.T) {
 func TestUpsertNewEntry(t *testing.T) {
 	now := time.Now()
 	entries := []Entry{
-		{Type: "store", Notebook: "work", Name: "standup", LastEdited: now.Add(-1 * time.Hour)},
+		{Type: TypeStore, Notebook: "work", Name: "standup", LastEdited: now.Add(-1 * time.Hour)},
 	}
 
-	newEntry := Entry{Type: "external", Path: "/tmp/notes.md", LastEdited: now}
+	newEntry := Entry{Type: TypeExternal, Path: "/tmp/notes.md", LastEdited: now}
 	result := upsert(entries, newEntry)
 
 	if len(result) != 2 {
 		t.Fatalf("got %d entries, want 2", len(result))
 	}
-	if result[0].Type != "external" || result[0].Path != "/tmp/notes.md" {
+	if result[0].Type != TypeExternal || result[0].Path != "/tmp/notes.md" {
 		t.Errorf("expected new entry first, got %+v", result[0])
 	}
 }
@@ -110,7 +110,7 @@ func TestCap(t *testing.T) {
 	var entries []Entry
 	for i := 0; i < MaxEntries; i++ {
 		entries = append(entries, Entry{
-			Type:       "store",
+			Type:       TypeStore,
 			Notebook:   "book",
 			Name:       "note-" + string(rune('a'+i%26)) + string(rune('0'+i/26)),
 			LastEdited: now.Add(-time.Duration(i) * time.Hour),
@@ -118,13 +118,13 @@ func TestCap(t *testing.T) {
 	}
 
 	// Adding one more should cap at MaxEntries.
-	extra := Entry{Type: "external", Path: "/tmp/extra.txt", LastEdited: now}
+	extra := Entry{Type: TypeExternal, Path: "/tmp/extra.txt", LastEdited: now}
 	result := upsert(entries, extra)
 
 	if len(result) != MaxEntries {
 		t.Errorf("got %d entries, want %d", len(result), MaxEntries)
 	}
-	if result[0].Type != "external" {
+	if result[0].Type != TypeExternal {
 		t.Errorf("expected new entry first, got %+v", result[0])
 	}
 }
@@ -149,10 +149,10 @@ func TestPrune(t *testing.T) {
 
 	now := time.Now()
 	entries := []Entry{
-		{Type: "store", Notebook: "work", Name: "standup", LastEdited: now},
-		{Type: "store", Notebook: "work", Name: "deleted-note", LastEdited: now},
-		{Type: "external", Path: extFile, LastEdited: now},
-		{Type: "external", Path: "/nonexistent/file.txt", LastEdited: now},
+		{Type: TypeStore, Notebook: "work", Name: "standup", LastEdited: now},
+		{Type: TypeStore, Notebook: "work", Name: "deleted-note", LastEdited: now},
+		{Type: TypeExternal, Path: extFile, LastEdited: now},
+		{Type: TypeExternal, Path: "/nonexistent/file.txt", LastEdited: now},
 	}
 
 	result := Prune(entries, dir)
@@ -170,16 +170,16 @@ func TestPrune(t *testing.T) {
 func TestRemove(t *testing.T) {
 	now := time.Now()
 	entries := []Entry{
-		{Type: "store", Notebook: "work", Name: "standup", LastEdited: now},
-		{Type: "external", Path: "/tmp/todo.txt", LastEdited: now},
-		{Type: "store", Notebook: "journal", Name: "today", LastEdited: now},
+		{Type: TypeStore, Notebook: "work", Name: "standup", LastEdited: now},
+		{Type: TypeExternal, Path: "/tmp/todo.txt", LastEdited: now},
+		{Type: TypeStore, Notebook: "journal", Name: "today", LastEdited: now},
 	}
 
-	result := Remove(entries, Entry{Type: "store", Notebook: "work", Name: "standup"})
+	result := Remove(entries, Entry{Type: TypeStore, Notebook: "work", Name: "standup"})
 	if len(result) != 2 {
 		t.Fatalf("got %d entries, want 2", len(result))
 	}
-	if result[0].Type != "external" {
+	if result[0].Type != TypeExternal {
 		t.Errorf("expected external first, got %+v", result[0])
 	}
 }
@@ -189,7 +189,7 @@ func TestRecord(t *testing.T) {
 	path := filepath.Join(dir, "recent.json")
 
 	now := time.Now()
-	entry := Entry{Type: "store", Notebook: "work", Name: "standup", LastEdited: now}
+	entry := Entry{Type: TypeStore, Notebook: "work", Name: "standup", LastEdited: now}
 
 	if err := Record(path, entry); err != nil {
 		t.Fatalf("Record: %v", err)
@@ -215,38 +215,38 @@ func TestSameIdentity(t *testing.T) {
 	}{
 		{
 			"same store entry",
-			Entry{Type: "store", Notebook: "work", Name: "standup"},
-			Entry{Type: "store", Notebook: "work", Name: "standup"},
+			Entry{Type: TypeStore, Notebook: "work", Name: "standup"},
+			Entry{Type: TypeStore, Notebook: "work", Name: "standup"},
 			true,
 		},
 		{
 			"different store name",
-			Entry{Type: "store", Notebook: "work", Name: "standup"},
-			Entry{Type: "store", Notebook: "work", Name: "retro"},
+			Entry{Type: TypeStore, Notebook: "work", Name: "standup"},
+			Entry{Type: TypeStore, Notebook: "work", Name: "retro"},
 			false,
 		},
 		{
 			"different store notebook",
-			Entry{Type: "store", Notebook: "work", Name: "standup"},
-			Entry{Type: "store", Notebook: "journal", Name: "standup"},
+			Entry{Type: TypeStore, Notebook: "work", Name: "standup"},
+			Entry{Type: TypeStore, Notebook: "journal", Name: "standup"},
 			false,
 		},
 		{
 			"same external path",
-			Entry{Type: "external", Path: "/tmp/a.txt"},
-			Entry{Type: "external", Path: "/tmp/a.txt"},
+			Entry{Type: TypeExternal, Path: "/tmp/a.txt"},
+			Entry{Type: TypeExternal, Path: "/tmp/a.txt"},
 			true,
 		},
 		{
 			"different external path",
-			Entry{Type: "external", Path: "/tmp/a.txt"},
-			Entry{Type: "external", Path: "/tmp/b.txt"},
+			Entry{Type: TypeExternal, Path: "/tmp/a.txt"},
+			Entry{Type: TypeExternal, Path: "/tmp/b.txt"},
 			false,
 		},
 		{
 			"different types",
-			Entry{Type: "store", Notebook: "work", Name: "standup"},
-			Entry{Type: "external", Path: "/tmp/a.txt"},
+			Entry{Type: TypeStore, Notebook: "work", Name: "standup"},
+			Entry{Type: TypeExternal, Path: "/tmp/a.txt"},
 			false,
 		},
 	}


### PR DESCRIPTION
## Summary

- **Extract `internal/format/` package** — consolidates `ShortenHome`, `RelativeTime`, `HumanSize`, `FormatFloat` from 3 duplicate locations (cmd/, browser/, editor/) into one shared package
- **Add type constants** — `recents.TypeStore` / `recents.TypeExternal` replace raw string literals across 6 files
- **Add convenience helpers** — `RecordStore()`, `RecordExternal()`, `LoadPruned()` eliminate boilerplate at every call site
- **Fix browser delete efficiency** — `removeRecentEntry()` returns entries directly instead of triggering redundant Load+Prune+Save cycle
- **Delete `internal/browser/format.go`** — fully replaced by shared package
- **Net -91 lines** across the codebase

## Test plan

- [ ] All 542 tests pass, go vet clean
- [ ] `notebook recent` output unchanged
- [ ] TUI browser recents tab functions identically
- [ ] Editor header displays shortened home paths correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)