### PR TITLE
feat: styled help overlays, identity-based cursor restoration

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -19,12 +19,12 @@ func runBrowser() error {
 	}
 
 	var lastBook string
-	var lastCursor int
+	var lastSel *browser.Selection
 	for {
 		m := browser.New(browser.Config{
 			Store:          store,
 			InitialBook:    lastBook,
-			InitialCursor:  lastCursor,
+			RestoreSel:     lastSel,
 			DismissedHints: config.LoadDismissedHints(),
 		})
 
@@ -41,10 +41,10 @@ func runBrowser() error {
 			return nil
 		}
 
-		lastCursor = final.Cursor()
+		lastSel = sel
 
 		if sel.FromRecent {
-			// Entered from recents — return to L0 at the same cursor.
+			// Entered from recents — return to L0.
 			lastBook = ""
 		} else {
 			// Entered from notebook list — return to L1 inside the book.

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -22,8 +22,8 @@ import (
 // Config holds the dependencies needed by the browser.
 type Config struct {
 	Store          *storage.Store
-	InitialBook    string // if set, start at L1 in this notebook
-	InitialCursor  int    // cursor position to restore within the initial view
+	InitialBook    string     // if set, start at L1 in this notebook
+	RestoreSel     *Selection // if set, reposition cursor to this item after load
 	DismissedHints map[string]bool
 }
 
@@ -64,6 +64,9 @@ type Model struct {
 	// After a rename, this holds the new name so the cursor repositions to it.
 	selectAfterReload string
 
+	// restoreSel holds the previously selected item to reposition the cursor after load.
+	restoreSel *Selection
+
 	// Temporary status message shown in the status bar.
 	statusText string
 	statusGen  int // generation counter for auto-dismiss
@@ -100,7 +103,7 @@ func New(cfg Config) Model {
 		m.level = 1
 		m.currentBook = cfg.InitialBook
 	}
-	m.cursor = cfg.InitialCursor
+	m.restoreSel = cfg.RestoreSel
 	m.dismissedHints = cfg.DismissedHints
 	if m.dismissedHints == nil {
 		m.dismissedHints = make(map[string]bool)
@@ -114,11 +117,6 @@ func New(cfg Config) Model {
 // Selected returns the note selection if the user chose one, or nil.
 func (m Model) Selected() *Selection {
 	return m.selected
-}
-
-// Cursor returns the current cursor position.
-func (m Model) Cursor() int {
-	return m.cursor
 }
 
 // scheduleStatusDismiss increments the generation counter and returns a tick
@@ -298,6 +296,7 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	m.statusText = ""
 	// Clear deferred cursor positioning once the user interacts.
 	m.selectAfterReload = ""
+	m.restoreSel = nil
 
 	// Global quit keys.
 	if msg.String() == "ctrl+c" {
@@ -970,13 +969,14 @@ func (m Model) renderThemeOverlay() string {
 		h = 24
 	}
 
+	accent := lipgloss.NewStyle().Foreground(lipgloss.Color(theme.Current().Accent)).Bold(true)
 	dim := lipgloss.NewStyle().Faint(true)
 
 	// Left pane: UI theme preset list.
 	listWidth := 30
 	var left strings.Builder
-	left.WriteString("  UI Theme\n")
-	left.WriteString("  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n")
+	left.WriteString("  " + accent.Render("UI Theme") + "\n")
+	left.WriteString("  " + dim.Render("─────────────────") + "\n")
 
 	presets := theme.Presets()
 	for i, p := range presets {
@@ -1038,7 +1038,7 @@ func (m Model) renderThemeOverlay() string {
 	rendered := outer.Render(combined)
 
 	// Status hint.
-	statusHint := dim.Render("  \u2191/\u2193 navigate \u00b7 Enter apply \u00b7 Esc cancel")
+	statusHint := dim.Render("↑/↓ navigate · Enter apply · Esc cancel")
 
 	full := rendered + "\n" + statusHint
 
@@ -1104,6 +1104,20 @@ func (m *Model) resetFilter() {
 		}
 		// Re-apply deferred cursor positioning every time data loads,
 		// so whichever async source arrives last gets the final say.
+		if m.restoreSel != nil {
+			for i, fi := range m.filteredRecent {
+				e := m.recentEntries[fi]
+				if m.restoreSel.FilePath != "" {
+					if e.Path == m.restoreSel.FilePath {
+						m.cursor = i
+						break
+					}
+				} else if e.Notebook == m.restoreSel.Book && e.Name == m.restoreSel.Note {
+					m.cursor = i
+					break
+				}
+			}
+		}
 		if m.selectAfterReload != "" && len(m.notebooks) > 0 {
 			for i, fi := range m.filtered {
 				if m.notebooks[fi].name == m.selectAfterReload {
@@ -1127,6 +1141,15 @@ func (m *Model) resetFilter() {
 		m.filtered[i] = i
 	}
 
+	// Restore cursor to previously-opened note.
+	if m.restoreSel != nil && m.restoreSel.Note != "" && len(m.notes) > 0 {
+		for i, fi := range m.filtered {
+			if m.notes[fi].Name == m.restoreSel.Note {
+				m.cursor = i
+				break
+			}
+		}
+	}
 	// Re-apply deferred cursor positioning for note list.
 	if m.selectAfterReload != "" && len(m.notes) > 0 {
 		for i, fi := range m.filtered {
@@ -1249,25 +1272,6 @@ func (m Model) handleEsc() (tea.Model, tea.Cmd) {
 
 // renderHelpOverlay builds the centered help panel.
 func (m Model) renderHelpOverlay() string {
-	help := `  Navigation
-  ─────────────────────
-  ↑/↓       Navigate
-  Enter     Open / edit
-  Esc/⌃C    Back / quit
-  Tab       Jump section
-  /         Search
-
-  Actions
-  ─────────────────────
-  n         New
-  d         Delete / remove
-  r         Rename
-  c         Copy (notes)
-  t         Theme
-
-  ─────────────────────
-  Esc/? to close`
-
 	w := m.width
 	if w <= 0 {
 		w = 80
@@ -1277,9 +1281,27 @@ func (m Model) renderHelpOverlay() string {
 		h = 24
 	}
 
-	// Strip tab characters from Go source indentation in raw strings.
-	// Lipgloss v2 does not expand tabs.
-	help = strings.ReplaceAll(help, "\t", "")
+	accent := lipgloss.NewStyle().Foreground(lipgloss.Color(theme.Current().Accent)).Bold(true)
+	dim := lipgloss.NewStyle().Faint(true)
+	sep := dim.Render("─────────────────────")
+	s := dim.Render("/") // dimmed slash separator
+
+	var help strings.Builder
+	help.WriteString("  " + accent.Render("Navigation") + "\n")
+	help.WriteString("  " + sep + "\n")
+	help.WriteString("  ↑" + s + "↓         Navigate\n")
+	help.WriteString("  Enter       Open " + s + " edit\n")
+	help.WriteString("  Esc" + s + "⌃C      Back " + s + " quit\n")
+	help.WriteString("  Tab         Jump section\n")
+	help.WriteString("  /           Search\n")
+	help.WriteString("\n")
+	help.WriteString("  " + accent.Render("Actions") + "\n")
+	help.WriteString("  " + sep + "\n")
+	help.WriteString("  n           New\n")
+	help.WriteString("  d           Delete " + s + " remove\n")
+	help.WriteString("  r           Rename\n")
+	help.WriteString("  c           Copy (notes)\n")
+	help.WriteString("  t           Theme")
 
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
@@ -1288,9 +1310,13 @@ func (m Model) renderHelpOverlay() string {
 		Width(36).
 		Align(lipgloss.Left)
 
-	rendered := box.Render(help)
+	rendered := box.Render(help.String())
 
-	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, rendered)
+	statusHint := dim.Render("Esc/? to close")
+
+	full := rendered + "\n" + statusHint
+
+	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, full)
 }
 
 // currentHintID returns the hint ID relevant to the current browser state,
@@ -1415,7 +1441,7 @@ func (m Model) renderUnifiedList(maxLines int) string {
 		}
 	}
 
-	// Blank separator before notebooks (if recents has items).
+	// Blank separator before notebooks (if recents above).
 	if hasRecents {
 		rows = append(rows, vrow{text: "", dataIndex: -1})
 	}

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -1093,11 +1093,7 @@ func TestBrowserInitialBook(t *testing.T) {
 	})
 
 	cmd := m.Init()
-	if cmd != nil {
-		msg := cmd()
-		updated, _ := m.Update(msg)
-		m = updated.(Model)
-	}
+	m = processCmd(m, cmd)
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = updated.(Model)
 

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -1528,30 +1528,6 @@ func (m Model) View() tea.View {
 
 // renderHelpOverlay builds the full-screen help panel.
 func (m Model) renderHelpOverlay() string {
-	help := `  Keybindings
-  ─────────────────────────
-
-  Enter        New block
-  ⇧Enter       Newline
-  Backspace    Merge/delete
-  ⌃K           Cut block
-  ⌥↑/⌥↓        Move block
-  /            Block type
-
-  ⌃R           View mode
-  ⌃X           Checkbox
-  ⌃W           Word wrap
-
-  ⌃S           Save
-  Esc/⌃C       Quit
-
-  ─────────────────────────
-  Esc/⌃G to close`
-
-	// Strip tab characters that come from Go source indentation in the
-	// raw string literal. Lipgloss v2 does not expand tabs.
-	help = strings.ReplaceAll(help, "\t", "")
-
 	w := m.width
 	if w <= 0 {
 		w = 80
@@ -1561,6 +1537,29 @@ func (m Model) renderHelpOverlay() string {
 		h = 24
 	}
 
+	accent := lipgloss.NewStyle().Foreground(lipgloss.Color(theme.Current().Accent)).Bold(true)
+	dim := lipgloss.NewStyle().Faint(true)
+	sep := dim.Render("─────────────────────────")
+	s := dim.Render("/") // dimmed slash separator
+
+	var help strings.Builder
+	help.WriteString("  " + accent.Render("Keybindings") + "\n")
+	help.WriteString("  " + sep + "\n")
+	help.WriteString("\n")
+	help.WriteString("  Enter        New block\n")
+	help.WriteString("  ⇧Enter       Newline\n")
+	help.WriteString("  Backspace    Merge " + s + " delete\n")
+	help.WriteString("  ⌃K           Cut block\n")
+	help.WriteString("  ⌥↑" + s + "⌥↓        Move block\n")
+	help.WriteString("  /            Block type\n")
+	help.WriteString("\n")
+	help.WriteString("  ⌃R           View mode\n")
+	help.WriteString("  ⌃X           Checkbox\n")
+	help.WriteString("  ⌃W           Word wrap\n")
+	help.WriteString("\n")
+	help.WriteString("  ⌃S           Save\n")
+	help.WriteString("  Esc" + s + "⌃C       Quit")
+
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color(theme.Current().Border)).
@@ -1568,9 +1567,13 @@ func (m Model) renderHelpOverlay() string {
 		Width(36).
 		Align(lipgloss.Left)
 
-	rendered := box.Render(help)
+	rendered := box.Render(help.String())
 
-	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, rendered)
+	statusHint := dim.Render("Esc/⌃G to close")
+
+	full := rendered + "\n" + statusHint
+
+	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, full)
 }
 
 // renderStatusBar builds the bottom status bar.

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -915,8 +915,9 @@ func TestHelpContainsBlockOperationKeybindings(t *testing.T) {
 
 	keybindings := []string{
 		"Enter", "New block",
-		"Backspace", "Merge/delete",
-		"\u2325\u2191", "Move block",
+		"Backspace", "Merge",
+		"delete",
+		"Move block",
 	}
 	for _, kb := range keybindings {
 		if !containsPlainText(view, kb) {


### PR DESCRIPTION
## Summary

- Restyle help overlays (browser `?` and editor `⌃G`) with accent-colored headers, dim separators, and dim `/` key separators
- Footer hints render below the box with faint styling, properly centered
- Fix column alignment in both help screens (misaligned Move block, Quit, Navigate, Back/quit, Open/edit)
- Replace integer cursor restoration with identity-based `RestoreSel` — saves full `Selection` (book + note + filepath) and matches by identity on re-enter, fixing wrong-note restoration when multiple notes share a name across notebooks
- Remove stale `InitialCursor`/`Cursor()` in favor of the deterministic approach

## Test plan

- [ ] Open browser help (`?`) — verify accent headers, dim separators, aligned columns, centered footer
- [ ] Open editor help (`⌃G`) — same checks
- [ ] Open theme picker (`t`) — styled header, centered footer
- [ ] Select a note from recents, edit, go back — cursor on the correct recent entry
- [ ] Have same-named notes in different notebooks in recents — cursor restores to the right one
- [ ] External file in recents — cursor restores correctly after editing

🤖 Generated with [Claude Code](https://claude.com/claude-code)