### PR TITLE
fix: consistent cursor placement between blocks (Closes #163)

### DIFF
--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -194,6 +194,7 @@ func newTextareaForBlock(b block.Block, width int) textarea.Model {
 	}
 	ta.SetWidth(taWidth)
 	ta.SetValue(b.Content)
+	ta.MoveToBegin()
 
 	// Set height from the textarea's own wrapping — it knows best.
 	ta.SetHeight(ta.VisualLineCount())
@@ -304,26 +305,33 @@ func (m *Model) focusBlock(idx int) {
 	m.cursorCmd = m.textareas[idx].Focus()
 }
 
-// navigateUp moves focus to the previous block, placing cursor at end.
+// navigateUp moves focus to the previous block, preserving horizontal position.
 func (m *Model) navigateUp() {
 	if m.active <= 0 {
 		return
 	}
+	// Capture horizontal position before leaving.
+	charOffset := m.textareas[m.active].LineInfo().CharOffset
 	m.focusBlock(m.active - 1)
-	// Place cursor at the end of the previous block's textarea.
+	// Move to the last visual line and restore horizontal offset.
 	ta := &m.textareas[m.active]
-	ta.CursorEnd()
+	ta.MoveToEnd()
+	li := ta.LineInfo()
+	ta.SetCursorColumn(li.StartColumn + charOffset)
 }
 
-// navigateDown moves focus to the next block, placing cursor at start.
+// navigateDown moves focus to the next block, preserving horizontal position.
 func (m *Model) navigateDown() {
 	if m.active >= len(m.textareas)-1 {
 		return
 	}
+	// Capture horizontal position before leaving.
+	charOffset := m.textareas[m.active].LineInfo().CharOffset
 	m.focusBlock(m.active + 1)
-	// Place cursor at the start of the next block's textarea.
+	// Move to the first visual line and restore horizontal offset.
 	ta := &m.textareas[m.active]
-	ta.CursorStart()
+	ta.MoveToBegin()
+	ta.SetCursorColumn(charOffset)
 }
 
 // isMultiLine returns true if the block type allows multi-line content.
@@ -610,7 +618,7 @@ func (m *Model) handleEnter() {
 	m.insertBlockAfter(m.active, newBlock)
 	// Place cursor at the start of the new block (not at the end, which is
 	// where SetValue leaves it).
-	m.textareas[m.active].CursorStart()
+	m.textareas[m.active].MoveToBegin()
 }
 
 // handleBackspace processes Backspace at position 0 for block deletion/merging.
@@ -638,7 +646,7 @@ func (m *Model) handleBackspace() bool {
 	if bt == block.Divider {
 		m.pushUndo()
 		m.deleteBlock(m.active)
-		m.textareas[m.active].CursorEnd()
+		m.textareas[m.active].MoveToEnd()
 		return true
 	}
 
@@ -653,7 +661,7 @@ func (m *Model) handleBackspace() bool {
 		}
 		m.pushUndo()
 		m.deleteBlock(m.active)
-		m.textareas[m.active].CursorEnd()
+		m.textareas[m.active].MoveToEnd()
 		return true
 	}
 

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -615,6 +615,9 @@ func TestEnterOnSingleLineBlockCreatesNewBlock(t *testing.T) {
 		t.Fatalf("expected 1 block, got %d", m.BlockCount())
 	}
 
+	// Move cursor to end (newTextareaForBlock places cursor at start).
+	m.textareas[m.active].MoveToEnd()
+
 	// Press Enter.
 	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	m = updated.(Model)
@@ -1282,6 +1285,9 @@ func TestEnterOnEmptyBulletConvertsToParagraph(t *testing.T) {
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = updated.(Model)
 
+	// Move cursor to end (newTextareaForBlock places cursor at start).
+	m.textareas[m.active].MoveToEnd()
+
 	// Press Enter on the non-empty bullet to create a new empty bullet.
 	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	m = updated.(Model)
@@ -1315,6 +1321,9 @@ func TestEnterOnEmptyNumberedListConvertsToParagraph(t *testing.T) {
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = updated.(Model)
 
+	// Move cursor to end (newTextareaForBlock places cursor at start).
+	m.textareas[m.active].MoveToEnd()
+
 	// Press Enter to create a new empty numbered list item.
 	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	m = updated.(Model)
@@ -1342,6 +1351,9 @@ func TestEnterOnEmptyChecklistConvertsToParagraph(t *testing.T) {
 	m := New(Config{Title: "test", Content: "- [ ] task one"})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = updated.(Model)
+
+	// Move cursor to end (newTextareaForBlock places cursor at start).
+	m.textareas[m.active].MoveToEnd()
 
 	// Press Enter to create a new empty checklist item.
 	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})


### PR DESCRIPTION
## Summary
- Replaced `CursorStart()`/`CursorEnd()` (row-level) with `MoveToBegin()`/`MoveToEnd()` (document-level) across `newTextareaForBlock`, `navigateUp/Down`, and `handleBackspace`
- Cross-block navigation now preserves horizontal cursor position via `LineInfo().CharOffset`, so the cursor stays at the same column when arrowing between blocks

## Test plan
- [x] Navigate down into a wrapped block — cursor at start, not end
- [x] Navigate up into a wrapped block — cursor on last line at matching column
- [x] Round-trip up/down produces consistent cursor placement
- [x] Backspace to delete/merge blocks places cursor correctly
- [x] All 558 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)