### PR TITLE
feat: definition block type with lookup palette (Closes #188)

### DIFF
--- a/internal/block/block.go
+++ b/internal/block/block.go
@@ -22,6 +22,7 @@ const (
 	CodeBlock                     // fenced code block (``` ... ```)
 	Quote                         // > block quote
 	Divider                       // ---, ***, or ___
+	DefinitionList                // term\n: definition
 )
 
 // String returns the human-readable name of a BlockType.
@@ -47,6 +48,8 @@ func (bt BlockType) String() string {
 		return "Quote"
 	case Divider:
 		return "Divider"
+	case DefinitionList:
+		return "DefinitionList"
 	default:
 		return "Unknown"
 	}
@@ -85,6 +88,8 @@ func (bt BlockType) Short() string {
 		return "qt"
 	case Divider:
 		return "hr"
+	case DefinitionList:
+		return "df"
 	default:
 		return "?"
 	}
@@ -116,6 +121,17 @@ func CountNumberedPosition(blocks []Block, idx int) int {
 		}
 	}
 	return num
+}
+
+// ExtractDefinition splits a definition list block's content into its term
+// (first line) and definition (remaining lines). The content stores both
+// parts separated by a newline.
+func ExtractDefinition(content string) (term, definition string) {
+	first, rest, found := strings.Cut(content, "\n")
+	if found {
+		return first, rest
+	}
+	return first, ""
 }
 
 // ExtractCodeLanguage splits a code block's content into its title line

--- a/internal/block/parse.go
+++ b/internal/block/parse.go
@@ -149,12 +149,35 @@ func Parse(markdown string) []Block {
 			continue
 		}
 
+		// --- Definition (term followed by one or more ": definition" lines) ---
+		if i+1 < len(lines) && !isBlockStart(line) && isDefinitionLine(lines[i+1]) {
+			term := line
+			i++
+			var defs []string
+			for i < len(lines) && isDefinitionLine(lines[i]) {
+				defs = append(defs, strings.TrimPrefix(lines[i], ": "))
+				i++
+			}
+			blocks = append(blocks, Block{
+				Type:    DefinitionList,
+				Content: term + "\n" + strings.Join(defs, "\n"),
+			})
+			continue
+		}
+
 		// --- Paragraph (merge consecutive non-special lines) ---
 		var paraLines []string
 		for i < len(lines) {
 			if isBlockStart(lines[i]) {
 				break
 			}
+			paraLines = append(paraLines, lines[i])
+			i++
+		}
+		// Safety: if no lines were collected (current line is a block start
+		// that wasn't matched by any preceding handler), consume it as a
+		// single-line paragraph to avoid an infinite loop.
+		if len(paraLines) == 0 {
 			paraLines = append(paraLines, lines[i])
 			i++
 		}
@@ -177,7 +200,8 @@ func isBlockStart(line string) bool {
 		strings.HasPrefix(line, "# ") ||
 		strings.HasPrefix(line, "## ") ||
 		strings.HasPrefix(line, "### ") ||
-		strings.HasPrefix(line, "> ") {
+		strings.HasPrefix(line, "> ") ||
+		strings.HasPrefix(line, ": ") {
 		return true
 	}
 	_, stripped := stripListIndent(line)
@@ -190,6 +214,11 @@ func isBlockStart(line string) bool {
 		return true
 	}
 	return isDivider(line)
+}
+
+// isDefinitionLine reports whether a line starts a definition (": ").
+func isDefinitionLine(line string) bool {
+	return strings.HasPrefix(line, ": ")
 }
 
 // isDivider reports whether a line is a thematic break (---, ***, or ___).

--- a/internal/block/parse_test.go
+++ b/internal/block/parse_test.go
@@ -221,6 +221,40 @@ func TestParse(t *testing.T) {
 				{Type: CodeBlock, Content: "go\nfunc main() {}\nmore code"},
 			},
 		},
