### PR TITLE
feat: dismissable onboarding hints, shared status bar, browser width fix (Closes #168)

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -6,6 +6,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/oobagi/notebook/internal/browser"
+	"github.com/oobagi/notebook/internal/config"
 )
 
 // runBrowser launches the TUI browser in a loop. When the user selects
@@ -28,6 +29,7 @@ func runBrowser() error {
 			InitialBook:        lastBook,
 			InitialCursor:      lastCursor,
 			InitialSavedCursor: lastSavedCursor,
+			DismissedHints:     config.LoadDismissedHints(),
 		})
 
 		p := tea.NewProgram(m)

--- a/cmd/dispatcher.go
+++ b/cmd/dispatcher.go
@@ -9,6 +9,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/oobagi/notebook/internal/clipboard"
+	"github.com/oobagi/notebook/internal/config"
 	"github.com/oobagi/notebook/internal/editor"
 	"github.com/oobagi/notebook/internal/format"
 	"github.com/oobagi/notebook/internal/recents"
@@ -214,6 +215,7 @@ func editNote(w io.Writer, book, note string) error {
 			recents.RecordStore(book, note)
 			return nil
 		},
+		DismissedHints: config.LoadDismissedHints(),
 	}
 
 	m := editor.New(cfg)

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -23,11 +23,12 @@ type EditFunc func(book, note string) error
 
 // Config holds the dependencies needed by the browser.
 type Config struct {
-	Store         *storage.Store
-	EditNote      EditFunc
+	Store              *storage.Store
+	EditNote           EditFunc
 	InitialBook        string // if set, start at L1 in this notebook
 	InitialCursor      int    // cursor position to restore within the initial view
 	InitialSavedCursor int    // L0 cursor to restore when returning from L1
+	DismissedHints     map[string]bool
 }
 
 // Selection represents a note the user chose to open.
@@ -81,6 +82,9 @@ type Model struct {
 	themeMode      bool   // theme picker overlay visible
 	uiThemeCursor  int    // cursor in UI theme preset list
 	uiThemePreview string // preview for highlighted UI preset
+
+	// Onboarding hints.
+	dismissedHints map[string]bool
 }
 
 // notebookItem holds pre-fetched metadata for a notebook.
@@ -102,6 +106,10 @@ func New(cfg Config) Model {
 	}
 	m.cursor = cfg.InitialCursor
 	m.savedCursor = cfg.InitialSavedCursor
+	m.dismissedHints = cfg.DismissedHints
+	if m.dismissedHints == nil {
+		m.dismissedHints = make(map[string]bool)
+	}
 	return m
 }
 
@@ -392,6 +400,16 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 		if s == "?" {
 			m.showHelp = true
+			return m, nil
+		}
+		if s == "h" {
+			if hint := m.currentHintID(); hint != "" {
+				if m.dismissedHints == nil {
+					m.dismissedHints = make(map[string]bool)
+				}
+				m.dismissedHints[hint] = true
+				config.DismissHint(hint)
+			}
 			return m, nil
 		}
 		if s == "/" {
@@ -1287,6 +1305,23 @@ func (m Model) renderHelpOverlay() string {
 	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, rendered)
 }
 
