### PR TITLE
feat: undo/redo for block editor (Closes #164)

### DIFF
--- a/fork/bubbles/textarea/textarea.go
+++ b/fork/bubbles/textarea/textarea.go
@@ -737,6 +737,17 @@ func (m *Model) SetCursorColumn(col int) {
 	m.lastCharOffset = 0
 }
 
+// SetRow moves the cursor to the given row. If the row is out of bounds it is
+// clamped. The column is clamped to the length of the new row.
+func (m *Model) SetRow(row int) {
+	m.row = clamp(row, 0, len(m.value)-1)
+	if m.col > len(m.value[m.row]) {
+		m.col = len(m.value[m.row])
+	}
+	m.lastCharOffset = 0
+	m.repositionView()
+}
+
 // CursorStart moves the cursor to the start of the input field.
 func (m *Model) CursorStart() {
 	m.SetCursorColumn(0)

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -76,6 +76,9 @@ type Model struct {
 	blockLineOffsets []int           // view mode: starting Y line of each block in rendered output
 	blockLineCounts  []int           // per-block rendered line counts from renderAllBlocks
 	dismissedHints   map[string]bool // tracks which onboarding hints the user has dismissed
+	undo      undoStack // undo history
+	redo      undoStack // redo history
+	undoDirty bool      // true when textarea content changed since last snapshot
 }
 
 type statusKind int
@@ -284,12 +287,16 @@ func (m *Model) scheduleStatusDismiss() tea.Cmd {
 }
 
 // focusBlock switches focus from the current block to the block at index idx.
+// If undoDirty is true (content changed via typing since the last snapshot),
+// a snapshot is pushed so that character-level edits are batched per focus change.
 func (m *Model) focusBlock(idx int) {
 	if idx < 0 || idx >= len(m.textareas) {
 		return
 	}
+	if m.undoDirty {
+		m.pushUndo()
+	}
 	if m.active >= 0 && m.active < len(m.textareas) {
-		// Sync content from old active textarea back to block.
 		m.blocks[m.active].Content = m.textareas[m.active].Value()
 		m.textareas[m.active].Blur()
 	}
@@ -629,6 +636,7 @@ func (m *Model) handleBackspace() bool {
 
 	// Divider: backspace always deletes the divider (selected as a unit).
 	if bt == block.Divider {
+		m.pushUndo()
 		m.deleteBlock(m.active)
 		m.textareas[m.active].CursorEnd()
 		return true
@@ -641,9 +649,9 @@ func (m *Model) handleBackspace() bool {
 				if m.blocks[0].Type == block.Paragraph {
 					return true // Already empty paragraph, nothing to do.
 				}
-				// Non-paragraph single block: deleteBlock will convert to empty paragraph.
 			}
 		}
+		m.pushUndo()
 		m.deleteBlock(m.active)
 		m.textareas[m.active].CursorEnd()
 		return true
@@ -651,6 +659,7 @@ func (m *Model) handleBackspace() bool {
 
 	// List item at position 0: convert to paragraph, keeping text.
 	if bt == block.BulletList || bt == block.NumberedList || bt == block.Checklist {
+		m.pushUndo()
 		m.blocks[m.active].Type = block.Paragraph
 		m.blocks[m.active].Checked = false
 		newTA := newTextareaForBlock(m.blocks[m.active], m.width)
@@ -668,10 +677,12 @@ func (m *Model) handleBackspace() bool {
 
 	// If previous block is a divider, just delete the divider.
 	if m.blocks[m.active-1].Type == block.Divider {
+		m.pushUndo()
 		m.deleteBlock(m.active - 1)
 		return true
 	}
 
+	m.pushUndo()
 	m.mergeBlockUp(m.active)
 	return true
 }
@@ -807,6 +818,7 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Left-click on a checklist block toggles its checked state.
 			if msg.Button == tea.MouseLeft {
 				if idx >= 0 && idx < len(m.blocks) && m.blocks[idx].Type == block.Checklist {
+					m.pushUndo()
 					m.blocks[idx].Checked = !m.blocks[idx].Checked
 					if idx < len(m.textareas) {
 						m.blocks[idx].Content = m.textareas[idx].Value()
@@ -887,6 +899,7 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			case "enter":
 				if sel := m.palette.selected(); sel != nil {
+					m.pushUndo()
 					m.applyPaletteSelection(sel.Type)
 				}
 				m.palette.close()
@@ -1000,7 +1013,26 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.showHelp = true
 			return m, nil
 
+		case "ctrl+z":
+			if m.performUndo() {
+				m.updateViewport()
+			} else {
+				m.status = "Nothing to undo"
+				m.statusStyle = statusWarning
+			}
+			return m, m.scheduleStatusDismiss()
+
+		case "ctrl+y":
+			if m.performRedo() {
+				m.updateViewport()
+			} else {
+				m.status = "Nothing to redo"
+				m.statusStyle = statusWarning
+			}
+			return m, m.scheduleStatusDismiss()
+
 		case "ctrl+k":
+			m.pushUndo()
 			m.cutBlock()
 			m.updateViewport()
 			return m, nil
@@ -1033,6 +1065,7 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if bt == block.CodeBlock || bt == block.Quote || bt == block.Divider {
 					// These types don't split on Enter, so there's no other
 					// way to insert content above them. Create a paragraph.
+					m.pushUndo()
 					m.insertBlockBefore(0, block.Block{Type: block.Paragraph})
 					m.updateViewport()
 					return m, nil
@@ -1052,11 +1085,13 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case "alt+up":
+			m.pushUndo()
 			m.swapBlocks(-1)
 			m.updateViewport()
 			return m, nil
 
 		case "alt+down":
+			m.pushUndo()
 			m.swapBlocks(1)
 			m.updateViewport()
 			return m, nil
@@ -1091,6 +1126,7 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+x":
 			// Toggle checklist checked state.
 			if m.active >= 0 && m.active < len(m.blocks) && m.blocks[m.active].Type == block.Checklist {
+				m.pushUndo()
 				m.blocks[m.active].Checked = !m.blocks[m.active].Checked
 				m.updateViewport()
 				return m, nil
@@ -1146,6 +1182,7 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			// Handle Enter key: always split/create via handleEnter.
 			if keyMsg.Code == tea.KeyEnter {
+				m.pushUndo()
 				m.handleEnter()
 				m.updateViewport()
 				return m, nil
@@ -1174,6 +1211,13 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.updateViewport()
 				return m, nil
 			}
+		}
+
+		// Capture pre-typing state on the first content-changing keystroke.
+		// Subsequent characters in the same block are batched into one undo entry.
+		if !m.undoDirty {
+			m.undo.push(m.captureState())
+			m.undoDirty = true
 		}
 
 		var cmd tea.Cmd
@@ -1536,6 +1580,7 @@ func (m Model) renderHelpOverlay() string {
 	help.WriteString("  ⇧Enter       Newline\n")
 	help.WriteString("  Backspace    Merge " + s + " delete\n")
 	help.WriteString("  ⌃K           Cut block\n")
+	help.WriteString("  ⌃Z" + s + "⌃Y        Undo " + s + " redo\n")
 	help.WriteString("  ⌥↑" + s + "⌥↓        Move block\n")
 	help.WriteString("  /            Block type\n")
 	help.WriteString("\n")

--- a/internal/editor/undo.go
+++ b/internal/editor/undo.go
@@ -1,0 +1,120 @@
+package editor
+
+import (
+	"charm.land/bubbles/v2/textarea"
+	"github.com/oobagi/notebook/internal/block"
+)
+
+const maxUndoDepth = 100
+
+// editorState captures a snapshot of the editor for undo/redo.
+type editorState struct {
+	blocks []block.Block
+	active int
+	row    int
+	col    int
+}
+
+// undoStack is a bounded stack of editor snapshots.
+type undoStack struct {
+	items []editorState
+}
+
+func (s *undoStack) push(state editorState) {
+	s.items = append(s.items, state)
+	if len(s.items) > maxUndoDepth {
+		s.items = s.items[len(s.items)-maxUndoDepth:]
+	}
+}
+
+func (s *undoStack) pop() (editorState, bool) {
+	if len(s.items) == 0 {
+		return editorState{}, false
+	}
+	last := s.items[len(s.items)-1]
+	s.items = s.items[:len(s.items)-1]
+	return last, true
+}
+
+func (s *undoStack) clear() {
+	s.items = s.items[:0]
+}
+
+func (s *undoStack) len() int {
+	return len(s.items)
+}
+
+// captureState snapshots the current editor state.
+func (m *Model) captureState() editorState {
+	row, col := 0, 0
+	if m.active >= 0 && m.active < len(m.textareas) {
+		row = m.textareas[m.active].Line()
+		col = m.textareas[m.active].Column()
+	}
+	blocks := make([]block.Block, len(m.blocks))
+	copy(blocks, m.blocks)
+	if m.active >= 0 && m.active < len(m.textareas) {
+		blocks[m.active].Content = m.textareas[m.active].Value()
+	}
+	return editorState{
+		blocks: blocks,
+		active: m.active,
+		row:    row,
+		col:    col,
+	}
+}
+
+// pushUndo saves the current state onto the undo stack and clears the redo stack.
+func (m *Model) pushUndo() {
+	m.undo.push(m.captureState())
+	m.redo.clear()
+}
+
+// restoreState rebuilds the editor from a snapshot.
+func (m *Model) restoreState(state editorState) {
+	m.blocks = make([]block.Block, len(state.blocks))
+	copy(m.blocks, state.blocks)
+
+	m.textareas = make([]textarea.Model, len(m.blocks))
+	w := m.width
+	if w <= 0 {
+		w = defaultWidth
+	}
+	for i, b := range m.blocks {
+		m.textareas[i] = newTextareaForBlock(b, w)
+	}
+
+	active := state.active
+	if active < 0 || active >= len(m.blocks) {
+		active = 0
+	}
+	m.active = active
+	if len(m.textareas) > 0 {
+		m.cursorCmd = m.textareas[m.active].Focus()
+		m.textareas[m.active].SetRow(state.row)
+		m.textareas[m.active].SetCursorColumn(state.col)
+	}
+	m.undoDirty = false
+}
+
+// performUndo restores the previous state. Returns true if undo was performed.
+func (m *Model) performUndo() bool {
+	if m.undo.len() == 0 {
+		return false
+	}
+	m.redo.push(m.captureState())
+	state, _ := m.undo.pop()
+	m.restoreState(state)
+	return true
+}
+
+// performRedo re-applies the next state. Returns true if redo was performed.
+func (m *Model) performRedo() bool {
+	if m.redo.len() == 0 {
+		return false
+	}
+	m.undo.push(m.captureState())
+	state, _ := m.redo.pop()
+	m.restoreState(state)
+	return true
+}

--- a/internal/editor/undo_test.go
+++ b/internal/editor/undo_test.go
@@ -1,0 +1,297 @@
+package editor
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/oobagi/notebook/internal/block"
+)
+
+// helper to create an editor with the given markdown content.
+func newTestEditor(content string) Model {
+	return New(Config{
+		Title:   "test",
+		Content: content,
+	})
+}
+
+// helper to send a key message and return the updated model.
+func sendKey(m Model, key string) Model {
+	var msg tea.KeyPressMsg
+	switch key {
+	case "enter":
+		msg = tea.KeyPressMsg{Code: tea.KeyEnter}
+	case "backspace":
+		msg = tea.KeyPressMsg{Code: tea.KeyBackspace}
+	case "ctrl+z":
+		msg = tea.KeyPressMsg{Code: 'z', Mod: tea.ModCtrl}
+	case "ctrl+y":
+		msg = tea.KeyPressMsg{Code: 'y', Mod: tea.ModCtrl}
+	case "ctrl+k":
+		msg = tea.KeyPressMsg{Code: 'k', Mod: tea.ModCtrl}
+	case "ctrl+x":
+		msg = tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl}
+	case "alt+up":
+		msg = tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModAlt}
+	case "alt+down":
+		msg = tea.KeyPressMsg{Code: tea.KeyDown, Mod: tea.ModAlt}
+	default:
+		if len(key) == 1 {
+			msg = tea.KeyPressMsg{Code: rune(key[0]), Text: key}
+		}
+	}
+	result, _ := m.Update(msg)
+	return result.(Model)
+}
+
+func TestUndoAfterEnter(t *testing.T) {
+	m := newTestEditor("hello world")
+	if len(m.blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(m.blocks))
+	}
+
+	// Move cursor to middle and press Enter to split.
+	m.textareas[0].SetCursorColumn(5)
+	m = sendKey(m, "enter")
+
+	if len(m.blocks) != 2 {
+		t.Fatalf("expected 2 blocks after split, got %d", len(m.blocks))
+	}
+
+	// Undo should rejoin.
+	m = sendKey(m, "ctrl+z")
+	if len(m.blocks) != 1 {
+		t.Fatalf("expected 1 block after undo, got %d", len(m.blocks))
+	}
+	if m.textareas[0].Value() != "hello world" {
+		t.Errorf("expected 'hello world', got %q", m.textareas[0].Value())
+	}
+}
+
+func TestUndoAfterBackspaceMerge(t *testing.T) {
+	// Use two bullet items so they parse as separate blocks.
+	m := newTestEditor("- alpha\n- beta")
+	if len(m.blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(m.blocks))
+	}
+
+	// Focus second block and position cursor at start.
+	m.focusBlock(1)
+	m.textareas[1].CursorStart()
+
+	// Backspace at position 0 of a bullet converts to paragraph.
+	m = sendKey(m, "backspace")
+
+	if m.blocks[1].Type != block.Paragraph {
+		t.Fatalf("expected Paragraph after backspace, got %v", m.blocks[1].Type)
+	}
+
+	// Undo should restore the bullet list type.
+	m = sendKey(m, "ctrl+z")
+	if m.blocks[1].Type != block.BulletList {
+		t.Errorf("expected BulletList after undo, got %v", m.blocks[1].Type)
+	}
+}
+
+func TestUndoAfterCutBlock(t *testing.T) {
+	m := newTestEditor("# Title\n\nparagraph")
+	originalContent := m.textareas[0].Value()
+
+	m = sendKey(m, "ctrl+k")
+
+	// First block was cut — remaining blocks should be fewer.
+	if len(m.blocks) >= 3 {
+		t.Fatalf("expected fewer blocks after cut, got %d", len(m.blocks))
+	}
+
+	m = sendKey(m, "ctrl+z")
+	if len(m.blocks) != 3 {
+		t.Fatalf("expected 3 blocks after undo, got %d", len(m.blocks))
+	}
+	if m.textareas[0].Value() != originalContent {
+		t.Errorf("expected %q, got %q", originalContent, m.textareas[0].Value())
+	}
+}
+
+func TestUndoAfterSwap(t *testing.T) {
+	m := newTestEditor("- first\n- second")
+	if len(m.blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(m.blocks))
+	}
+
+	first := m.textareas[0].Value()
+	second := m.textareas[1].Value()
+
+	m = sendKey(m, "alt+down")
+
+	// After swap, order should be reversed.
+	if m.textareas[0].Value() != second || m.textareas[1].Value() != first {
+		t.Fatalf("swap did not work: [0]=%q [1]=%q", m.textareas[0].Value(), m.textareas[1].Value())
+	}
+
+	m = sendKey(m, "ctrl+z")
+	if m.textareas[0].Value() != first || m.textareas[1].Value() != second {
+		t.Errorf("undo did not restore order: [0]=%q [1]=%q", m.textareas[0].Value(), m.textareas[1].Value())
+	}
+}
+
+func TestUndoAfterChecklistToggle(t *testing.T) {
+	m := newTestEditor("- [ ] task")
+	if m.blocks[0].Type != block.Checklist {
+		t.Fatalf("expected Checklist, got %v", m.blocks[0].Type)
+	}
+	if m.blocks[0].Checked {
+		t.Fatal("expected unchecked")
+	}
+
+	m = sendKey(m, "ctrl+x")
+	if !m.blocks[0].Checked {
+		t.Fatal("expected checked after toggle")
+	}
+
+	m = sendKey(m, "ctrl+z")
+	if m.blocks[0].Checked {
+		t.Error("expected unchecked after undo")
+	}
+}
+
+func TestRedoAfterUndo(t *testing.T) {
+	m := newTestEditor("hello world")
+	m.textareas[0].SetCursorColumn(5)
+	m = sendKey(m, "enter")
+
+	if len(m.blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(m.blocks))
+	}
+
+	m = sendKey(m, "ctrl+z")
+	if len(m.blocks) != 1 {
+		t.Fatalf("expected 1 block after undo, got %d", len(m.blocks))
+	}
+
+	m = sendKey(m, "ctrl+y")
+	if len(m.blocks) != 2 {
+		t.Fatalf("expected 2 blocks after redo, got %d", len(m.blocks))
+	}
+}
+
+func TestNewEditClearsRedoStack(t *testing.T) {
+	m := newTestEditor("hello world")
+	m.textareas[0].SetCursorColumn(5)
+	m = sendKey(m, "enter")
+	m = sendKey(m, "ctrl+z")
+
+	// Now type something — should clear redo.
+	m = sendKey(m, "a")
+	m = sendKey(m, "ctrl+y")
+
+	// Redo should show "Nothing to redo" since new edit cleared it.
+	if m.redo.len() != 0 {
+		t.Error("expected redo stack to be empty after new edit")
+	}
+}
+
+func TestUndoEmptyStackShowsStatus(t *testing.T) {
+	m := newTestEditor("hello")
+	m = sendKey(m, "ctrl+z")
+
+	if m.status != "Nothing to undo" {
+		t.Errorf("expected 'Nothing to undo' status, got %q", m.status)
+	}
+}
+
+func TestRedoEmptyStackShowsStatus(t *testing.T) {
+	m := newTestEditor("hello")
+	m = sendKey(m, "ctrl+y")
+
+	if m.status != "Nothing to redo" {
+		t.Errorf("expected 'Nothing to redo' status, got %q", m.status)
+	}
+}
+
+func TestUndoMaxDepth(t *testing.T) {
+	m := newTestEditor("start")
+
+	// Push 101 mutations — should cap at 100.
+	for i := 0; i < maxUndoDepth+1; i++ {
+		m.textareas[0].SetCursorColumn(len(m.textareas[0].Value()))
+		m = sendKey(m, "enter")
+	}
+
+	if m.undo.len() > maxUndoDepth {
+		t.Errorf("expected max %d undo entries, got %d", maxUndoDepth, m.undo.len())
+	}
+}
+
+func TestCharacterBatching(t *testing.T) {
+	m := newTestEditor("- first\n- second")
+	original := m.textareas[0].Value()
+
+	// Type several characters in the first block.
+	for _, ch := range "abc" {
+		m = sendKey(m, string(ch))
+	}
+
+	// Check the undo stack has a pre-typing snapshot.
+	if m.undo.len() != 1 {
+		t.Fatalf("expected 1 undo entry (pre-typing), got %d", m.undo.len())
+	}
+	preTyping := m.undo.items[0]
+	if preTyping.blocks[0].Content != original {
+		t.Fatalf("pre-typing snapshot has wrong content: %q (expected %q)", preTyping.blocks[0].Content, original)
+	}
+
+	// Undo the typing directly (no structural mutation needed).
+	m = sendKey(m, "ctrl+z")
+
+	if m.textareas[0].Value() != original {
+		t.Errorf("expected %q after undoing typing, got %q", original, m.textareas[0].Value())
+	}
+}
+
+func TestUndoStackStruct(t *testing.T) {
+	var s undoStack
+
+	// Push and pop.
+	s.push(editorState{active: 1})
+	s.push(editorState{active: 2})
+	if s.len() != 2 {
+		t.Fatalf("expected len 2, got %d", s.len())
+	}
+
+	state, ok := s.pop()
+	if !ok || state.active != 2 {
+		t.Errorf("expected active=2, got %d", state.active)
+	}
+
+	// Clear.
+	s.clear()
+	if s.len() != 0 {
+		t.Errorf("expected empty after clear, got %d", s.len())
+	}
+
+	// Pop from empty.
+	_, ok = s.pop()
+	if ok {
+		t.Error("expected pop from empty to return false")
+	}
+}
+
+func TestCursorRestoredAfterUndo(t *testing.T) {
+	m := newTestEditor("hello world")
+
+	// Place cursor at position 5.
+	m.textareas[0].SetCursorColumn(5)
+
+	// Split with Enter.
+	m = sendKey(m, "enter")
+
+	// Undo — cursor should be back at column 5, row 0.
+	m = sendKey(m, "ctrl+z")
+
+	row := m.textareas[m.active].Line()
+	col := m.textareas[m.active].Column()
+	if row != 0 || col != 5 {
+		t.Errorf("expected cursor at (0, 5), got (%d, %d)", row, col)
+	}
+}


### PR DESCRIPTION
## Summary
- Full-snapshot undo/redo system: Ctrl+Z / Ctrl+Y with 100-entry depth cap
- Structural mutations (Enter split, Backspace merge/delete, Ctrl+K cut, Alt+Up/Down swap, Ctrl+X checkbox toggle, palette type change) each create an undo entry
- Character-level edits batched per focus-change boundary — typing "hello world" then moving blocks creates one undo entry
- Cursor position (row + column) restored on undo/redo via new `SetRow()` on forked textarea
- Help overlay updated with Ctrl+Z/Ctrl+Y bindings

## Test plan
- [x] `go vet ./...` — clean
- [x] All existing 100 editor tests pass (no regression)
- [x] 12 new undo-specific tests: split, merge, cut, swap, toggle, redo, max depth, batching, cursor restore, empty stack status
- [x] Full test suite passes (all packages)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)