### PR TITLE
fix: remove left/right arrow navigation in browser

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -400,10 +400,10 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
-	case "enter", "right":
+	case "enter":
 		return m.handleEnter()
 
-	case "esc", "left":
+	case "esc":
 		return m.handleEsc()
 
 	default:


### PR DESCRIPTION
## Summary
- Remove `right` as alias for `enter` (drill into notebook/note)
- Remove `left` as alias for `esc` (go back)
- Arrow keys still work for up/down list navigation and cursor positioning in input/filter fields

## Test plan
- [ ] Verify `←` / `→` no longer navigate between notebook levels
- [ ] Verify `Enter` and `Esc` still work for navigation
- [ ] Verify `←` / `→` still move cursor in filter and input fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)