+// currentHintID returns the hint ID relevant to the current browser state,
+// or "" if no hint applies.
+func (m Model) currentHintID() string {
+	if m.level == 0 && !m.recentsView && !m.filtering {
+		return "browser.theme"
+	}
+	return ""
+}
+
+// statusBarHeight returns the number of terminal lines the rendered status
+// bar will occupy. When the bar text is wider than the terminal, lipgloss
+// wraps it onto multiple lines; this helper accounts for that.
+func (m Model) statusBarHeight() int {
+	rendered := m.renderStatusBar()
+	return strings.Count(rendered, "\n") + 1
+}
+
 // View implements tea.Model.
 func (m Model) View() tea.View {
 	if m.quitting {
@@ -1312,7 +1347,7 @@ func (m Model) View() tea.View {
 		b.WriteString("\n\n")
 
 		// Content area.
-		contentHeight := m.height - 4 // breadcrumb + blank + status bar + blank
+		contentHeight := m.height - 3 - m.statusBarHeight() // breadcrumb + blank line above content + status bar + blank line above status
 		if contentHeight < 1 {
 			contentHeight = 1
 		}
@@ -1672,15 +1707,28 @@ func (m Model) renderStatusBar() string {
 		return dim.Render("  Filter: "+before) + cursor.Render(cursorChar) + dim.Render(after+" \u00B7 Esc clear \u00B7 Enter select")
 	}
 
+	width := m.width
+	if width <= 0 {
+		width = 80
+	}
+
+	left := " "
+	var hint string
+	var right string
+
 	if m.recentsView {
-		return dim.Render("  \u2191/\u2193 navigate \u00B7 Enter open \u00B7 d remove \u00B7 Tab notebooks \u00B7 / search \u00B7 q quit \u00B7 ? help")
+		right = "\u2191/\u2193 navigate \u00B7 Enter open \u00B7 d remove \u00B7 Tab notebooks \u00B7 / search \u00B7 q quit \u00B7 ? help"
+	} else if m.level == 0 {
+		if !m.dismissedHints["browser.theme"] {
+			hint = lipgloss.NewStyle().Italic(true).Render("press t to change theme!  [h]ide")
+		}
+		right = "\u2191/\u2193 navigate \u00B7 Enter open \u00B7 Tab recents \u00B7 / search \u00B7 q quit \u00B7 ? help"
+	} else {
+		right = "\u2191/\u2193 navigate \u00B7 Enter open \u00B7 / search \u00B7 Esc back \u00B7 q quit \u00B7 ? help"
 	}
 
-	if m.level == 0 {
-		return dim.Render("  \u2191/\u2193 navigate \u00B7 Enter open \u00B7 Tab recents \u00B7 / search \u00B7 q quit \u00B7 ? help")
-	}
-
-	return dim.Render("  \u2191/\u2193 navigate \u00B7 Enter open \u00B7 / search \u00B7 Esc back \u00B7 q quit \u00B7 ? help")
+	bar := format.StatusBar(left, hint, right, width)
+	return lipgloss.NewStyle().Faint(true).Width(width).Render(bar)
 }
 
 // pluralize returns "1 note" or "3 notes" style strings.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,7 @@ var ValidKeys = map[string]bool{
 	"editor":      true,
 	"theme":       true,
 	"date_format": true,
+	"show_hints":  true,
 }
 
 // Path returns the path to the config file: ~/.config/notebook/config.toml.
@@ -118,6 +119,12 @@ func Set(cfg *Config, key, value string) error {
 		cfg.Theme = value
 	case "date_format":
 		cfg.DateFormat = value
+	case "show_hints":
+		if value != "true" {
+			return fmt.Errorf("show_hints only supports \"true\" to re-enable hints")
+		}
+		ResetHints()
+		return nil
 	default:
 		return fmt.Errorf("unknown config key: %q", key)
 	}
@@ -135,6 +142,12 @@ func Get(cfg Config, key string) (string, error) {
 		return cfg.Theme, nil
 	case "date_format":
 		return cfg.DateFormat, nil
+	case "show_hints":
+		dismissed := LoadDismissedHints()
+		if len(dismissed) == 0 {
+			return "true", nil
+		}
+		return "false", nil
 	default:
 		return "", fmt.Errorf("unknown config key: %q", key)
 	}

--- a/internal/config/hints.go
+++ b/internal/config/hints.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// HintsPath returns the path to the dismissed hints file.
+func HintsPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "notebook", "hints.json")
+}
+
+// LoadDismissedHints reads the set of dismissed hint IDs from disk.
+func LoadDismissedHints() map[string]bool {
+	path := HintsPath()
+	if path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var ids []string
+	if err := json.Unmarshal(data, &ids); err != nil {
+		return nil
+	}
+	m := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		m[id] = true
+	}
+	return m
+}
+
+// DismissHint adds a hint ID to the dismissed set and persists it.
+func DismissHint(id string) {
+	dismissed := LoadDismissedHints()
+	if dismissed == nil {
+		dismissed = make(map[string]bool)
+	}
+	dismissed[id] = true
+	saveDismissedHints(dismissed)
+}
+
+// ResetHints clears all dismissed hints.
+func ResetHints() {
+	path := HintsPath()
+	if path != "" {
+		os.Remove(path)
+	}
+}
+
+func saveDismissedHints(m map[string]bool) {
+	path := HintsPath()
+	if path == "" {
+		return
+	}
+	ids := make([]string, 0, len(m))
+	for id := range m {
+		ids = append(ids, id)
+	}
+	data, err := json.Marshal(ids)
+	if err != nil {
+		return
+	}
+	dir := filepath.Dir(path)
+	os.MkdirAll(dir, 0o755)
+	os.WriteFile(path, data, 0o644)
+}

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -12,6 +12,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/oobagi/notebook/internal/block"
+	"github.com/oobagi/notebook/internal/config"
+	"github.com/oobagi/notebook/internal/format"
 	"github.com/oobagi/notebook/internal/theme"
 )
 
@@ -27,6 +29,8 @@ type Config struct {
 	Content string
 	// Save is called with the current content when the user presses Ctrl+S.
 	Save func(string) error
+	// DismissedHints tracks which onboarding hints have been dismissed.
+	DismissedHints map[string]bool
 }
 
 // savedMsg is sent after a successful save.
