### PR TITLE
feat: embed block type for cross-referencing notes (Closes #190)

### DIFF
--- a/cmd/dispatcher.go
+++ b/cmd/dispatcher.go
@@ -215,6 +215,49 @@ func editNote(w io.Writer, book, note string) error {
 			recents.RecordStore(book, note)
 			return nil
 		},
+		ResolveEmbed: func(path string) (string, string, error) {
+			parts := strings.SplitN(path, "/", 2)
+			var nb, nt string
+			if len(parts) == 2 {
+				nb, nt = parts[0], parts[1]
+			} else {
+				// No slash — assume current notebook.
+				nb, nt = book, parts[0]
+			}
+			ref, err := store.GetNote(nb, nt)
+			if err != nil {
+				return "", "", err
+			}
+			title := storage.DisplayName(ref.Notebook) + " \u203A " + storage.DisplayName(ref.Name)
+			return title, ref.Content, nil
+		},
+		SaveEmbed: func(path, content string) error {
+			parts := strings.SplitN(path, "/", 2)
+			var nb, nt string
+			if len(parts) == 2 {
+				nb, nt = parts[0], parts[1]
+			} else {
+				nb, nt = book, parts[0]
+			}
+			return store.UpdateNote(nb, nt, content)
+		},
+		ListEmbedTargets: func() []string {
+			notebooks, err := store.ListNotebooks()
+			if err != nil {
+				return nil
+			}
+			var targets []string
+			for _, nb := range notebooks {
+				notes, err := store.ListNotes(nb)
+				if err != nil {
+					continue
+				}
+				for _, n := range notes {
+					targets = append(targets, nb+"/"+n.Name)
+				}
+			}
+			return targets
+		},
 		DismissedHints: config.LoadDismissedHints(),
 		HideChecked: cfg.HideChecked,
 		CascadeChecks: cfg.CascadeChecks,

--- a/internal/block/block.go
+++ b/internal/block/block.go
@@ -22,6 +22,7 @@ const (
 	CodeBlock                     // fenced code block (``` ... ```)
 	Quote                         // > block quote
 	Divider                       // ---, ***, or ___
+	Embed                         // ![[path]] embedded note reference
 )
 
 // String returns the human-readable name of a BlockType.
@@ -47,6 +48,8 @@ func (bt BlockType) String() string {
 		return "Quote"
 	case Divider:
 		return "Divider"
+	case Embed:
+		return "Embed"
 	default:
 		return "Unknown"
 	}
@@ -85,6 +88,8 @@ func (bt BlockType) Short() string {
 		return "qt"
 	case Divider:
 		return "hr"
+	case Embed:
+		return "em"
 	default:
 		return "?"
 	}

--- a/internal/block/parse.go
+++ b/internal/block/parse.go
@@ -149,6 +149,14 @@ func Parse(markdown string) []Block {
 			continue
 		}
 
+		// --- Embed (![[path]]) ---
+		if strings.HasPrefix(line, "![[") && strings.HasSuffix(line, "]]") {
+			path := line[3 : len(line)-2]
+			blocks = append(blocks, Block{Type: Embed, Content: path})
+			i++
+			continue
+		}
+
 		// --- Paragraph (merge consecutive non-special lines) ---
 		var paraLines []string
 		for i < len(lines) {
@@ -187,6 +195,9 @@ func isBlockStart(line string) bool {
 		return true
 	}
 	if _, _, ok := parseNumberedItem(stripped); ok {
+		return true
+	}
+	if strings.HasPrefix(line, "![[") && strings.HasSuffix(line, "]]") {
 		return true
 	}
 	return isDivider(line)

--- a/internal/block/parse_test.go
+++ b/internal/block/parse_test.go
@@ -221,6 +221,31 @@ func TestParse(t *testing.T) {
 				{Type: CodeBlock, Content: "go\nfunc main() {}\nmore code"},
 			},
 		},
+		{
+			name:  "embed block",
+			input: "![[notebook/note]]",
+			expect: []Block{
+				{Type: Embed, Content: "notebook/note"},
+			},
+		},
+		{
+			name:  "embed in mixed content",
+			input: "# Title\n\n![[notebook/note]]\n\nSome text.",
+			expect: []Block{
+				{Type: Heading1, Content: "Title"},
+				{Type: Paragraph, Content: ""},
+				{Type: Embed, Content: "notebook/note"},
+				{Type: Paragraph, Content: ""},
+				{Type: Paragraph, Content: "Some text."},
+			},
+		},
+		{
+			name:  "embed with spaces in path",
+			input: "![[my notebook/my note]]",
+			expect: []Block{
+				{Type: Embed, Content: "my notebook/my note"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -274,6 +299,8 @@ func formatBlocks(blocks []Block) string {
 			b.WriteString("Quote")
 		case Divider:
 			b.WriteString("Divider")
+		case Embed:
+			b.WriteString("Embed")
 		}
 		if bl.Content != "" {
 			b.WriteString(" " + bl.Content)

--- a/internal/block/serialize.go
+++ b/internal/block/serialize.go
@@ -77,6 +77,9 @@ func Serialize(blocks []Block) string {
 		case Divider:
 			lines = append(lines, "---")
 
+		case Embed:
+			lines = append(lines, "![["+b.Content+"]]")
+
 		default:
 			if b.Content != "" {
 				lines = append(lines, strings.Split(b.Content, "\n")...)

--- a/internal/block/serialize_test.go
+++ b/internal/block/serialize_test.go
@@ -129,6 +129,18 @@ func TestSerializeRoundTrip(t *testing.T) {
 			name: "divider between paragraphs",
 			md:   "above\n\n---\n\nbelow",
 		},
+		{
+			name: "embed block",
+			md:   "![[notebook/note]]",
+		},
+		{
+			name: "embed with spaces",
+			md:   "![[my notebook/my note]]",
+		},
+		{
+			name: "embed between paragraphs",
+			md:   "text\n\n![[ref]]\n\nmore text",
+		},
 	}
 
 	for _, tt := range tests {
@@ -155,6 +167,8 @@ func TestSerializeIdempotent(t *testing.T) {
 		"> quote\n> continues",
 		"---",
 		"# Title\n\nSome intro text.\n\n## Section\n\n- bullet one\n- bullet two\n\n1. step one\n2. step two\n\n> a quote\n\n---\n\n```go\nfunc main() {}\n```\n\n- [ ] task\n- [x] done",
+		"![[notebook/note]]",
+		"text\n\n![[ref]]\n\nmore text",
 	}
 
 	for _, md := range inputs {

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -37,6 +37,14 @@ type Config struct {
 	CascadeChecks *bool
 	// WordWrap from config; nil = default (true).
 	WordWrap *bool
+	// ResolveEmbed resolves an embed path (e.g. "notebook/note") to its title
+	// and content. Returns an error if the note doesn't exist.
+	ResolveEmbed func(path string) (title, content string, err error)
+	// SaveEmbed saves modified content back to an embedded note.
+	SaveEmbed func(path, content string) error
+	// ListEmbedTargets returns all available "notebook/note" paths for the
+	// embed picker. Called when the picker opens.
+	ListEmbedTargets func() []string
 }
 
 // savedMsg is sent after a successful save.
@@ -87,6 +95,8 @@ type Model struct {
 	undoDirty   bool            // true when textarea content changed since last snapshot
 	sortChecked   bool // sort checked checklist items to bottom of each group
 	cascadeChecks bool // checking parent also checks/unchecks children
+	embedModal    embedModalState // overlay for viewing embedded note references
+	embedPicker   embedPicker     // note picker for embed block insertion
 }
 
 type statusKind int
@@ -97,6 +107,60 @@ const (
 	statusError
 	statusWarning
 )
+
+// embedModalState holds the state for the embedded note bottom sheet.
+type embedModalState struct {
+	visible          bool
+	title            string         // display title for the sheet header
+	path             string         // original embed path for save-back
+	blocks           []block.Block  // parsed blocks of the referenced note
+	scroll           int            // scroll offset (line index)
+	lines            []string       // pre-split rendered lines
+	blockLineOffsets []int          // starting line of each block within lines
+	hoverBlock       int            // block under mouse cursor (-1 = none)
+	sheetStartY      int            // Y line where the sheet content begins
+}
+
+// open prepares the sheet with parsed blocks and resets state.
+func (e *embedModalState) open(title, path string, blocks []block.Block) {
+	e.visible = true
+	e.title = title
+	e.path = path
+	e.blocks = blocks
+	e.scroll = 0
+	e.hoverBlock = -1
+	// Layout: line 0=context, 1=blank, 2=sep → sheet starts at Y=2.
+	e.sheetStartY = 2
+	// lines and blockLineOffsets are populated by renderEmbedSheetContent.
+}
+
+// close hides the sheet.
+func (e *embedModalState) close() {
+	e.visible = false
+	e.title = ""
+	e.path = ""
+	e.blocks = nil
+	e.lines = nil
+	e.blockLineOffsets = nil
+	e.scroll = 0
+	e.hoverBlock = -1
+}
+
+// blockAtLine returns the block index containing the given line, or -1.
+func (e *embedModalState) blockAtLine(line int) int {
+	if len(e.blockLineOffsets) == 0 {
+		return -1
+	}
+	result := -1
+	for i, offset := range e.blockLineOffsets {
+		if offset <= line {
+			result = i
+		} else {
+			break
+		}
+	}
+	return result
+}
 
 // defaultWidth and defaultHeight are sensible initial dimensions so the
 // cursor is visible even before the first WindowSizeMsg arrives.
@@ -131,6 +195,12 @@ func blockPrefixWidth(bt block.BlockType, indent int) int {
 		base = lipgloss.Width(th.Blocks.Quote.Bar)
 	case block.CodeBlock:
 		base = 4
+	case block.Embed:
+		icon := th.Blocks.Embed.Icon
+		if icon == "" {
+			icon = "\u2197 "
+		}
+		base = lipgloss.Width(icon)
 	}
 	return indent*4 + base
 }
@@ -991,6 +1061,13 @@ func (m *Model) applyPaletteSelection(bt block.BlockType) {
 		m.textareas[m.active].SetValue(m.textareas[m.active].Value() + "\n")
 		m.cursorCmd = m.textareas[m.active].Focus()
 	}
+	// Open the note picker for embed blocks so the user can browse targets.
+	if bt == block.Embed && m.config.ListEmbedTargets != nil {
+		targets := m.config.ListEmbedTargets()
+		if len(targets) > 0 {
+			m.embedPicker.open(targets)
+		}
+	}
 	m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount())
 }
 
@@ -1048,18 +1125,54 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.MouseMotionMsg:
+		if m.embedModal.visible {
+			contentStartY := m.embedModal.sheetStartY + 2
+			if msg.Y >= contentStartY {
+				contentLine := m.embedModal.scroll + (msg.Y - contentStartY)
+				idx := m.embedModal.blockAtLine(contentLine)
+				old := m.embedModal.hoverBlock
+				m.embedModal.hoverBlock = idx
+				if idx != old {
+					// Re-render for hover feedback on interactive blocks.
+					needsUpdate := false
+					for _, checkIdx := range []int{idx, old} {
+						if checkIdx >= 0 && checkIdx < len(m.embedModal.blocks) {
+							bt := m.embedModal.blocks[checkIdx].Type
+							if bt == block.Checklist || bt == block.Embed {
+								needsUpdate = true
+								break
+							}
+						}
+					}
+					if needsUpdate {
+						m.renderEmbedSheetContent()
+					}
+				}
+			} else {
+				m.embedModal.hoverBlock = -1
+			}
+			return m, nil
+		}
 		if m.viewMode {
-			// Track hover state for checklist visual feedback.
+			// Track hover state for checklist/embed visual feedback.
 			hoverY := m.viewport.YOffset() + msg.Y
 			idx := m.blockIndexAtLine(hoverY)
 			oldHover := m.hoverBlock
 			m.hoverBlock = idx
 
-			// Re-render if hovering over a different checklist block.
+			// Re-render if hovering over a different interactive block.
 			if idx != oldHover {
-				isChecklistHover := idx >= 0 && idx < len(m.blocks) && m.blocks[idx].Type == block.Checklist
-				wasChecklistHover := oldHover >= 0 && oldHover < len(m.blocks) && m.blocks[oldHover].Type == block.Checklist
-				if isChecklistHover || wasChecklistHover {
+				needsUpdate := false
+				for _, checkIdx := range []int{idx, oldHover} {
+					if checkIdx >= 0 && checkIdx < len(m.blocks) {
+						bt := m.blocks[checkIdx].Type
+						if bt == block.Checklist || bt == block.Embed {
+							needsUpdate = true
+							break
+						}
+					}
+				}
+				if needsUpdate {
 					m.updateViewport()
 				}
 			}
@@ -1069,15 +1182,42 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.MouseClickMsg:
+		if m.embedModal.visible {
+			// Click above the sheet (context area) dismisses it.
+			if msg.Y < m.embedModal.sheetStartY {
+				m.embedModal.close()
+				m.updateViewport()
+				return m, nil
+			}
+			// Map click Y to a content line, accounting for scroll and sheet header.
+			// Sheet layout: sheetStartY=sep, +1=title, +2..=content
+			contentStartY := m.embedModal.sheetStartY + 2
+			if msg.Button == tea.MouseLeft && msg.Y >= contentStartY {
+				contentLine := m.embedModal.scroll + (msg.Y - contentStartY)
+				idx := m.embedModal.blockAtLine(contentLine)
+				if idx >= 0 && idx < len(m.embedModal.blocks) {
+					if m.embedModal.blocks[idx].Type == block.Checklist {
+						m.embedModal.blocks[idx].Checked = !m.embedModal.blocks[idx].Checked
+						// Save changes back to the referenced note.
+						if m.config.SaveEmbed != nil {
+							content := block.Serialize(m.embedModal.blocks)
+							_ = m.config.SaveEmbed(m.embedModal.path, content)
+						}
+						m.renderEmbedSheetContent()
+					}
+				}
+			}
+			return m, nil
+		}
 		if m.viewMode {
 			// Track hover state for checklist visual feedback.
 			hoverY := m.viewport.YOffset() + msg.Y
 			idx := m.blockIndexAtLine(hoverY)
 			m.hoverBlock = idx
 
-			// Left-click on a checklist block toggles its checked state.
-			if msg.Button == tea.MouseLeft {
-				if idx >= 0 && idx < len(m.blocks) && m.blocks[idx].Type == block.Checklist {
+			if msg.Button == tea.MouseLeft && idx >= 0 && idx < len(m.blocks) {
+				// Left-click on a checklist block toggles its checked state.
+				if m.blocks[idx].Type == block.Checklist {
 					m.pushUndo()
 					if idx < len(m.textareas) {
 						m.blocks[idx].Content = m.textareas[idx].Value()
@@ -1089,6 +1229,11 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.updateViewport()
 					return m, nil
 				}
+				// Left-click on an embed block opens the referenced note.
+				if m.blocks[idx].Type == block.Embed {
+					m.openEmbedModal(idx)
+					return m, nil
+				}
 			}
 		} else {
 			m.hoverBlock = -1
@@ -1096,6 +1241,17 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.MouseWheelMsg:
+		if m.embedModal.visible {
+			// Scroll the embed modal content.
+			if msg.Button == tea.MouseWheelDown {
+				m.embedModal.scroll++
+			} else if msg.Button == tea.MouseWheelUp {
+				if m.embedModal.scroll > 0 {
+					m.embedModal.scroll--
+				}
+			}
+			return m, nil
+		}
 		// View mode captures mouse — forward wheel to viewport for scrolling.
 		if m.viewMode {
 			var cmd tea.Cmd
@@ -1213,10 +1369,84 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
+		// When embed picker is visible, intercept all keys.
+		if m.embedPicker.visible {
+			switch msg.String() {
+			case "up":
+				m.embedPicker.moveUp()
+				m.updateViewport()
+				return m, nil
+			case "down":
+				m.embedPicker.moveDown()
+				m.updateViewport()
+				return m, nil
+			case "enter":
+				if sel := m.embedPicker.selected(); sel != "" {
+					m.textareas[m.active].SetValue(sel)
+					m.cursorCmd = m.textareas[m.active].Focus()
+				}
+				m.embedPicker.close()
+				m.updateViewport()
+				return m, nil
+			case "esc":
+				m.embedPicker.close()
+				m.updateViewport()
+				return m, nil
+			case "backspace":
+				if !m.embedPicker.deleteFilterRune() {
+					m.embedPicker.close()
+				}
+				m.updateViewport()
+				return m, nil
+			default:
+				if len(msg.Text) > 0 {
+					for _, r := range msg.Text {
+						m.embedPicker.addFilterRune(r)
+					}
+					m.updateViewport()
+					return m, nil
+				}
+			}
+			return m, nil
+		}
+
 		// Clear transient status on any keypress.
 		if m.statusStyle == statusSuccess {
 			m.status = ""
 			m.statusStyle = statusNone
+		}
+
+		// Embed modal: intercept keys when overlay is showing.
+		if m.embedModal.visible {
+			switch msg.String() {
+			case "esc", "q":
+				m.embedModal.close()
+				m.updateViewport()
+			case "up", "k":
+				if m.embedModal.scroll > 0 {
+					m.embedModal.scroll--
+				}
+			case "down", "j":
+				m.embedModal.scroll++
+			case "pgup":
+				m.embedModal.scroll -= m.height / 2
+				if m.embedModal.scroll < 0 {
+					m.embedModal.scroll = 0
+				}
+			case "pgdown":
+				m.embedModal.scroll += m.height / 2
+			case "ctrl+c":
+				m.embedModal.close()
+				if m.modified() {
+					m.quitPrompt = true
+					m.status = "Save before quitting? [Y/n/Esc]"
+					m.statusStyle = statusWarning
+					return m, nil
+				}
+				m.quitting = true
+				return m, tea.Quit
+			}
+			return m, nil
 		}
 
 		// View mode: intercept keys early.
@@ -1498,6 +1728,18 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 
+			// On Embed blocks, Tab opens the note picker.
+			if keyMsg.Code == tea.KeyTab && m.blocks[m.active].Type == block.Embed {
+				if m.config.ListEmbedTargets != nil {
+					targets := m.config.ListEmbedTargets()
+					if len(targets) > 0 {
+						m.embedPicker.open(targets)
+						m.updateViewport()
+						return m, nil
+					}
+				}
+			}
+
 			// Handle Enter key: always split/create via handleEnter.
 			if keyMsg.Code == tea.KeyEnter {
 				m.pushUndo()
@@ -1769,6 +2011,10 @@ func (m *Model) computeBlockLineOffsets() {
 				}
 			case prev.Type == block.CodeBlock || prev.Type == block.Quote:
 				advance("")
+			case b.Type == block.Embed:
+				advance("")
+			case prev.Type == block.Embed:
+				advance("")
 			case b.Type == block.Divider:
 				advance("")
 			case prev.Type == block.Divider:
@@ -1818,6 +2064,12 @@ func (m *Model) renderAllBlocks() string {
 		parts = append(parts, rendered)
 		if m.palette.visible && i == m.active {
 			if pv := m.palette.render(m.width); pv != "" {
+				lineCount += strings.Count(pv, "\n") + 1
+				parts = append(parts, pv)
+			}
+		}
+		if m.embedPicker.visible && i == m.active {
+			if pv := m.embedPicker.render(m.width); pv != "" {
 				lineCount += strings.Count(pv, "\n") + 1
 				parts = append(parts, pv)
 			}
@@ -1886,6 +2138,10 @@ func (m Model) renderViewContent() string {
 				}
 			case prev.Type == block.CodeBlock || prev.Type == block.Quote:
 				parts = append(parts, "") // blank after code/quote blocks
+			case b.Type == block.Embed:
+				parts = append(parts, "") // blank before embeds
+			case prev.Type == block.Embed:
+				parts = append(parts, "") // blank after embeds
 			case b.Type == block.Divider:
 				parts = append(parts, "") // blank before dividers
 			case prev.Type == block.Divider:
@@ -1915,7 +2171,9 @@ func (m Model) View() tea.View {
 	}
 
 	var content string
-	if m.showHelp {
+	if m.embedModal.visible {
+		content = m.renderEmbedSheet()
+	} else if m.showHelp {
 		content = m.renderHelpOverlay()
 	} else if m.viewMode {
 		statusBar := m.renderStatusBar()
@@ -2028,4 +2286,183 @@ func (m Model) renderStatusBar() string {
 	}
 
 	return style.Render(bar)
+}
+
+// openEmbedModal resolves an embed block's reference and opens the sheet.
+func (m *Model) openEmbedModal(idx int) {
+	if idx < 0 || idx >= len(m.blocks) || m.blocks[idx].Type != block.Embed {
+		return
+	}
+	path := m.blocks[idx].Content
+	if idx < len(m.textareas) {
+		path = m.textareas[idx].Value()
+	}
+	if path == "" {
+		return
+	}
+
+	if m.config.ResolveEmbed == nil {
+		errBlocks := []block.Block{{Type: block.Paragraph, Content: "Embed links not available."}}
+		m.embedModal.open(path, path, errBlocks)
+		m.renderEmbedSheetContent()
+		return
+	}
+
+	title, content, err := m.config.ResolveEmbed(path)
+	if err != nil {
+		errBlocks := []block.Block{{Type: block.Paragraph, Content: "Note not found: " + path}}
+		m.embedModal.open(path, path, errBlocks)
+		m.renderEmbedSheetContent()
+		return
+	}
+
+	refBlocks := block.Parse(content)
+	m.embedModal.open(title, path, refBlocks)
+	m.renderEmbedSheetContent()
+}
+
+// renderEmbedSheetContent pre-renders the embed sheet blocks into lines
+// and computes block line offsets for click hit-testing.
+func (m *Model) renderEmbedSheetContent() {
+	em := &m.embedModal
+	contentWidth := viewMaxWidth
+	if m.width-4 < contentWidth {
+		contentWidth = m.width - 4
+		if contentWidth < 20 {
+			contentWidth = 20
+		}
+	}
+
+	leftPad := (m.width - contentWidth) / 2
+	if leftPad < 0 {
+		leftPad = 0
+	}
+	padStr := strings.Repeat(" ", leftPad)
+
+	var parts []string
+	offsets := make([]int, len(em.blocks))
+	parts = append(parts, "") // top breathing room
+
+	prevIdx := -1
+	for i, b := range em.blocks {
+		if prevIdx >= 0 {
+			prev := em.blocks[prevIdx]
+			switch {
+			case b.Type == block.Heading1:
+				parts = append(parts, "", "")
+			case b.Type == block.Heading2 || b.Type == block.Heading3:
+				parts = append(parts, "")
+			case b.Type == block.CodeBlock || b.Type == block.Quote:
+				if prev.Type != b.Type {
+					parts = append(parts, "")
+				}
+			case prev.Type == block.CodeBlock || prev.Type == block.Quote:
+				parts = append(parts, "")
+			case b.Type == block.Embed:
+				parts = append(parts, "")
+			case prev.Type == block.Embed:
+				parts = append(parts, "")
+			case b.Type == block.Divider:
+				parts = append(parts, "")
+			case prev.Type == block.Divider:
+				parts = append(parts, "")
+			}
+		}
+
+		offsets[i] = len(parts)
+		hovered := i == em.hoverBlock
+		rendered := renderViewBlock(b, b.Content, contentWidth, true, em.blocks, i, hovered)
+		for _, l := range strings.Split(rendered, "\n") {
+			parts = append(parts, padStr+l)
+		}
+		prevIdx = i
+	}
+	parts = append(parts, "", "")
+
+	em.lines = parts
+	em.blockLineOffsets = offsets
+}
+
+// renderEmbedSheet renders the full-width bottom sheet overlay for embedded notes.
+func (m Model) renderEmbedSheet() string {
+	w := m.width
+	if w <= 0 {
+		w = 80
+	}
+	h := m.height
+	if h <= 0 {
+		h = 24
+	}
+
+	th := theme.Current()
+	dim := lipgloss.NewStyle().Faint(true)
+	accent := lipgloss.NewStyle().Foreground(lipgloss.Color(th.Accent))
+
+	// Sheet takes all but the top 2 lines (context peek).
+	sheetH := h - 2
+	if sheetH < 6 {
+		sheetH = 6
+	}
+
+	// Title bar: centered, with separator line.
+	titleText := accent.Bold(true).Render(m.embedModal.title)
+	titleW := lipgloss.Width(titleText)
+	titlePad := (w - titleW) / 2
+	if titlePad < 0 {
+		titlePad = 0
+	}
+	titleLine := strings.Repeat(" ", titlePad) + titleText
+
+	sepChar := "\u2500"
+	sep := dim.Render(strings.Repeat(sepChar, w))
+
+	// Content area: sheetH minus title(1) + sep(1) + status(1) = sheetH-3
+	contentH := sheetH - 3
+	if contentH < 1 {
+		contentH = 1
+	}
+
+	// Apply scroll.
+	lines := m.embedModal.lines
+	maxScroll := len(lines) - contentH
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	scroll := m.embedModal.scroll
+	if scroll > maxScroll {
+		scroll = maxScroll
+	}
+	if scroll < 0 {
+		scroll = 0
+	}
+	end := scroll + contentH
+	if end > len(lines) {
+		end = len(lines)
+	}
+	visible := lines[scroll:end]
+
+	// Pad to fill the content area.
+	body := strings.Join(visible, "\n")
+	if len(visible) < contentH {
+		body += strings.Repeat("\n", contentH-len(visible))
+	}
+
+	// Status bar.
+	statusRight := "Esc close \u00B7 \u2191\u2193 scroll"
+	statusLeft := ""
+	if len(lines) > contentH {
+		pct := 0
+		if maxScroll > 0 {
+			pct = scroll * 100 / maxScroll
+		}
+		statusLeft = fmt.Sprintf(" %d%%", pct)
+	}
+	statusBar := format.StatusBar(statusLeft, "", statusRight, w)
+	statusBar = dim.Render(statusBar)
+
+	// Top context: dimmed current note title.
+	contextLine := dim.Render("  " + m.config.Title)
+	blank := ""
+
+	return contextLine + "\n" + blank + "\n" + sep + "\n" + titleLine + "\n" + body + "\n" + statusBar
 }

--- a/internal/editor/embed_picker.go
+++ b/internal/editor/embed_picker.go
@@ -1,0 +1,178 @@
+package editor
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/oobagi/notebook-cli/internal/theme"
+)
+
+// embedPicker is a floating popup for selecting a notebook/note target
+// when inserting or editing an embed block. Works like the command palette:
+// type to filter, arrow keys to navigate, Enter to select.
+type embedPicker struct {
+	visible  bool
+	items    []string // "notebook/note" paths
+	filtered []int    // indices into items matching filter
+	filter   string
+	cursor   int
+}
+
+// open populates the picker with items and shows it.
+func (p *embedPicker) open(items []string) {
+	p.visible = true
+	p.items = items
+	p.filter = ""
+	p.cursor = 0
+	p.refilter()
+}
+
+// close hides the picker.
+func (p *embedPicker) close() {
+	p.visible = false
+	p.filter = ""
+	p.cursor = 0
+}
+
+// refilter rebuilds the filtered index list from the current filter text.
+func (p *embedPicker) refilter() {
+	if p.filter == "" {
+		p.filtered = make([]int, len(p.items))
+		for i := range p.items {
+			p.filtered[i] = i
+		}
+		p.cursor = 0
+		return
+	}
+
+	lower := strings.ToLower(p.filter)
+	var result []int
+	for i, item := range p.items {
+		if strings.Contains(strings.ToLower(item), lower) {
+			result = append(result, i)
+		}
+	}
+	p.filtered = result
+	if p.cursor >= len(p.filtered) {
+		p.cursor = len(p.filtered) - 1
+	}
+	if p.cursor < 0 {
+		p.cursor = 0
+	}
+}
+
+// addFilterRune appends a rune and refilters.
+func (p *embedPicker) addFilterRune(r rune) {
+	p.filter += string(r)
+	p.refilter()
+}
+
+// deleteFilterRune removes the last rune. Returns false if filter was empty.
+func (p *embedPicker) deleteFilterRune() bool {
+	if p.filter == "" {
+		return false
+	}
+	runes := []rune(p.filter)
+	p.filter = string(runes[:len(runes)-1])
+	p.refilter()
+	return true
+}
+
+func (p *embedPicker) moveUp() {
+	if p.cursor > 0 {
+		p.cursor--
+	}
+}
+
+func (p *embedPicker) moveDown() {
+	if p.cursor < len(p.filtered)-1 {
+		p.cursor++
+	}
+}
+
+// selected returns the currently highlighted path, or "" if none.
+func (p *embedPicker) selected() string {
+	if len(p.filtered) == 0 || p.cursor < 0 || p.cursor >= len(p.filtered) {
+		return ""
+	}
+	return p.items[p.filtered[p.cursor]]
+}
+
+// render draws the picker as a floating box.
+func (p *embedPicker) render(width int) string {
+	if !p.visible {
+		return ""
+	}
+
+	th := theme.Current()
+
+	filterLine := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(th.Muted)).
+		Render("\u2197 " + p.filter)
+
+	var body string
+
+	if len(p.filtered) == 0 {
+		noMatch := lipgloss.NewStyle().
+			Foreground(lipgloss.Color(th.Muted)).
+			Render("No matching notes")
+		body = filterLine + "\n" + noMatch
+	} else {
+		// Show at most 10 items to keep the popup compact.
+		maxVisible := 10
+		start := 0
+		if p.cursor >= maxVisible {
+			start = p.cursor - maxVisible + 1
+		}
+		end := start + maxVisible
+		if end > len(p.filtered) {
+			end = len(p.filtered)
+		}
+
+		var rows []string
+		for i := start; i < end; i++ {
+			idx := p.filtered[i]
+			path := p.items[idx]
+
+			// Split into notebook and note parts for display.
+			label := path
+			if i == p.cursor {
+				label = lipgloss.NewStyle().
+					Bold(true).
+					Foreground(lipgloss.Color(th.Accent)).
+					Render(label)
+			} else {
+				label = lipgloss.NewStyle().
+					Foreground(lipgloss.Color(th.Muted)).
+					Render(label)
+			}
+			rows = append(rows, "  "+label)
+		}
+
+		// Scroll indicators.
+		if start > 0 {
+			rows = append([]string{lipgloss.NewStyle().Foreground(lipgloss.Color(th.Muted)).Render("  \u2191 more")}, rows...)
+		}
+		if end < len(p.filtered) {
+			rows = append(rows, lipgloss.NewStyle().Foreground(lipgloss.Color(th.Muted)).Render("  \u2193 more"))
+		}
+
+		body = filterLine + "\n" + strings.Join(rows, "\n")
+	}
+
+	boxWidth := 40
+	if boxWidth > width-4 {
+		boxWidth = width - 4
+	}
+	if boxWidth < 24 {
+		boxWidth = 24
+	}
+
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color(th.Border)).
+		Padding(0, 1).
+		Width(boxWidth)
+
+	return box.Render(body)
+}

--- a/internal/editor/palette.go
+++ b/internal/editor/palette.go
@@ -38,6 +38,7 @@ func defaultPaletteItems() []paletteItem {
 		{Icon: "``", Label: "Code Block", Type: block.CodeBlock},
 		{Icon: ">", Label: "Quote", Type: block.Quote},
 		{Icon: "\u2014", Label: "Divider", Type: block.Divider},
+		{Icon: "\u2197", Label: "Embed", Type: block.Embed},
 	}
 }
 

--- a/internal/editor/render.go
+++ b/internal/editor/render.go
@@ -312,6 +312,16 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 		}
 		rendered = strings.Join(lines, "\n")
 
+	case block.Embed:
+		bs := th.Blocks.Embed
+		embedColor := resolveColor(bs.Color, th.Accent)
+		icon := bs.Icon
+		if icon == "" {
+			icon = "\u2197 "
+		}
+		prefix := lipgloss.NewStyle().Foreground(lipgloss.Color(embedColor)).Render(icon)
+		rendered = prefixFirstLine(prefix, taView)
+
 	default:
 		rendered = taView
 	}
@@ -672,6 +682,18 @@ func renderInactiveBlock(b block.Block, content string, width int, wordWrap bool
 		}
 		rendered = lipgloss.NewStyle().Foreground(lipgloss.Color(divColor)).Render(divLine)
 
+	case block.Embed:
+		bs := th.Blocks.Embed
+		embedColor := resolveColor(bs.Color, th.Accent)
+		icon := bs.Icon
+		if icon == "" {
+			icon = "\u2197 "
+		}
+		pill := lipgloss.NewStyle().
+			Foreground(lipgloss.Color(embedColor)).
+			Render(icon + wrapped)
+		rendered = pill
+
 	default:
 		rendered = wrapped
 	}
@@ -816,6 +838,19 @@ func renderViewBlock(b block.Block, content string, width int, wordWrap bool, bl
 			divLine = string(runes[:width])
 		}
 		rendered = lipgloss.NewStyle().Foreground(lipgloss.Color(divColor)).Render(divLine)
+
+	case block.Embed:
+		bs := th.Blocks.Embed
+		embedColor := resolveColor(bs.Color, th.Accent)
+		icon := bs.Icon
+		if icon == "" {
+			icon = "\u2197 "
+		}
+		style := lipgloss.NewStyle().Foreground(lipgloss.Color(embedColor))
+		if hovered {
+			style = style.Underline(true)
+		}
+		rendered = style.Render(icon + wrapped)
 
 	default:
 		rendered = wrapped

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -91,6 +91,12 @@ type DividerStyle struct {
 	Color    string // hex; "" means theme.Accent (active) / theme.Muted (inactive)
 }
 
+// EmbedStyle controls embedded note link rendering.
+type EmbedStyle struct {
+	Icon  string // prefix icon, e.g. "↗ "
+	Color string // hex; "" means theme.Accent
+}
+
 // BlockStyles groups all per-block-type formatting.
 type BlockStyles struct {
 	Heading1  HeadingStyle
@@ -102,6 +108,7 @@ type BlockStyles struct {
 	Code      CodeStyle
 	Quote     QuoteStyle
 	Divider   DividerStyle
+	Embed     EmbedStyle
 }
 
 // DefaultBlockStyles returns the baseline block styles that match the original
@@ -124,6 +131,7 @@ func DefaultBlockStyles() BlockStyles {
 		Code:    CodeStyle{LabelAlign: "left"},
 		Quote:   QuoteStyle{Bar: "\u2502 "},
 		Divider: DividerStyle{Char: "\u2500", MaxWidth: 40},
+		Embed:   EmbedStyle{Icon: "\u2197 "},
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `Embed` block type with `![[notebook/note]]` parse/serialize syntax and round-trip tests
- `/` command palette entry + Tab-triggered note picker with fuzzy filtering for selecting embed targets
- View mode: accent-colored pill with hover underline; click opens full-width bottom sheet showing the referenced note
- Bottom sheet is interactive: checkboxes toggle and save back to the referenced note, scroll with keys/mouse
- Missing references show "Note not found" in the sheet; `EmbedStyle` added to theme system (all 16 presets)

## Test plan
- [ ] Create two notes in the same notebook
- [ ] In one note, type `/` → select "Embed" → note picker appears
- [ ] Filter and select a target note → path fills in
- [ ] Press Tab on the embed block → picker reopens
- [ ] Press Enter → creates new block below (normal behavior)
- [ ] Ctrl+R to view mode → embed shows as styled pill
- [ ] Hover embed → underline appears
- [ ] Click embed → bottom sheet opens with full referenced note
- [ ] Click a checkbox in the sheet → toggles and saves
- [ ] Scroll with ↑↓/mouse wheel in the sheet
- [ ] Esc to dismiss sheet
- [ ] Click above the sheet (dimmed context) → dismisses
- [ ] Test missing reference: manually type nonexistent path, click → "Note not found"
- [ ] Round-trip: save and reopen → `![[path]]` syntax preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)