### PR TITLE
refactor: DRY up rendering pipeline, add GoReleaser for v1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # Output
 *.out
+dist/
 
 # Go workspace
 go.work

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,40 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - main: .
+    binary: notebook
+    ldflags:
+      - -s -w -X github.com/oobagi/notebook/cmd.Version={{.Version}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^chore:"
+      - "^ci:"
+      - "^test:"
+
+release:
+  github:
+    owner: oobagi
+    name: notebook

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -419,6 +419,21 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 }
 
+// insertAtCursor inserts ch into s at the given cursor position and returns the
+// updated string and new cursor position.
+func insertAtCursor(s string, cursor int, ch string) (string, int) {
+	return s[:cursor] + ch + s[cursor:], cursor + len(ch)
+}
+
+// backspaceAtCursor removes the character before cursor and returns the updated
+// string and new cursor position. If cursor is already at 0, s is unchanged.
+func backspaceAtCursor(s string, cursor int) (string, int) {
+	if cursor > 0 {
+		return s[:cursor-1] + s[cursor:], cursor - 1
+	}
+	return s, cursor
+}
+
 func (m Model) handleFilterKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	m.inputCur.IsBlinked = false
 	switch msg.String() {
@@ -448,11 +463,8 @@ func (m Model) handleFilterKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "backspace":
-		if m.filterCursor > 0 {
-			m.filter = m.filter[:m.filterCursor-1] + m.filter[m.filterCursor:]
-			m.filterCursor--
-			m.applyFilter()
-		}
+		m.filter, m.filterCursor = backspaceAtCursor(m.filter, m.filterCursor)
+		m.applyFilter()
 		return m, nil
 
 	case "up":
@@ -472,16 +484,13 @@ func (m Model) handleFilterKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "space":
-		m.filter = m.filter[:m.filterCursor] + " " + m.filter[m.filterCursor:]
-		m.filterCursor++
+		m.filter, m.filterCursor = insertAtCursor(m.filter, m.filterCursor, " ")
 		m.applyFilter()
 		return m, nil
 
 	default:
 		if len(msg.Text) > 0 {
-			ch := msg.Text
-			m.filter = m.filter[:m.filterCursor] + ch + m.filter[m.filterCursor:]
-			m.filterCursor += len(ch)
+			m.filter, m.filterCursor = insertAtCursor(m.filter, m.filterCursor, msg.Text)
 			m.applyFilter()
 			return m, nil
 		}
@@ -529,22 +538,16 @@ func (m Model) handleInputKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "backspace":
-		if m.inputCursor > 0 {
-			m.inputValue = m.inputValue[:m.inputCursor-1] + m.inputValue[m.inputCursor:]
-			m.inputCursor--
-		}
+		m.inputValue, m.inputCursor = backspaceAtCursor(m.inputValue, m.inputCursor)
 		return m, nil
 
 	case "space":
-		m.inputValue = m.inputValue[:m.inputCursor] + " " + m.inputValue[m.inputCursor:]
-		m.inputCursor++
+		m.inputValue, m.inputCursor = insertAtCursor(m.inputValue, m.inputCursor, " ")
 		return m, nil
 
 	default:
 		if len(msg.Text) > 0 {
-			ch := msg.Text
-			m.inputValue = m.inputValue[:m.inputCursor] + ch + m.inputValue[m.inputCursor:]
-			m.inputCursor += len(ch)
+			m.inputValue, m.inputCursor = insertAtCursor(m.inputValue, m.inputCursor, msg.Text)
 			return m, nil
 		}
 	}

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -74,6 +74,7 @@ type Model struct {
 	hoverBlock       int             // view mode: block index under mouse cursor (-1 = none)
 	cursorCmd        tea.Cmd         // pending cursor blink command from Focus()
 	blockLineOffsets []int           // view mode: starting Y line of each block in rendered output
+	blockLineCounts  []int           // per-block rendered line counts from renderAllBlocks
 	dismissedHints   map[string]bool // tracks which onboarding hints the user has dismissed
 }
 
@@ -92,6 +93,10 @@ const (
 	defaultWidth  = 80
 	defaultHeight = 24
 )