@@ -65,11 +69,12 @@ type Model struct {
 	blockClip   *block.Block // block-level clipboard for Ctrl+K block cut
 	statusGen   int    // generation counter for status auto-dismiss
 	palette     palette // "/" command palette for block type insertion
-	wordWrap         bool     // when true, text wraps at terminal width
-	viewMode         bool     // when true, read-only rendering with no cursor
-	hoverBlock       int      // view mode: block index under mouse cursor (-1 = none)
-	cursorCmd        tea.Cmd  // pending cursor blink command from Focus()
-	blockLineOffsets []int    // view mode: starting Y line of each block in rendered output
+	wordWrap         bool            // when true, text wraps at terminal width
+	viewMode         bool            // when true, read-only rendering with no cursor
+	hoverBlock       int             // view mode: block index under mouse cursor (-1 = none)
+	cursorCmd        tea.Cmd         // pending cursor blink command from Focus()
+	blockLineOffsets []int           // view mode: starting Y line of each block in rendered output
+	dismissedHints   map[string]bool // tracks which onboarding hints the user has dismissed
 }
 
 type statusKind int
@@ -130,18 +135,24 @@ func New(cfg Config) Model {
 
 	vp := viewport.New(viewport.WithWidth(defaultWidth), viewport.WithHeight(defaultHeight-2)) // -1 header, -1 status bar
 
+	dismissed := cfg.DismissedHints
+	if dismissed == nil {
+		dismissed = make(map[string]bool)
+	}
+
 	return Model{
-		blocks:     blocks,
-		textareas:  textareas,
-		active:     0,
-		viewport:   vp,
-		config:     cfg,
-		initial:    cfg.Content,
-		width:      defaultWidth,
-		height:     defaultHeight,
-		palette:    newPalette(),
-		wordWrap:   true,
-		hoverBlock: -1,
+		blocks:         blocks,
+		textareas:      textareas,
+		active:         0,
+		viewport:       vp,
+		config:         cfg,
+		initial:        cfg.Content,
+		width:          defaultWidth,
+		height:         defaultHeight,
+		palette:        newPalette(),
+		wordWrap:       true,
+		dismissedHints: dismissed,
+		hoverBlock:     -1,
 	}
 }
 
@@ -943,6 +954,12 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 				}
 				return m, nil
+			case "h":
+				if !m.dismissedHints["editor.checkbox"] {
+					m.dismissedHints["editor.checkbox"] = true
+					config.DismissHint("editor.checkbox")
+				}
+				return m, nil
 			case "ctrl+g":
 				m.showHelp = true
 				return m, nil
@@ -1565,22 +1582,20 @@ func (m Model) renderStatusBar() string {
 		left += " [modified]"
 	}
 
+	var hint string
 	var right string
 	if m.status != "" {
 		right = m.status
 	} else if m.viewMode {
-		left = " click checkboxes to toggle"
+		if !m.dismissedHints["editor.checkbox"] {
+			hint = lipgloss.NewStyle().Italic(true).Render("click checkboxes to toggle!  [h]ide")
+		}
 		right = "\u2303R edit \u00B7 \u2303Q quit"
 	} else {
 		right = "/ commands \u00B7 \u2303S save \u00B7 \u2303R view \u00B7 \u2303G help \u00B7 \u2303Q quit"
 	}
 
-	gap := width - lipgloss.Width(left) - lipgloss.Width(right)
-	if gap < 1 {
-		gap = 1
-	}
-
-	bar := left + strings.Repeat(" ", gap) + right
+	bar := format.StatusBar(left, hint, right, width)
 
 	style := lipgloss.NewStyle().Width(width)
 	switch m.statusStyle {

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -5,7 +5,29 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"charm.land/lipgloss/v2"
 )
+
+// StatusBar builds a status bar string with left status, an optional centered
+// hint, and right-aligned keybinds. Width constrains the total bar width.
+// All three sections always render — nothing is dropped at narrow widths.
+func StatusBar(left, hint, right string, width int) string {
+	if width <= 0 {
+		width = 80
+	}
+
+	if hint != "" {
+		left += " " + hint
+	}
+
+	gap := width - lipgloss.Width(left) - lipgloss.Width(right)
+	if gap < 1 {
+		gap = 1
+	}
+
+	return left + strings.Repeat(" ", gap) + right
+}
 
 // ShortenHome replaces the home directory prefix with ~/ for display.
 func ShortenHome(path string) string {


### PR DESCRIPTION
## Summary
- Add per-hint onboarding system with persistent dismissal (`[h]ide` removes the current hint permanently, stored in `~/.config/notebook/hints.json`)
- Editor view mode: *click checkboxes to toggle!* hint; Browser L0: *press t to change theme!* hint — both italic and fun
- Extract `format.StatusBar()` shared builder for left/hint/right bar layout, replacing duplicated gap logic in editor and browser
- Fix browser `contentHeight` to use dynamic `statusBarHeight()` instead of hardcoded `-4`, matching the editor's existing wrapping-aware pattern
- Add `show_hints` config key — `notebook config set show_hints true` resets all dismissed hints

## Test plan
- [ ] Open editor in view mode — hint shows italic on left, keybinds on right
- [ ] Press `h` — hint disappears permanently, survives app restart
- [ ] Open browser at notebooks list — theme hint shows on left
- [ ] Press `h` — theme hint dismissed permanently
- [ ] `notebook config set show_hints true` — all hints re-appear
- [ ] Narrow terminal — status bar wraps, content area adjusts (no elements lost)
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)