+		{
+			name:  "definition list single item",
+			input: "Term\n: Definition text here",
+			expect: []Block{
+				{Type: DefinitionList, Content: "Term\nDefinition text here"},
+			},
+		},
+		{
+			name:  "definition list multiple items",
+			input: "Term One\n: First definition\n\nTerm Two\n: Second definition",
+			expect: []Block{
+				{Type: DefinitionList, Content: "Term One\nFirst definition"},
+				{Type: Paragraph, Content: ""},
+				{Type: DefinitionList, Content: "Term Two\nSecond definition"},
+			},
+		},
+		{
+			name:  "definition list in mixed document",
+			input: "# Glossary\n\nAPI\n: Application Programming Interface\n\nSDK\n: Software Development Kit",
+			expect: []Block{
+				{Type: Heading1, Content: "Glossary"},
+				{Type: Paragraph, Content: ""},
+				{Type: DefinitionList, Content: "API\nApplication Programming Interface"},
+				{Type: Paragraph, Content: ""},
+				{Type: DefinitionList, Content: "SDK\nSoftware Development Kit"},
+			},
+		},
+		{
+			name:  "orphan definition line parsed as paragraph",
+			input: ": orphan definition",
+			expect: []Block{
+				{Type: Paragraph, Content: ": orphan definition"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -274,6 +308,8 @@ func formatBlocks(blocks []Block) string {
 			b.WriteString("Quote")
 		case Divider:
 			b.WriteString("Divider")
+		case DefinitionList:
+			b.WriteString("DefinitionList")
 		}
 		if bl.Content != "" {
 			b.WriteString(" " + bl.Content)

--- a/internal/block/serialize.go
+++ b/internal/block/serialize.go
@@ -77,6 +77,13 @@ func Serialize(blocks []Block) string {
 		case Divider:
 			lines = append(lines, "---")
 
+		case DefinitionList:
+			term, def := ExtractDefinition(b.Content)
+			lines = append(lines, term)
+			for _, d := range strings.Split(def, "\n") {
+				lines = append(lines, ": "+d)
+			}
+
 		default:
 			if b.Content != "" {
 				lines = append(lines, strings.Split(b.Content, "\n")...)

--- a/internal/block/serialize_test.go
+++ b/internal/block/serialize_test.go
@@ -129,6 +129,18 @@ func TestSerializeRoundTrip(t *testing.T) {
 			name: "divider between paragraphs",
 			md:   "above\n\n---\n\nbelow",
 		},
+		{
+			name: "definition list single item",
+			md:   "Term\n: Definition text here",
+		},
+		{
+			name: "definition list multiple items",
+			md:   "Term One\n: First definition\n\nTerm Two\n: Second definition",
+		},
+		{
+			name: "definition list in mixed document",
+			md:   "# Glossary\n\nAPI\n: Application Programming Interface\n\nSDK\n: Software Development Kit",
+		},
 	}
 
 	for _, tt := range tests {
@@ -155,6 +167,8 @@ func TestSerializeIdempotent(t *testing.T) {
 		"> quote\n> continues",
 		"---",
 		"# Title\n\nSome intro text.\n\n## Section\n\n- bullet one\n- bullet two\n\n1. step one\n2. step two\n\n> a quote\n\n---\n\n```go\nfunc main() {}\n```\n\n- [ ] task\n- [x] done",
+		"Term\n: Definition text here",
+		"API\n: Application Programming Interface\n\nSDK\n: Software Development Kit",
 	}
 
 	for _, md := range inputs {

--- a/internal/editor/deflookup.go
+++ b/internal/editor/deflookup.go
@@ -1,0 +1,222 @@
+package editor
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/oobagi/notebook-cli/internal/block"
+	"github.com/oobagi/notebook-cli/internal/theme"
+)
+
+// maxDefLookupItems is the maximum number of items shown at once.
+const maxDefLookupItems = 6
+
+// defLookup is a searchable panel that lists all definition list blocks
+// in the current document, allowing the user to filter by term and jump
+// to a selected definition. Renders as a footer modal above the status bar.
+type defLookup struct {
+	visible  bool
+	items    []defItem
+	filtered []int  // indices into items matching filter
+	filter   string // typed search text
+	cursor   int    // selection in filtered list
+}
+
+// defItem represents one definition list block in the document.
+type defItem struct {
+	Term       string
+	Definition string
+	BlockIdx   int // index in Model.blocks
+}
+
+// open scans blocks for definition lists and shows the lookup.
+func (d *defLookup) open(blocks []block.Block) {
+	d.visible = true
+	d.filter = ""
+	d.cursor = 0
+	d.items = nil
+	for i, b := range blocks {
+		if b.Type == block.DefinitionList {
+			term, def := block.ExtractDefinition(b.Content)
+			d.items = append(d.items, defItem{
+				Term:       term,
+				Definition: def,
+				BlockIdx:   i,
+			})
+		}
+	}
+	d.refilter()
+}
+
+// close hides the lookup.
+func (d *defLookup) close() {
+	d.visible = false
+	d.filter = ""
+	d.cursor = 0
+	d.items = nil
+}
+
+// refilter rebuilds the filtered list based on current filter text.
+func (d *defLookup) refilter() {
+	if d.filter == "" {
+		d.filtered = make([]int, len(d.items))
+		for i := range d.items {
+			d.filtered[i] = i
+		}
+		d.cursor = 0
+		return
+	}
+	lower := strings.ToLower(d.filter)
+	var result []int
+	for i, item := range d.items {
+		if strings.Contains(strings.ToLower(item.Term), lower) {
+			result = append(result, i)
+		}
+	}
+	d.filtered = result
+	if d.cursor >= len(d.filtered) {
+		d.cursor = len(d.filtered) - 1
+	}
+	if d.cursor < 0 {
+		d.cursor = 0
+	}
+}
+
+func (d *defLookup) addFilterRune(r rune) {
+	d.filter += string(r)
+	d.refilter()
+}
+
+func (d *defLookup) deleteFilterRune() bool {
+	if d.filter == "" {
+		return false
+	}
+	runes := []rune(d.filter)
+	d.filter = string(runes[:len(runes)-1])
+	d.refilter()
+	return true
+}
+
+func (d *defLookup) moveUp() {
+	if d.cursor > 0 {
+		d.cursor--
+	}
+}
+
+func (d *defLookup) moveDown() {
+	if d.cursor < len(d.filtered)-1 {
+		d.cursor++
+	}
+}
+
+func (d *defLookup) selected() *defItem {
+	if len(d.filtered) == 0 || d.cursor < 0 || d.cursor >= len(d.filtered) {
+		return nil
+	}
+	return &d.items[d.filtered[d.cursor]]
+}
+
+// height returns the number of terminal lines the modal occupies.
+func (d *defLookup) height() int {
+	if !d.visible {
+		return 0
+	}
+	if d.filter == "" {
+		return 3 // border + filter + gap
+	}
+	n := len(d.filtered)
+	if n > maxDefLookupItems {
+		n = maxDefLookupItems
+	}
+	if n == 0 {
+		n = 1 // "No definitions" / "No matches" line
+	}
+	return n + 3 // border + filter + items + gap
+}
+
+// visibleWindow returns the slice of filtered indices to display,
+// keeping the cursor visible.
+func (d *defLookup) visibleWindow() (start, end int) {
+	n := len(d.filtered)
+	if n <= maxDefLookupItems {
+		return 0, n
+	}
+	// Keep cursor centered when possible.
+	half := maxDefLookupItems / 2
+	start = d.cursor - half
+	if start < 0 {
+		start = 0
+	}
+	end = start + maxDefLookupItems
+	if end > n {
+		end = n
+		start = end - maxDefLookupItems
+	}
+	return start, end
+}
+
+// render draws the definition lookup as a full-width footer modal.
+func (d *defLookup) render(width int) string {
+	if !d.visible {
+		return ""
+	}
+
+	th := theme.Current()
+	dim := lipgloss.NewStyle().Foreground(lipgloss.Color(th.Muted))
+	accent := lipgloss.NewStyle().Foreground(lipgloss.Color(th.Accent)).Bold(true)
+
+	// Top border — full width horizontal line.
+	border := dim.Render(strings.Repeat("─", width))
+
+	// Filter line.
+	prompt := dim.Render(": ")
+	filterText := d.filter
+	if filterText == "" {
+		filterText = dim.Render("search definitions...")
+	}
+	filterLine := " " + prompt + filterText
+
+	// Only show results once the user starts typing.
+	if d.filter == "" {
+		return border + "\n" + filterLine + "\n"
+	}
+
+	// Items.
+	var rows []string
+	if len(d.items) == 0 {
+		rows = append(rows, " "+dim.Render("No definitions in this note"))
+	} else if len(d.filtered) == 0 {
+		rows = append(rows, " "+dim.Render("No matches"))
+	} else {
+		start, end := d.visibleWindow()
+		for vi := start; vi < end; vi++ {
+			item := d.items[d.filtered[vi]]
+
+			term := item.Term
+			if term == "" {
+				term = "(empty)"
+			}
+			def := item.Definition
+			maxDef := width - len(term) - 8 // term + spacing + margins
+			if maxDef < 10 {
+				maxDef = 10
+			}
+			if len(def) > maxDef {
+				def = def[:maxDef-3] + "..."
+			}
+
+			if vi == d.cursor {
+				marker := accent.Render("›")
+				termStr := accent.Render(term)
+				defStr := dim.Render(def)
+				rows = append(rows, " "+marker+" "+termStr+"  "+defStr)
+			} else {
+				termStr := lipgloss.NewStyle().Bold(true).Render(term)
+				defStr := dim.Render(def)
+				rows = append(rows, "   "+termStr+"  "+defStr)
+			}
+		}
+	}
+
+	return border + "\n" + filterLine + "\n" + strings.Join(rows, "\n") + "\n"
+}

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -74,7 +74,8 @@ type Model struct {
 	showHelp    bool
 	blockClip   *block.Block // block-level clipboard for Ctrl+K block cut
 	statusGen   int    // generation counter for status auto-dismiss
-	palette     palette // "/" command palette for block type insertion
+	palette     palette    // "/" command palette for block type insertion
+	defLookup   defLookup  // ":" definition lookup palette
 	wordWrap         bool            // when true, text wraps at terminal width
 	viewMode         bool            // when true, read-only rendering with no cursor
 	hoverBlock       int             // view mode: block index under mouse cursor (-1 = none)
@@ -131,6 +132,8 @@ func blockPrefixWidth(bt block.BlockType, indent int) int {
 		base = lipgloss.Width(th.Blocks.Quote.Bar)
 	case block.CodeBlock:
 		base = 4
+	case block.DefinitionList:
+		base = lipgloss.Width(th.Blocks.Definition.Marker)
 	}
 	return indent*4 + base
 }
@@ -476,7 +479,7 @@ func (m *Model) navigateDown() {
 
 // isMultiLine returns true if the block type allows multi-line content.
 func isMultiLine(bt block.BlockType) bool {
-	return bt == block.Paragraph || bt == block.CodeBlock || bt == block.Quote
+	return bt == block.Paragraph || bt == block.CodeBlock || bt == block.Quote || bt == block.DefinitionList
 }
 
 // insertBlockBefore inserts a new block before the given index, creates a
@@ -720,6 +723,41 @@ func (m *Model) handleEnter() {
 		return
 	}
 
+	// Definition block: same pattern as code/quote — Enter inserts a
+	// newline via the textarea natively. Empty last line exits to paragraph.
+	// Empty block converts to paragraph.
+	if bt == block.DefinitionList {
+		if content == "" || content == "\n" {
+			m.blocks[m.active].Type = block.Paragraph
+			m.blocks[m.active].Content = ""
+			newTA := newTextareaForBlock(m.blocks[m.active], m.width)
+			m.cursorCmd = newTA.Focus()
+			m.textareas[m.active] = newTA
+			return
+		}
+
+		lines := strings.Split(content, "\n")
+		cursorLine := ta.Line()
+		isLastLine := cursorLine >= len(lines)-1
+		currentLineEmpty := cursorLine < len(lines) && lines[cursorLine] == ""
+
+		if isLastLine && currentLineEmpty && len(lines) > 1 {
+			// Empty definition line: trim it and exit to paragraph.
+			trimmed := strings.Join(lines[:len(lines)-1], "\n")
+			ta.SetValue(trimmed)
+			m.blocks[m.active].Content = trimmed
+			m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount())
+			m.insertBlockAfter(m.active, block.Block{Type: block.Paragraph})
+			return
+		}
+
+		// Otherwise insert a newline within the block (term→def, or new def line).
+		m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount() + 1)
+		m.textareas[m.active], _ = m.textareas[m.active].Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+		m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount())
+		return
+	}
+
 	// Code block / Quote: Enter inserts a newline within the block.
 	// On an empty last line, exit the block by trimming the empty line
 	// and inserting a new paragraph below.
@@ -901,6 +939,21 @@ func (m *Model) handleBackspace() bool {
 		return true
 	}
 
+	// Definition list at position 0: convert to paragraph (keep content).
+	if bt == block.DefinitionList {
+		m.pushUndo()
+		// Take only the term line as paragraph content.
+		term, _ := block.ExtractDefinition(content)
+		m.blocks[m.active].Type = block.Paragraph
+		m.blocks[m.active].Content = term
+		newTA := newTextareaForBlock(m.blocks[m.active], m.width)
+		newTA.SetValue(term)
+		m.cursorCmd = newTA.Focus()
+		newTA.SetCursorColumn(0)
+		m.textareas[m.active] = newTA
+		return true
+	}
+
 	if content == "" {
 		// Empty block: delete it, focus previous.
 		if m.active == 0 {
@@ -928,8 +981,8 @@ func (m *Model) handleBackspace() bool {
 		return true
 	}
 
-	// Don't merge content into code blocks or quote blocks.
-	if m.blocks[m.active-1].Type == block.CodeBlock || m.blocks[m.active-1].Type == block.Quote {
+	// Don't merge content into code blocks, quote blocks, or definition lists.
+	if m.blocks[m.active-1].Type == block.CodeBlock || m.blocks[m.active-1].Type == block.Quote || m.blocks[m.active-1].Type == block.DefinitionList {
 		return false
 	}
 
@@ -989,6 +1042,13 @@ func (m *Model) applyPaletteSelection(bt block.BlockType) {
 	// from the title into the code area immediately.
 	if bt == block.CodeBlock && !strings.Contains(m.textareas[m.active].Value(), "\n") {
 		m.textareas[m.active].SetValue(m.textareas[m.active].Value() + "\n")
+		m.cursorCmd = m.textareas[m.active].Focus()
+	}
+	// Ensure new definition list blocks have term\ndefinition structure.
+	// Place cursor on the term line so the user types the term first.
+	if bt == block.DefinitionList && !strings.Contains(m.textareas[m.active].Value(), "\n") {
+		m.textareas[m.active].SetValue(m.textareas[m.active].Value() + "\n")
+		m.textareas[m.active].MoveToBegin()
 		m.cursorCmd = m.textareas[m.active].Focus()
 	}
 	m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount())
@@ -1213,6 +1273,59 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
+		// When definition lookup is visible, intercept all keys.
+		if m.defLookup.visible {
+			switch msg.String() {
+			case "up":
+				m.defLookup.moveUp()
+				m.updateViewport()
+				return m, nil
+			case "down":
+				m.defLookup.moveDown()
+				m.updateViewport()
+				return m, nil
+			case "enter":
+				if sel := m.defLookup.selected(); sel != nil {
+					if m.viewMode {
+						// Scroll to the block in view mode.
+						m.active = sel.BlockIdx
+						if sel.BlockIdx < len(m.blockLineOffsets) {
+							m.viewport.SetYOffset(m.blockLineOffsets[sel.BlockIdx])
+						}
+					} else {
+						m.focusBlock(sel.BlockIdx)
+					}
+				}
+				m.defLookup.close()
+				m.updateViewport()
+				return m, nil
+			case "esc":
+				m.defLookup.close()
+				m.updateViewport()
+				return m, nil
+			case "backspace":
+				if !m.defLookup.deleteFilterRune() {
+					m.defLookup.close()
+				}
+				m.updateViewport()
+				return m, nil
+			default:
+				if msg.Code == ':' {
+					m.defLookup.close()
+					m.updateViewport()
+					return m, nil
+				}
+				if len(msg.Text) > 0 {
+					for _, r := range msg.Text {
+						m.defLookup.addFilterRune(r)
+					}
+					m.updateViewport()
+					return m, nil
+				}
+			}
+			return m, nil
+		}
+
 		// Clear transient status on any keypress.
 		if m.statusStyle == statusSuccess {
 			m.status = ""
@@ -1284,6 +1397,12 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "pgdown":
 				m.viewport.HalfPageDown()
 				return m, nil
+			default:
+				if msg.Code == ':' {
+					m.defLookup.open(m.blocks)
+					m.updateViewport()
+					return m, nil
+				}
 			}
 			// Swallow everything else in view mode.
 			return m, nil
@@ -1352,16 +1471,13 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 
 		case "up":
-			if m.isAtFirstLine() && m.active == 0 {
-				bt := m.blocks[0].Type
-				if bt == block.CodeBlock || bt == block.Quote || bt == block.Divider {
-					// These types don't split on Enter, so there's no other
-					// way to insert content above them. Create a paragraph.
-					m.pushUndo()
-					m.insertBlockBefore(0, block.Block{Type: block.Paragraph})
-					m.updateViewport()
-					return m, nil
-				}
+			if m.isAtFirstLine() && m.active == 0 && m.blocks[0].Type != block.Paragraph {
+				// First block isn't a paragraph — pressing up inserts one
+				// above so there's always a way to add content before it.
+				m.pushUndo()
+				m.insertBlockBefore(0, block.Block{Type: block.Paragraph})
+				m.updateViewport()
+				return m, nil
 			}
 			if m.isAtFirstLine() && m.active > 0 {
 				m.navigateUp()
@@ -1422,8 +1538,7 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			info := ta.LineInfo()
 			logicalCol := info.StartColumn + info.ColumnOffset
 			if logicalCol > 0 {
-				// Let the textarea's built-in DeleteBeforeCursor handle it.
-				// It operates on internal state without resetting cursor position.
+				m.pushUndo()
 				m.textareas[m.active], _ = m.textareas[m.active].Update(msg)
 				m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount())
 				m.updateViewport()
@@ -1498,6 +1613,16 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 
+			// Handle ":" at position 0 of an empty block to open definition lookup.
+			if keyMsg.Code == ':' && len(keyMsg.Text) > 0 {
+				ta := &m.textareas[m.active]
+				if ta.Line() == 0 && ta.LineInfo().ColumnOffset == 0 && ta.Value() == "" {
+					m.defLookup.open(m.blocks)
+					m.updateViewport()
+					return m, nil
+				}
+			}
+
 			// Handle Enter key: always split/create via handleEnter.
 			if keyMsg.Code == tea.KeyEnter {
 				m.pushUndo()
@@ -1511,6 +1636,21 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.handleBackspace() {
 					m.updateViewport()
 					return m, nil
+				}
+				// Definition block: prevent deleting the term/definition
+				// separator newline. Backspace at line 1 col 0 → jump to term.
+				if m.blocks[m.active].Type == block.DefinitionList {
+					ta := &m.textareas[m.active]
+					info := ta.LineInfo()
+					// Only intercept at the true start of raw line 1
+					// (not a wrapped continuation where StartColumn > 0).
+					if ta.Line() == 1 && info.ColumnOffset == 0 && info.StartColumn == 0 {
+						ta.MoveToBegin()
+						ta.CursorEnd()
+						m.cursorCmd = ta.Focus()
+						m.updateViewport()
+						return m, nil
+					}
 				}
 			}
 
@@ -1581,6 +1721,26 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
+		// Word/line deletes should get their own undo entry rather than
+		// being silently batched with prior character-level typing.
+		if keyMsg, ok := msg.(tea.KeyPressMsg); ok && m.undoDirty {
+			isWordOrLineDelete := false
+			switch {
+			case keyMsg.Code == tea.KeyBackspace && keyMsg.Mod.Contains(tea.ModAlt):
+				isWordOrLineDelete = true
+			case keyMsg.Code == tea.KeyDelete && keyMsg.Mod.Contains(tea.ModAlt):
+				isWordOrLineDelete = true
+			case keyMsg.Code == 'd' && keyMsg.Mod.Contains(tea.ModAlt):
+				isWordOrLineDelete = true
+			}
+			if isWordOrLineDelete {
+				m.pushUndo()
+				// Keep undoDirty true so the generic handler below
+				// doesn't capture a second undo entry for this same action.
+				m.undoDirty = true
+			}
+		}
+
 		// Capture state before the textarea processes the keystroke so we
 		// can detect whether content actually changed (vs. cursor movement).
 		var preState editorState
@@ -1597,6 +1757,18 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.undo.push(preState)
 			m.redo.clear()
 			m.undoDirty = true
+		}
+
+		// Definition block guard: if a delete operation destroyed the
+		// term/definition newline separator, restore it.
+		if m.blocks[m.active].Type == block.DefinitionList {
+			val := m.textareas[m.active].Value()
+			if !strings.Contains(val, "\n") {
+				m.textareas[m.active].SetValue(val + "\n")
+				m.textareas[m.active].MoveToBegin()
+				m.textareas[m.active].CursorEnd()
+				m.cursorCmd = m.textareas[m.active].Focus()
+			}
 		}
 
 		// Re-enforce width and recalculate height after every keystroke.
@@ -1619,6 +1791,9 @@ func (m *Model) updateViewport() {
 	// wrapping which may change as content is modified (e.g. "[modified]"
 	// indicator).
 	h := m.height - m.headerHeight() - m.statusBarHeight()
+	if m.defLookup.visible {
+		h -= m.defLookup.height()
+	}
 	if h < 1 {
 		h = 1
 	}
@@ -1919,11 +2094,21 @@ func (m Model) View() tea.View {
 		content = m.renderHelpOverlay()
 	} else if m.viewMode {
 		statusBar := m.renderStatusBar()
-		content = m.viewport.View() + "\n" + statusBar
+		if m.defLookup.visible {
+			modal := m.defLookup.render(m.width)
+			content = m.viewport.View() + "\n" + modal + "\n" + statusBar
+		} else {
+			content = m.viewport.View() + "\n" + statusBar
+		}
 	} else {
 		header := m.renderHeader()
 		statusBar := m.renderStatusBar()
-		content = header + "\n" + m.viewport.View() + "\n" + statusBar
+		if m.defLookup.visible {
+			modal := m.defLookup.render(m.width)
+			content = header + "\n" + m.viewport.View() + "\n" + modal + "\n" + statusBar
+		} else {
+			content = header + "\n" + m.viewport.View() + "\n" + statusBar
+		}
 	}
 
 	v := tea.NewView(content)
@@ -1963,6 +2148,8 @@ func (m Model) renderHelpOverlay() string {
 	help.WriteString("  ⌃Z" + s + "⌃Y        Undo " + s + " redo\n")
 	help.WriteString("  ⌥↑" + s + "⌥↓        Move block\n")
 	help.WriteString("  /            Block type\n")
+	help.WriteString("\n")
+	help.WriteString("  :            Definitions\n")
 	help.WriteString("\n")
 	help.WriteString("  ⌃R           View mode\n")
 	help.WriteString("  ⌃X           Checkbox\n")
@@ -2008,9 +2195,9 @@ func (m Model) renderStatusBar() string {
 		if !m.dismissedHints["editor.checkbox"] {
 			hint = "click checkboxes to toggle!  [h]ide"
 		}
-		right = "\u2303R edit \u00B7 Esc quit"
+		right = ": defs \u00B7 \u2303R edit \u00B7 Esc quit"
 	} else {
-		right = "/ blocks \u00B7 \u2303G help \u00B7 Esc quit"
+		right = "/ blocks \u00B7 : defs \u00B7 \u2303G help \u00B7 Esc quit"
 	}
 
 	bar := format.StatusBar(left, hint, right, width)

--- a/internal/editor/palette.go
+++ b/internal/editor/palette.go
@@ -39,6 +39,7 @@ func defaultPaletteItems() []paletteItem {
 		{Icon: "\u2610", Label: "Checklist", Type: block.Checklist},
 		{Icon: "``", Label: "Code Block", Type: block.CodeBlock},
 		{Icon: ">", Label: "Quote", Type: block.Quote},
+		{Icon: ":", Label: "Definition", Type: block.DefinitionList},
 		{Icon: "\u2014", Label: "Divider", Type: block.Divider},
 	}
 }

--- a/internal/editor/palette_test.go
+++ b/internal/editor/palette_test.go
@@ -138,16 +138,17 @@ func TestPaletteContainsAllBlockTypes(t *testing.T) {
 	items := defaultPaletteItems()
 
 	expectedTypes := map[block.BlockType]bool{
-		block.Paragraph:    true,
-		block.Heading1:     true,
-		block.Heading2:     true,
-		block.Heading3:     true,
-		block.BulletList:   true,
-		block.NumberedList: true,
-		block.Checklist:    true,
-		block.CodeBlock:    true,
-		block.Quote:        true,
-		block.Divider:      true,
+		block.Paragraph:      true,
+		block.Heading1:       true,
+		block.Heading2:       true,
+		block.Heading3:       true,
+		block.BulletList:     true,
+		block.NumberedList:   true,
+		block.Checklist:      true,
+		block.CodeBlock:      true,
+		block.Quote:          true,
+		block.Divider:        true,
+		block.DefinitionList: true,
 	}
 
 	for _, item := range items {

--- a/internal/editor/render.go
+++ b/internal/editor/render.go
@@ -312,6 +312,71 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 		}
 		rendered = strings.Join(lines, "\n")
 
+	case block.DefinitionList:
+		bs := th.Blocks.Definition
+		markerColor := resolveColor(bs.MarkerColor, th.Muted)
+		marker := lipgloss.NewStyle().Foreground(lipgloss.Color(markerColor)).Render(bs.Marker)
+		markerIndent := strings.Repeat(" ", lipgloss.Width(marker))
+		faint := lipgloss.NewStyle().Faint(true)
+		rawLines := strings.Split(ta.Value(), "\n")
+		lines := strings.Split(taView, "\n")
+
+		// Build a map: for each raw line, how many visual lines it occupies.
+		// Visual line index → (rawLineIdx, isFirstVisualLine).
+		type visInfo struct {
+			rawIdx  int
+			isFirst bool
+		}
+		visMap := make([]visInfo, len(lines))
+		visIdx := 0
+		for ri, raw := range rawLines {
+			nVis := 1
+			if m.wordWrap {
+				segs := textarea.Wrap([]rune(raw), contentWidth)
+				if len(segs) > 0 {
+					nVis = len(segs)
+				}
+			}
+			for v := 0; v < nVis && visIdx < len(lines); v++ {
+				visMap[visIdx] = visInfo{rawIdx: ri, isFirst: v == 0}
+				visIdx++
+			}
+		}
+
+		cursorFg := lipgloss.Color(th.Accent)
+		cursorStyle := lipgloss.NewStyle().Foreground(cursorFg).Reverse(true)
+
+		for i, l := range lines {
+			vi := visMap[i]
+			if vi.rawIdx == 0 {
+				// Term line: no prefix, just bold + placeholder.
+				if rawLines[0] == "" && vi.isFirst {
+					if cursorVisIdx == i {
+						lines[i] = cursorStyle.Render(" ") + faint.Render("Term")
+					} else {
+						lines[i] = faint.Render("Term")
+					}
+				} else if bs.TermBold {
+					lines[i] = styleAroundCursor(l, lipgloss.NewStyle().Bold(true), cursorByteOffset, cursorLen, cursorVisIdx-i)
+				}
+			} else if vi.isFirst {
+				// First visual line of a definition: marker prefix.
+				if rawLines[vi.rawIdx] == "" {
+					if cursorVisIdx == i {
+						lines[i] = marker + cursorStyle.Render(" ") + faint.Render("Definition")
+					} else {
+						lines[i] = marker + faint.Render("Definition")
+					}
+				} else {
+					lines[i] = marker + l
+				}
+			} else {
+				// Wrapped continuation: indent to match marker width.
+				lines[i] = markerIndent + l
+			}
+		}
+		rendered = strings.Join(lines, "\n")
+
 	default:
 		rendered = taView
 	}
@@ -672,6 +737,43 @@ func renderInactiveBlock(b block.Block, content string, width int, wordWrap bool
 		}
 		rendered = lipgloss.NewStyle().Foreground(lipgloss.Color(divColor)).Render(divLine)
 
+	case block.DefinitionList:
+		bs := th.Blocks.Definition
+		markerColor := resolveColor(bs.MarkerColor, th.Muted)
+		marker := lipgloss.NewStyle().Foreground(lipgloss.Color(markerColor)).Render(bs.Marker)
+		markerIndent := strings.Repeat(" ", lipgloss.Width(marker))
+		term, def := block.ExtractDefinition(content)
+		termWrapped := term
+		if wordWrap {
+			// Term has no marker prefix; contentWidth already subtracts
+			// blockPrefixWidth (marker), so term wraps at the same width
+			// as the textarea in active mode.
+			termWrapped = wrapText(term, contentWidth)
+		}
+		termWrapped = format.RenderInlineMarkdown(termWrapped)
+		if bs.TermBold {
+			termWrapped = lipgloss.NewStyle().Bold(true).Render(termWrapped)
+		}
+		// Definition lines wrap at contentWidth — the marker is rendered
+		// within the prefix space already reserved by blockPrefixWidth.
+		// Do NOT subtract marker width again.
+		var defOutput []string
+		for _, rawDef := range strings.Split(def, "\n") {
+			dw := rawDef
+			if wordWrap {
+				dw = wrapText(rawDef, contentWidth)
+			}
+			dw = format.RenderInlineMarkdown(dw)
+			for j, vl := range strings.Split(dw, "\n") {
+				if j == 0 {
+					defOutput = append(defOutput, marker+vl)
+				} else {
+					defOutput = append(defOutput, markerIndent+vl)
+				}
+			}
+		}
+		rendered = termWrapped + "\n" + strings.Join(defOutput, "\n")
+
 	default:
 		rendered = wrapped
 	}
@@ -816,6 +918,32 @@ func renderViewBlock(b block.Block, content string, width int, wordWrap bool, bl
 			divLine = string(runes[:width])
 		}
 		rendered = lipgloss.NewStyle().Foreground(lipgloss.Color(divColor)).Render(divLine)
+
+	case block.DefinitionList:
+		bs := th.Blocks.Definition
+		markerColor := resolveColor(bs.MarkerColor, th.Muted)
+		marker := lipgloss.NewStyle().Foreground(lipgloss.Color(markerColor)).Render(bs.Marker)
+		markerIndent := strings.Repeat(" ", lipgloss.Width(marker))
+		term, def := block.ExtractDefinition(content)
+		termWrapped := wrapText(term, contentWidth)
+		termWrapped = format.RenderInlineMarkdown(termWrapped)
+		if bs.TermBold {
+			termWrapped = lipgloss.NewStyle().Bold(true).Render(termWrapped)
+		}
+		// contentWidth already has marker space reserved via blockPrefixWidth.
+		var defOutput []string
+		for _, rawDef := range strings.Split(def, "\n") {
+			dw := wrapText(rawDef, contentWidth)
+			dw = format.RenderInlineMarkdown(dw)
+			for j, vl := range strings.Split(dw, "\n") {
+				if j == 0 {
+					defOutput = append(defOutput, marker+vl)
+				} else {
+					defOutput = append(defOutput, markerIndent+vl)
+				}
+			}
+		}
+		rendered = termWrapped + "\n" + strings.Join(defOutput, "\n")
 
 	default:
 		rendered = wrapped

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -91,17 +91,25 @@ type DividerStyle struct {
 	Color    string // hex; "" means theme.Accent (active) / theme.Muted (inactive)
 }
 
+// DefinitionStyle controls definition list rendering.
+type DefinitionStyle struct {
+	Marker      string // prefix before definition, e.g. "  : "
+	MarkerColor string // hex; "" means theme.Muted
+	TermBold    bool   // whether to bold the term
+}
+
 // BlockStyles groups all per-block-type formatting.
 type BlockStyles struct {
-	Heading1  HeadingStyle
-	Heading2  HeadingStyle
-	Heading3  HeadingStyle
-	Bullet    ListStyle
-	Numbered  NumberedStyle
-	Checklist ChecklistStyle
-	Code      CodeStyle
-	Quote     QuoteStyle
-	Divider   DividerStyle
+	Heading1   HeadingStyle
+	Heading2   HeadingStyle
+	Heading3   HeadingStyle
+	Bullet     ListStyle
+	Numbered   NumberedStyle
+	Checklist  ChecklistStyle
+	Code       CodeStyle
+	Quote      QuoteStyle
+	Divider    DividerStyle
+	Definition DefinitionStyle
 }
 
 // DefaultBlockStyles returns the baseline block styles that match the original
@@ -121,9 +129,10 @@ func DefaultBlockStyles() BlockStyles {
 			CheckedBold:      true,
 			CheckedTextFaint: true,
 		},
-		Code:    CodeStyle{LabelAlign: "left"},
-		Quote:   QuoteStyle{Bar: "\u2502 "},
-		Divider: DividerStyle{Char: "\u2500", MaxWidth: 40},
+		Code:       CodeStyle{LabelAlign: "left"},
+		Quote:      QuoteStyle{Bar: "\u2502 "},
+		Divider:    DividerStyle{Char: "\u2500", MaxWidth: 40},
+		Definition: DefinitionStyle{Marker: "  : ", TermBold: true},
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Definition block type** — term + multiple `: definition` lines, parsed from and serialized to standard definition list markdown
- **":" lookup palette** — footer modal for searching definitions by term, works in both edit and view mode, shows results only after typing
- **Enter flow** — term → Enter → definition line → Enter → new definition → Enter on empty → exit to paragraph
- **Rendering** — bold term, `: ` marker on each definition line, faint "Term"/"Definition" placeholders, proper word-wrap (marker on first visual line only, indent on continuations)
- **Guards** — backspace at line 1 col 0 jumps to term, post-keystroke guard restores separator if any delete crosses it
- **Undo fixes** — ctrl+u and opt+delete now create proper undo entries instead of being silently batched
- **Generic fix** — up arrow at first block inserts paragraph above for ALL non-paragraph types (was hardcoded to code/quote/divider)

## Test plan

- [ ] Create definition via `/` → Definition
- [ ] Type term, Enter, type definition, Enter, type second definition, Enter, Enter → exits to paragraph
- [ ] Verify `: ` marker on each definition line, bold term, placeholders when empty
- [ ] Long definition text wraps correctly — `: ` only on first visual line
- [ ] Backspace at start of definition line jumps to term (doesn't delete separator)
- [ ] cmd+delete / opt+delete can't destroy the separator
- [ ] Press `:` in view mode or empty block in edit mode → lookup palette opens
- [ ] Type to filter, arrow keys, Enter to jump, Esc or `:` to close
- [ ] Undo/redo works for opt+delete and ctrl+u
- [ ] Up arrow at first block (any type) inserts paragraph above
- [ ] Parse/serialize round-trip: save and reopen preserves definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)