### PR TITLE
fix: undo/redo only tracks content changes, not cursor movement

### DIFF
--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -1213,15 +1213,23 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		// Capture pre-typing state on the first content-changing keystroke.
-		// Subsequent characters in the same block are batched into one undo entry.
+		// Capture state before the textarea processes the keystroke so we
+		// can detect whether content actually changed (vs. cursor movement).
+		var preState editorState
 		if !m.undoDirty {
-			m.undo.push(m.captureState())
-			m.undoDirty = true
+			preState = m.captureState()
 		}
 
 		var cmd tea.Cmd
 		m.textareas[m.active], cmd = m.textareas[m.active].Update(msg)
+
+		// Only push an undo entry when content actually changed, not on
+		// cursor-only movements (left, right, home, end, etc.).
+		if !m.undoDirty && m.textareas[m.active].Value() != preState.blocks[preState.active].Content {
+			m.undo.push(preState)
+			m.redo.clear()
+			m.undoDirty = true
+		}
 
 		// Re-enforce width and recalculate height after every keystroke.
 		// This ensures the textarea re-wraps correctly after content changes

--- a/internal/editor/undo.go
+++ b/internal/editor/undo.go
@@ -68,6 +68,7 @@ func (m *Model) captureState() editorState {
 func (m *Model) pushUndo() {
 	m.undo.push(m.captureState())
 	m.redo.clear()
+	m.undoDirty = false
 }
 
 // restoreState rebuilds the editor from a snapshot.
@@ -94,13 +95,22 @@ func (m *Model) restoreState(state editorState) {
 		m.textareas[m.active].SetRow(state.row)
 		m.textareas[m.active].SetCursorColumn(state.col)
 	}
+
+	// Close palette if open and recalculate textarea dimensions
+	// (resizeTextareas respects wordWrap and sets correct viewport size).
+	m.palette.close()
 	m.undoDirty = false
+	m.resizeTextareas()
 }
 
 // performUndo restores the previous state. Returns true if undo was performed.
 func (m *Model) performUndo() bool {
 	if m.undo.len() == 0 {
 		return false
+	}
+	// Flush any pending dirty content before capturing current state for redo.
+	if m.active >= 0 && m.active < len(m.textareas) {
+		m.blocks[m.active].Content = m.textareas[m.active].Value()
 	}
 	m.redo.push(m.captureState())
 	state, _ := m.undo.pop()
@@ -112,6 +122,9 @@ func (m *Model) performUndo() bool {
 func (m *Model) performRedo() bool {
 	if m.redo.len() == 0 {
 		return false
+	}
+	if m.active >= 0 && m.active < len(m.textareas) {
+		m.blocks[m.active].Content = m.textareas[m.active].Value()
 	}
 	m.undo.push(m.captureState())
 	state, _ := m.redo.pop()


### PR DESCRIPTION
## Summary
- Cursor-only keystrokes (arrows, home, end) were pushing undo snapshots — required spamming Ctrl+Z ~20 times to undo one edit
- Now compares textarea content before/after update, only creates undo entry when content actually changed
- Also fixes: `resizeTextareas` after restore (rendering bugs), typing after undo clears redo, palette closed on undo, `pushUndo` resets `undoDirty`

## Test plan
- [x] All 112 editor tests pass
- [x] Full suite: 558 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)