+
+// noWrapWidth is a very large width used when word-wrap is disabled so that
+// text never wraps within the textarea.
+const noWrapWidth = 1000
 
 // gutterWidth is the fixed width of the left gutter that shows block type
 // labels. The format is "h1 │ " = label(2) + space + sep(1) + space = 5.
@@ -117,6 +122,23 @@ func blockPrefixWidth(bt block.BlockType) int {
 	default:
 		return 0
 	}
+}
+
+// contentWidth returns the effective textarea width for a block, accounting
+// for the gutter, block prefix, and word-wrap setting.
+func (m Model) contentWidth(bt block.BlockType) int {
+	mw := m.width
+	if mw <= 0 {
+		mw = defaultWidth
+	}
+	w := mw - gutterWidth - blockPrefixWidth(bt)
+	if w < 1 {
+		w = 1
+	}
+	if !m.wordWrap {
+		w = noWrapWidth
+	}
+	return w
 }
 
 // New creates a new editor Model from the given config.
@@ -238,14 +260,7 @@ func (m *Model) resizeTextareas() {
 		w = defaultWidth
 	}
 	for i, b := range m.blocks {
-		taWidth := w - gutterWidth - blockPrefixWidth(b.Type)
-		if taWidth < 1 {
-			taWidth = 1
-		}
-		if !m.wordWrap {
-			taWidth = 1000
-		}
-		m.textareas[i].SetWidth(taWidth)
+		m.textareas[i].SetWidth(m.contentWidth(b.Type))
 		m.textareas[i].SetHeight(m.textareas[i].VisualLineCount())
 	}
 	// Update viewport dimensions, reserving space for the header and status bar
@@ -340,21 +355,18 @@ func (m *Model) insertBlockAfter(idx int, b block.Block) {
 	}
 	ta := newTextareaForBlock(b, m.width)
 
-	// Insert into blocks slice.
 	newBlocks := make([]block.Block, 0, len(m.blocks)+1)
 	newBlocks = append(newBlocks, m.blocks[:idx+1]...)
 	newBlocks = append(newBlocks, b)
 	newBlocks = append(newBlocks, m.blocks[idx+1:]...)
 	m.blocks = newBlocks
 
-	// Insert into textareas slice.
 	newTAs := make([]textarea.Model, 0, len(m.textareas)+1)
 	newTAs = append(newTAs, m.textareas[:idx+1]...)
 	newTAs = append(newTAs, ta)
 	newTAs = append(newTAs, m.textareas[idx+1:]...)
 	m.textareas = newTAs
 
-	// Focus the new block.
 	m.focusBlock(idx + 1)
 }
 
@@ -392,14 +404,12 @@ func (m *Model) mergeBlockUp(idx int) {
 		return
 	}
 
-	// Sync content from textarea.
 	currentContent := m.textareas[idx].Value()
 	prevContent := m.textareas[idx-1].Value()
 	// Merge content: concatenate directly (no added newline), matching
 	// Notion/Google Docs behavior where backspace joins text on the same line.
 	merged := prevContent + currentContent
 
-	// Update previous block content.
 	m.blocks[idx-1].Content = merged
 	m.textareas[idx-1].SetValue(merged)
 
@@ -412,17 +422,9 @@ func (m *Model) mergeBlockUp(idx int) {
 	}
 
 	// Reconfigure textarea for the (possibly changed) block type.
-	taWidth := m.width - gutterWidth - blockPrefixWidth(m.blocks[idx-1].Type)
-	if taWidth < 1 {
-		taWidth = 1
-	}
-	if !m.wordWrap {
-		taWidth = 1000
-	}
-	m.textareas[idx-1].SetWidth(taWidth)
+	m.textareas[idx-1].SetWidth(m.contentWidth(m.blocks[idx-1].Type))
 	m.textareas[idx-1].SetHeight(m.textareas[idx-1].VisualLineCount())
 
-	// Remove the current block.
 	m.blocks = append(m.blocks[:idx], m.blocks[idx+1:]...)
 	m.textareas = append(m.textareas[:idx], m.textareas[idx+1:]...)
 
