### PR TITLE
fix: correct browser cursor restoration for recents and async loads

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -19,17 +19,13 @@ func runBrowser() error {
 	}
 
 	var lastBook string
-	var lastCursor, lastSavedCursor int
+	var lastCursor int
 	for {
 		m := browser.New(browser.Config{
-			Store: store,
-			EditNote: func(book, note string) error {
-				return editNote(nil, book, note)
-			},
-			InitialBook:        lastBook,
-			InitialCursor:      lastCursor,
-			InitialSavedCursor: lastSavedCursor,
-			DismissedHints:     config.LoadDismissedHints(),
+			Store:          store,
+			InitialBook:    lastBook,
+			InitialCursor:  lastCursor,
+			DismissedHints: config.LoadDismissedHints(),
 		})
 
 		p := tea.NewProgram(m)
@@ -46,17 +42,20 @@ func runBrowser() error {
 		}
 
 		lastCursor = final.Cursor()
-		lastSavedCursor = final.SavedCursor()
 
-		// External file selection from recents.
-		if sel.FilePath != "" {
+		if sel.FromRecent {
+			// Entered from recents — return to L0 at the same cursor.
 			lastBook = ""
+		} else {
+			// Entered from notebook list — return to L1 inside the book.
+			lastBook = sel.Book
+		}
+
+		if sel.FilePath != "" {
 			if err := openFile(sel.FilePath); err != nil {
 				return fmt.Errorf("open file: %w", err)
 			}
 		} else {
-			// Launch editor for the selected note.
-			lastBook = sel.Book
 			if err := editNote(os.Stderr, sel.Book, sel.Note); err != nil {
 				return fmt.Errorf("edit note: %w", err)
 			}

--- a/internal/block/block.go
+++ b/internal/block/block.go
@@ -83,10 +83,9 @@ func (bt BlockType) Short() string {
 
 // Block holds a single parsed content block.
 type Block struct {
-	Type     BlockType // kind of block
-	Content  string    // text content without markdown prefix
-	Language string    // code block language hint (CodeBlock only) — deprecated, kept for compat
-	Checked  bool      // whether checklist item is checked (Checklist only)
+	Type    BlockType // kind of block
+	Content string    // text content without markdown prefix
+	Checked bool      // whether checklist item is checked (Checklist only)
 }
 
 // ExtractCodeLanguage splits a code block's content into its title line

--- a/internal/block/parse_test.go
+++ b/internal/block/parse_test.go
@@ -237,9 +237,6 @@ func TestParse(t *testing.T) {
 				if got[i].Content != tt.expect[i].Content {
 					t.Errorf("block[%d].Content: got %q, want %q", i, got[i].Content, tt.expect[i].Content)
 				}
-				if got[i].Language != tt.expect[i].Language {
-					t.Errorf("block[%d].Language: got %q, want %q", i, got[i].Language, tt.expect[i].Language)
-				}
 				if got[i].Checked != tt.expect[i].Checked {
 					t.Errorf("block[%d].Checked: got %v, want %v", i, got[i].Checked, tt.expect[i].Checked)
 				}

--- a/internal/block/serialize_test.go
+++ b/internal/block/serialize_test.go
@@ -174,9 +174,6 @@ func TestSerializeIdempotent(t *testing.T) {
 				if blocks1[i].Content != blocks2[i].Content {
 					t.Errorf("block[%d].Content: %q vs %q", i, blocks1[i].Content, blocks2[i].Content)
 				}
-				if blocks1[i].Language != blocks2[i].Language {
-					t.Errorf("block[%d].Language: %q vs %q", i, blocks1[i].Language, blocks2[i].Language)
-				}
 				if blocks1[i].Checked != blocks2[i].Checked {
 					t.Errorf("block[%d].Checked: %v vs %v", i, blocks1[i].Checked, blocks2[i].Checked)
 				}

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -19,36 +19,30 @@ import (
 	"github.com/oobagi/notebook/internal/theme"
 )
 
-// EditFunc is called when the user selects a note to edit.
-type EditFunc func(book, note string) error
-
 // Config holds the dependencies needed by the browser.
 type Config struct {
-	Store              *storage.Store
-	EditNote           EditFunc
-	InitialBook        string // if set, start at L1 in this notebook
-	InitialCursor      int    // cursor position to restore within the initial view
-	InitialSavedCursor int    // L0 cursor to restore when returning from L1
-	DismissedHints     map[string]bool
+	Store          *storage.Store
+	InitialBook    string // if set, start at L1 in this notebook
+	InitialCursor  int    // cursor position to restore within the initial view
+	DismissedHints map[string]bool
 }
 
 // Selection represents a note the user chose to open.
 type Selection struct {
-	Book     string
-	Note     string
-	FilePath string // non-empty for external file selections
+	Book       string
+	Note       string
+	FilePath   string // non-empty for external file selections
+	FromRecent bool   // true if selected from the recents section
 }
 
 // Model is the Bubble Tea model for the notebook/note browser.
 type Model struct {
 	store       *storage.Store
-	editNote    EditFunc
 	level       int    // 0=notebooks, 1=notes
 	notebooks   []notebookItem
 	notes       []model.Note
 	currentBook string // selected notebook name
 	cursor      int    // current selection index
-	savedCursor int    // notebook-level cursor restored on Esc
 	filter       string // fuzzy search filter text
 	filtering    bool   // whether filter mode is active
 	filterCursor int    // cursor position within filter
@@ -100,15 +94,13 @@ type notebookItem struct {
 // New creates a new browser model.
 func New(cfg Config) Model {
 	m := Model{
-		store:    cfg.Store,
-		editNote: cfg.EditNote,
+		store: cfg.Store,
 	}
 	if cfg.InitialBook != "" {
 		m.level = 1
 		m.currentBook = cfg.InitialBook
 	}
 	m.cursor = cfg.InitialCursor
-	m.savedCursor = cfg.InitialSavedCursor
 	m.dismissedHints = cfg.DismissedHints
 	if m.dismissedHints == nil {
 		m.dismissedHints = make(map[string]bool)
@@ -127,11 +119,6 @@ func (m Model) Selected() *Selection {
 // Cursor returns the current cursor position.
 func (m Model) Cursor() int {
 	return m.cursor
-}
-
-// SavedCursor returns the saved L0 cursor position.
-func (m Model) SavedCursor() int {
-	return m.savedCursor
 }
 
 // scheduleStatusDismiss increments the generation counter and returns a tick
@@ -253,29 +240,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case notebooksLoadedMsg:
 		m.notebooks = msg.notebooks
 		m.resetFilter()
-		if m.selectAfterReload != "" {
-			for i, fi := range m.filtered {
-				if m.notebooks[fi].name == m.selectAfterReload {
-					m.cursor = len(m.filteredRecent) + i
-					break
-				}
-			}
-			m.selectAfterReload = ""
-		}
 		return m, nil
 
 	case notesLoadedMsg:
 		m.notes = msg.notes
 		m.resetFilter()
-		if m.selectAfterReload != "" {
-			for i, fi := range m.filtered {
-				if m.notes[fi].Name == m.selectAfterReload {
-					m.cursor = i
-					break
-				}
-			}
-			m.selectAfterReload = ""
-		}
 		return m, nil
 
 	case recentsLoadedMsg:
@@ -327,6 +296,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	// Clear any lingering status text on next keypress.
 	m.statusText = ""
+	// Clear deferred cursor positioning once the user interacts.
+	m.selectAfterReload = ""
 
 	// Global quit keys.
 	if msg.String() == "ctrl+c" {
@@ -1131,6 +1102,16 @@ func (m *Model) resetFilter() {
 		for i := range m.notebooks {
 			m.filtered[i] = i
 		}
+		// Re-apply deferred cursor positioning every time data loads,
+		// so whichever async source arrives last gets the final say.
+		if m.selectAfterReload != "" && len(m.notebooks) > 0 {
+			for i, fi := range m.filtered {
+				if m.notebooks[fi].name == m.selectAfterReload {
+					m.cursor = len(m.filteredRecent) + i
+					break
+				}
+			}
+		}
 		total := m.totalL0Items()
 		if m.cursor >= total {
 			m.cursor = total - 1
@@ -1144,6 +1125,16 @@ func (m *Model) resetFilter() {
 	m.filtered = make([]int, len(m.notes))
 	for i := range m.notes {
 		m.filtered[i] = i
+	}
+
+	// Re-apply deferred cursor positioning for note list.
+	if m.selectAfterReload != "" && len(m.notes) > 0 {
+		for i, fi := range m.filtered {
+			if m.notes[fi].Name == m.selectAfterReload {
+				m.cursor = i
+				break
+			}
+		}
 	}
 
 	if m.cursor >= len(m.filtered) {
@@ -1191,12 +1182,14 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 			switch entry.Type {
 			case recents.TypeStore:
 				m.selected = &Selection{
-					Book: entry.Notebook,
-					Note: entry.Name,
+					Book:       entry.Notebook,
+					Note:       entry.Name,
+					FromRecent: true,
 				}
 			case recents.TypeExternal:
 				m.selected = &Selection{
-					FilePath: entry.Path,
+					FilePath:   entry.Path,
+					FromRecent: true,
 				}
 			}
 			return m, tea.Quit
@@ -1212,7 +1205,6 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 		idx := m.filtered[localIdx]
 		m.currentBook = m.notebooks[idx].name
 		m.level = 1
-		m.savedCursor = m.cursor
 		m.cursor = 0
 		m.filter = ""
 		m.filtering = false
@@ -1242,7 +1234,8 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 func (m Model) handleEsc() (tea.Model, tea.Cmd) {
 	if m.level == 1 {
 		m.level = 0
-		m.cursor = m.savedCursor
+		m.selectAfterReload = m.currentBook
+		m.cursor = 0
 		m.filter = ""
 		m.filtering = false
 		m.notebooks = nil
@@ -1494,9 +1487,6 @@ func (m Model) renderSectionHeader(title string) string {
 	return " " + style.Render(title)
 }
 
-
-
-
 func (m Model) renderNoteList(maxLines int) string {
 	if len(m.notes) == 0 {
 		return m.renderEmptyNotes()
@@ -1523,7 +1513,6 @@ func (m Model) renderNoteList(maxLines int) string {
 	return b.String()
 }
 
-
 func (m Model) formatRecentLine(e recents.Entry, selected bool) string {
 	bullet := "  "
 	label := recentEntryLabel(e)
@@ -1546,8 +1535,6 @@ func (m Model) formatRecentLine(e recents.Entry, selected bool) string {
 	)
 }
 
-
-
 // recentEntryLabel returns the display label for a recent entry.
 func recentEntryLabel(e recents.Entry) string {
 	switch e.Type {
@@ -1558,7 +1545,6 @@ func recentEntryLabel(e recents.Entry) string {
 	}
 	return ""
 }
-
 
 // visibleRange returns the slice of filtered indices to display,
 // implementing scrolling so the cursor stays visible.
@@ -1667,8 +1653,6 @@ func (m Model) renderEmptyNotes() string {
 	return m.renderStarEmpty("No notes in "+storage.DisplayName(m.currentBook)+".", "Press n to create one.", 0)
 }
 
-// renderStarEmpty renders a centered empty state with a star/dot pattern
-// inspired by the portfolio 404 page.
 // renderStarEmpty renders a centered empty state with a star/dot pattern.
 // If maxHeight > 0, it constrains the height to that value.
 func (m Model) renderStarEmpty(title, subtitle string, maxHeight int) string {

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -58,7 +58,6 @@ func initModel(t *testing.T, s *storage.Store) Model {
 	t.Setenv("HOME", t.TempDir())
 	m := New(Config{
 		Store:    s,
-		EditNote: func(book, note string) error { return nil },
 	})
 
 	// Run Init and process the resulting messages (including batches).
@@ -1090,7 +1089,6 @@ func TestBrowserInitialBook(t *testing.T) {
 
 	m := New(Config{
 		Store:       s,
-		EditNote:    func(book, note string) error { return nil },
 		InitialBook: "work",
 	})
 


### PR DESCRIPTION
## Summary
- Fix race condition where `selectAfterReload` was consumed by `notebooksLoadedMsg` before `recentsLoadedMsg` could adjust the offset, causing the cursor to land in the wrong section on Esc
- Add `Selection.FromRecent` so the browser re-enters at L0 (recents) instead of L1 (inside notebook) when a note was opened from recents
- Remove dead code: `EditFunc`, `editNote` field, `savedCursor`/`InitialSavedCursor`, deprecated `Block.Language` field, duplicate comments, extra blank lines

## Test plan
- [ ] Open a note from the recents section, exit editor, verify cursor is back on the same recents entry
- [ ] Open a note from the recents section without editing, exit, verify cursor position preserved
- [ ] Enter a notebook from L0, select a note, edit, Esc back to L0 — cursor should land on the notebook
- [ ] Enter a notebook from L0 without editing, Esc back — cursor should land on the notebook
- [ ] Filter, rename, create, delete operations still work correctly
- [ ] All 501 tests pass, go vet clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)