@@ -458,11 +460,9 @@ func (m *Model) swapBlocks(delta int) {
 	m.blocks[m.active].Content = m.textareas[m.active].Value()
 	m.blocks[target].Content = m.textareas[target].Value()
 
-	// Swap blocks.
 	m.blocks[m.active], m.blocks[target] = m.blocks[target], m.blocks[m.active]
 	m.textareas[m.active], m.textareas[target] = m.textareas[target], m.textareas[m.active]
 
-	// Move focus to the new position.
 	m.textareas[m.active].Blur()
 	m.active = target
 	m.cursorCmd = m.textareas[m.active].Focus()
@@ -714,15 +714,7 @@ func (m *Model) applyPaletteSelection(bt block.BlockType) {
 		return
 	}
 	m.blocks[m.active].Type = bt
-
-	taWidth := m.width - gutterWidth - blockPrefixWidth(bt)
-	if taWidth < 1 {
-		taWidth = 1
-	}
-	if !m.wordWrap {
-		taWidth = 1000
-	}
-	m.textareas[m.active].SetWidth(taWidth)
+	m.textareas[m.active].SetWidth(m.contentWidth(bt))
 
 	if bt == block.Divider {
 		m.blocks[m.active].Content = ""
@@ -1190,15 +1182,7 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Re-enforce width and recalculate height after every keystroke.
 		// This ensures the textarea re-wraps correctly after content changes
 		// (e.g. deleting a newline inserted via Ctrl+J).
-		bt := m.blocks[m.active].Type
-		taWidth := m.width - gutterWidth - blockPrefixWidth(bt)
-		if taWidth < 1 {
-			taWidth = 1
-		}
-		if !m.wordWrap {
-			taWidth = 1000
-		}
-		m.textareas[m.active].SetWidth(taWidth)
+		m.textareas[m.active].SetWidth(m.contentWidth(m.blocks[m.active].Type))
 		m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount())
 
 		m.updateViewport()
@@ -1235,16 +1219,11 @@ func (m *Model) updateViewport() {
 	// because SetContent may reset the viewport's internal scroll state.
 	if m.active >= 0 && m.active < len(m.blocks) && m.active < len(m.textareas) {
 		// Count rendered lines for all blocks before the active one,
-		// including the "\n" join separators between blocks.
+		// using cached line counts from renderAllBlocks to avoid re-rendering.
 		lineOffset := 0
 		for i := 0; i < m.active; i++ {
-			rendered := m.renderBlock(i)
-			lineOffset += strings.Count(rendered, "\n") + 1
-			// Account for palette rendered after a preceding block.
-			if m.palette.visible && i == m.palette.blockIdx {
-				if pv := m.palette.render(m.width); pv != "" {
-					lineOffset += strings.Count(pv, "\n") + 1
-				}
+			if i < len(m.blockLineCounts) {
+				lineOffset += m.blockLineCounts[i]
 			}
 		}
 
@@ -1407,18 +1386,25 @@ func (m Model) blockIndexAtLine(line int) int {
 
 // renderAllBlocks renders each block and joins them vertically.
 // When the command palette is visible, it is rendered below the active block.
-func (m Model) renderAllBlocks() string {
+// As a side effect, it populates m.blockLineCounts with the number of rendered
+// lines for each block (including any palette lines appended after it).
+func (m *Model) renderAllBlocks() string {
 	if m.viewMode {
 		return m.renderViewContent()
 	}
+	m.blockLineCounts = make([]int, len(m.blocks))
 	var parts []string
 	for i := range m.blocks {
-		parts = append(parts, m.renderBlock(i))
+		rendered := m.renderBlock(i)
+		lineCount := strings.Count(rendered, "\n") + 1
+		parts = append(parts, rendered)
 		if m.palette.visible && i == m.active {
 			if pv := m.palette.render(m.width); pv != "" {
+				lineCount += strings.Count(pv, "\n") + 1
 				parts = append(parts, pv)
 			}
 		}
+		m.blockLineCounts[i] = lineCount
 	}
 	return strings.Join(parts, "\n")
 }

--- a/internal/editor/render.go
+++ b/internal/editor/render.go
@@ -17,6 +17,28 @@ import (
 	"github.com/oobagi/notebook/internal/theme"
 )
 
+// countNumberedPosition returns the 1-based position of a numbered list block
+// by counting consecutive NumberedList blocks preceding it.
+func countNumberedPosition(blocks []block.Block, idx int) int {
+	num := 1
+	for i := idx - 1; i >= 0; i-- {
+		if blocks[i].Type == block.NumberedList {
+			num++
+		} else {
+			break
+		}
+	}
+	return num
+}
+
+// resolveColor returns color if non-empty, otherwise returns fallback.
+func resolveColor(color, fallback string) string {
+	if color == "" {
+		return fallback
+	}
+	return color
+}
+
 // renderHeader builds the header bar displayed at the top of the editor.
 // It shows the title on the left and file path + size on the right.
 func (m Model) renderHeader() string {
@@ -93,6 +115,8 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 	ta := m.textareas[idx]
 	content := ta.Value()
 
+	th := theme.Current()
+
 	// Content width for this block type.
 	contentWidth := m.width - gutterWidth - blockPrefixWidth(b.Type)
 	if contentWidth < 1 {
@@ -104,12 +128,8 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 
 	// Divider: selected as a unit — render highlighted hr, no cursor.
 	if b.Type == block.Divider {
-		dth := theme.Current()
-		bs := dth.Blocks.Divider
-		divColor := bs.Color
-		if divColor == "" {
-			divColor = dth.Accent
-		}
+		bs := th.Blocks.Divider
+		divColor := resolveColor(bs.Color, th.Accent)
 		w := m.width - gutterWidth
 		if w <= 0 {
 			w = 40
@@ -118,7 +138,7 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 			Foreground(lipgloss.Color(divColor)).
 			Render(strings.Repeat(bs.Char, w))
 		label := fmt.Sprintf("%2s", b.Type.Short())
-		accentStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(dth.Accent))
+		accentStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(th.Accent))
 		return accentStyle.Render(label) + " " + accentStyle.Render("│") + " " + rendered
 	}
 
@@ -175,8 +195,6 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 	taView := strings.Join(visualLines, "\n")
 	cursorANSI := ta.CursorView()
 
-	th := theme.Current()
-
 	var rendered string
 
 	switch b.Type {
@@ -194,37 +212,21 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 
 	case block.BulletList:
 		bs := th.Blocks.Bullet
-		markerColor := bs.MarkerColor
-		if markerColor == "" {
-			markerColor = th.Muted
-		}
+		markerColor := resolveColor(bs.MarkerColor, th.Muted)
 		prefix := lipgloss.NewStyle().Foreground(lipgloss.Color(markerColor)).Render(bs.Marker)
 		rendered = prefixFirstLine(prefix, taView)
 
 	case block.NumberedList:
 		bs := th.Blocks.Numbered
-		num := 1
-		for i := idx - 1; i >= 0; i-- {
-			if m.blocks[i].Type == block.NumberedList {
-				num++
-			} else {
-				break
-			}
-		}
-		markerColor := bs.MarkerColor
-		if markerColor == "" {
-			markerColor = th.Muted
-		}
+		num := countNumberedPosition(m.blocks, idx)
+		markerColor := resolveColor(bs.MarkerColor, th.Muted)
 		prefix := lipgloss.NewStyle().Foreground(lipgloss.Color(markerColor)).Render(fmt.Sprintf(bs.Format, num))
 		rendered = prefixFirstLine(prefix, taView)
 
 	case block.Checklist:
 		bs := th.Blocks.Checklist
 		if b.Checked {
-			checkedColor := bs.CheckedColor
-			if checkedColor == "" {
-				checkedColor = th.Accent
-			}
+			checkedColor := resolveColor(bs.CheckedColor, th.Accent)
 			style := lipgloss.NewStyle().Foreground(lipgloss.Color(checkedColor))
 			if bs.CheckedBold {
 				style = style.Bold(true)
@@ -236,10 +238,7 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 			}
 			rendered = prefixFirstLine(prefix, text)
 		} else {
-			uncheckedColor := bs.UncheckedColor
-			if uncheckedColor == "" {
-				uncheckedColor = th.Muted
-			}
+			uncheckedColor := resolveColor(bs.UncheckedColor, th.Muted)
 			prefix := lipgloss.NewStyle().Foreground(lipgloss.Color(uncheckedColor)).Render(bs.Unchecked)
 			rendered = prefixFirstLine(prefix, taView)
 		}
@@ -293,10 +292,7 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 
 	case block.Quote:
 		bs := th.Blocks.Quote
-		barColor := bs.BarColor
-		if barColor == "" {
-			barColor = th.Muted
-		}
+		barColor := resolveColor(bs.BarColor, th.Muted)
 		bar := lipgloss.NewStyle().Foreground(lipgloss.Color(barColor)).Render(bs.Bar)
 		lines := strings.Split(taView, "\n")
 		for i, l := range lines {
@@ -546,6 +542,8 @@ func renderInactiveBlock(b block.Block, content string, width int, wordWrap bool
 		contentWidth = 1
 	}
 
+	th := theme.Current()
+
 	// Wrap content to fit within the available width.
 	wrapped := content
 	if wordWrap {
@@ -556,50 +554,34 @@ func renderInactiveBlock(b block.Block, content string, width int, wordWrap bool
 
 	switch b.Type {
 	case block.Heading1:
-		style := theme.Current().Blocks.Heading1.Text.ToLipgloss(theme.Current().Accent)
+		style := th.Blocks.Heading1.Text.ToLipgloss(th.Accent)
 		rendered = style.Render(wrapped)
 
 	case block.Heading2:
-		style := theme.Current().Blocks.Heading2.Text.ToLipgloss("")
+		style := th.Blocks.Heading2.Text.ToLipgloss("")
 		rendered = style.Render(wrapped)
 
 	case block.Heading3:
-		style := theme.Current().Blocks.Heading3.Text.ToLipgloss("")
+		style := th.Blocks.Heading3.Text.ToLipgloss("")
 		rendered = style.Render(wrapped)
 
 	case block.BulletList:
-		bs := theme.Current().Blocks.Bullet
-		markerColor := bs.MarkerColor
-		if markerColor == "" {
-			markerColor = theme.Current().Muted
-		}
+		bs := th.Blocks.Bullet
+		markerColor := resolveColor(bs.MarkerColor, th.Muted)
 		prefix := lipgloss.NewStyle().Foreground(lipgloss.Color(markerColor)).Render(bs.Marker)
 		rendered = prefixFirstLine(prefix, wrapped)
 
 	case block.NumberedList:
-		bs := theme.Current().Blocks.Numbered
-		num := 1
-		for i := idx - 1; i >= 0; i-- {
-			if blocks[i].Type == block.NumberedList {
-				num++
-			} else {
-				break
-			}
-		}
-		markerColor := bs.MarkerColor
-		if markerColor == "" {
-			markerColor = theme.Current().Muted
-		}
+		bs := th.Blocks.Numbered
+		num := countNumberedPosition(blocks, idx)
+		markerColor := resolveColor(bs.MarkerColor, th.Muted)
 		prefix := lipgloss.NewStyle().Foreground(lipgloss.Color(markerColor)).Render(fmt.Sprintf(bs.Format, num))
 		rendered = prefixFirstLine(prefix, wrapped)
 
 	case block.Checklist:
-		bs := theme.Current().Blocks.Checklist
+		bs := th.Blocks.Checklist
 		if b.Checked {
-			checkedColor := bs.CheckedColor
-			if checkedColor == "" {
-				checkedColor = theme.Current().Accent
-			}
+			checkedColor := resolveColor(bs.CheckedColor, th.Accent)
 			style := lipgloss.NewStyle().Foreground(lipgloss.Color(checkedColor))
 			if bs.CheckedBold {
 				style = style.Bold(true)
@@ -611,16 +593,13 @@ func renderInactiveBlock(b block.Block, content string, width int, wordWrap bool
 			}
 			rendered = prefixFirstLine(prefix, text)
 		} else {
-			uncheckedColor := bs.UncheckedColor
-			if uncheckedColor == "" {
-				uncheckedColor = theme.Current().Muted
-			}
+			uncheckedColor := resolveColor(bs.UncheckedColor, th.Muted)
 			prefix := lipgloss.NewStyle().Foreground(lipgloss.Color(uncheckedColor)).Render(bs.Unchecked)
 			rendered = prefixFirstLine(prefix, wrapped)
 		}
 
 	case block.CodeBlock:
-		bs := theme.Current().Blocks.Code
+		bs := th.Blocks.Code
 		title, body := block.ExtractCodeLanguage(content)
 		label := ""
 		if title != "" {
@@ -635,14 +614,11 @@ func renderInactiveBlock(b block.Block, content string, width int, wordWrap bool
 		if title != "" && lexers.Get(title) != nil {
 			displayContent = highlightCode(displayContent, title)
 		}
-		rendered = renderCodeBox(displayContent, label, theme.Current().Border, bs.LabelAlign, contentWidth)
+		rendered = renderCodeBox(displayContent, label, th.Border, bs.LabelAlign, contentWidth)
 
 	case block.Quote:
-		bs := theme.Current().Blocks.Quote
-		barColor := bs.BarColor
-		if barColor == "" {
-			barColor = theme.Current().Muted
-		}
+		bs := th.Blocks.Quote
+		barColor := resolveColor(bs.BarColor, th.Muted)
 		bar := lipgloss.NewStyle().Foreground(lipgloss.Color(barColor)).Render(bs.Bar)
 		lines := strings.Split(wrapped, "\n")
 		for i, l := range lines {
@@ -651,23 +627,13 @@ func renderInactiveBlock(b block.Block, content string, width int, wordWrap bool
 		rendered = strings.Join(lines, "\n")
 
 	case block.Divider:
-		bs := theme.Current().Blocks.Divider
-		divColor := bs.Color
-		if divColor == "" {
-			divColor = theme.Current().Muted
-		}
+		bs := th.Blocks.Divider
+		divColor := resolveColor(bs.Color, th.Muted)
 		w := width - gutterWidth
 		if w <= 0 {
 			w = 40
 		}
 		rendered = lipgloss.NewStyle().Foreground(lipgloss.Color(divColor)).Render(strings.Repeat(bs.Char, w))
-
-	case block.Paragraph:
-		if wrapped == "" {
-			rendered = ""
-		} else {
-			rendered = wrapped
-		}
 
 	default:
 		rendered = wrapped
@@ -708,6 +674,8 @@ func renderViewBlock(b block.Block, content string, width int, wordWrap bool, bl
 		contentWidth = 1
 	}
 
+	th := theme.Current()
+
 	// Always wrap in view mode regardless of the no-wrap setting.
 	wrapped := wrapText(content, contentWidth)
 
@@ -715,50 +683,34 @@ func renderViewBlock(b block.Block, content string, width int, wordWrap bool, bl
 
 	switch b.Type {
 	case block.Heading1:
-		style := theme.Current().Blocks.Heading1.Text.ToLipgloss(theme.Current().Accent)
+		style := th.Blocks.Heading1.Text.ToLipgloss(th.Accent)
 		rendered = style.Render(wrapped)
 
 	case block.Heading2:
-		style := theme.Current().Blocks.Heading2.Text.ToLipgloss("")
+		style := th.Blocks.Heading2.Text.ToLipgloss("")
 		rendered = style.Render(wrapped)
 
 	case block.Heading3:
-		style := theme.Current().Blocks.Heading3.Text.ToLipgloss("")
+		style := th.Blocks.Heading3.Text.ToLipgloss("")
 		rendered = style.Render(wrapped)
 
 	case block.BulletList:
-		bs := theme.Current().Blocks.Bullet
-		markerColor := bs.MarkerColor
-		if markerColor == "" {
-			markerColor = theme.Current().Muted
-		}
+		bs := th.Blocks.Bullet
+		markerColor := resolveColor(bs.MarkerColor, th.Muted)
 		prefix := lipgloss.NewStyle().Foreground(lipgloss.Color(markerColor)).Render(bs.Marker)
 		rendered = prefixFirstLine(prefix, wrapped)
 
 	case block.NumberedList:
-		bs := theme.Current().Blocks.Numbered
-		num := 1
-		for i := idx - 1; i >= 0; i-- {
-			if blocks[i].Type == block.NumberedList {
-				num++
-			} else {
-				break
-			}
-		}
-		markerColor := bs.MarkerColor
-		if markerColor == "" {
-			markerColor = theme.Current().Muted
-		}
+		bs := th.Blocks.Numbered
+		num := countNumberedPosition(blocks, idx)
+		markerColor := resolveColor(bs.MarkerColor, th.Muted)
 		prefix := lipgloss.NewStyle().Foreground(lipgloss.Color(markerColor)).Render(fmt.Sprintf(bs.Format, num))
 		rendered = prefixFirstLine(prefix, wrapped)
 
 	case block.Checklist:
-		bs := theme.Current().Blocks.Checklist
+		bs := th.Blocks.Checklist
 		if b.Checked {
-			checkedColor := bs.CheckedColor
-			if checkedColor == "" {
-				checkedColor = theme.Current().Accent
-			}
+			checkedColor := resolveColor(bs.CheckedColor, th.Accent)
 			style := lipgloss.NewStyle().Foreground(lipgloss.Color(checkedColor))
 			if bs.CheckedBold {
 				style = style.Bold(true)
@@ -770,20 +722,17 @@ func renderViewBlock(b block.Block, content string, width int, wordWrap bool, bl
 			}
 			rendered = prefixFirstLine(prefix, text)
 		} else {
-			uncheckedColor := bs.UncheckedColor
-			if uncheckedColor == "" {
-				uncheckedColor = theme.Current().Muted
-			}
+			uncheckedColor := resolveColor(bs.UncheckedColor, th.Muted)
 			// On hover, light up the checkbox marker with the accent color.
 			if hovered {
-				uncheckedColor = theme.Current().Accent
+				uncheckedColor = th.Accent
 			}
 			prefix := lipgloss.NewStyle().Foreground(lipgloss.Color(uncheckedColor)).Render(bs.Unchecked)
 			rendered = prefixFirstLine(prefix, wrapped)
 		}
 
 	case block.CodeBlock:
-		bs := theme.Current().Blocks.Code
+		bs := th.Blocks.Code
 		title, body := block.ExtractCodeLanguage(content)
 		label := ""
 		if title != "" {
@@ -796,14 +745,11 @@ func renderViewBlock(b block.Block, content string, width int, wordWrap bool, bl
 		if title != "" && lexers.Get(title) != nil {
 			displayContent = highlightCode(displayContent, title)
 		}
-		rendered = renderCodeBox(displayContent, label, theme.Current().Border, bs.LabelAlign, contentWidth)
+		rendered = renderCodeBox(displayContent, label, th.Border, bs.LabelAlign, contentWidth)
 
 	case block.Quote:
-		bs := theme.Current().Blocks.Quote
-		barColor := bs.BarColor
-		if barColor == "" {
-			barColor = theme.Current().Muted
-		}
+		bs := th.Blocks.Quote
+		barColor := resolveColor(bs.BarColor, th.Muted)
 		bar := lipgloss.NewStyle().Foreground(lipgloss.Color(barColor)).Render(bs.Bar)
 		lines := strings.Split(wrapped, "\n")
 		for i, l := range lines {
@@ -812,19 +758,9 @@ func renderViewBlock(b block.Block, content string, width int, wordWrap bool, bl
 		rendered = strings.Join(lines, "\n")
 
 	case block.Divider:
-		bs := theme.Current().Blocks.Divider
-		divColor := bs.Color
-		if divColor == "" {
-			divColor = theme.Current().Muted
-		}
+		bs := th.Blocks.Divider
+		divColor := resolveColor(bs.Color, th.Muted)
 		rendered = lipgloss.NewStyle().Foreground(lipgloss.Color(divColor)).Render(strings.Repeat(bs.Char, width))
-
-	case block.Paragraph:
-		if wrapped == "" {
-			rendered = ""
-		} else {
-			rendered = wrapped
-		}
 
 	default:
 		rendered = wrapped


### PR DESCRIPTION
## Summary
- Extract shared helpers (`countNumberedPosition`, `resolveColor`, `contentWidth`, `insertAtCursor`, `backspaceAtCursor`) to eliminate duplicated logic across editor and browser
- Cache `theme.Current()` in render functions, fix double block rendering in `updateViewport()`, add `noWrapWidth` constant
- Remove redundant `Paragraph` switch cases and unnecessary comments (-75 LOC net)
- Add `.goreleaser.yml` for cross-platform binary builds and GitHub Actions release workflow

## Test plan
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] All 144 editor + browser tests pass
- [ ] CI passes on this PR
- [ ] After merge: tag `v1.0.0`, push tag, verify release workflow creates GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)