### PR TITLE
feat: table block with cell editing (Closes #184)

### DIFF
--- a/fork/bubbles/textarea/textarea.go
+++ b/fork/bubbles/textarea/textarea.go
@@ -670,9 +670,6 @@ func (m *Model) setCursorLineRelative(delta int) {
 	charOffset := max(m.lastCharOffset, li.CharOffset)
 	m.lastCharOffset = charOffset
 
-	// 2 columns to account for the trailing space wrapping.
-	const trailingSpace = 2
-
 	if delta > 0 { //nolint:nestif
 		// Moving down.
 		for range delta {
@@ -680,8 +677,9 @@ func (m *Model) setCursorLineRelative(delta int) {
 				m.row++
 				m.col = 0
 			} else {
-				// Move the cursor to the start of the next virtual line.
-				m.col = min(li.StartColumn+li.Width+trailingSpace, len(m.value[m.row])-1)
+				// Jump to the segment boundary; LineInfo's wrap-around
+				// logic naturally advances to the next visual line.
+				m.col = min(li.StartColumn+li.Width, len(m.value[m.row]))
 			}
 			li = m.LineInfo()
 		}
@@ -692,8 +690,9 @@ func (m *Model) setCursorLineRelative(delta int) {
 				m.row--
 				m.col = len(m.value[m.row])
 			} else {
-				// Move the cursor to the end of the previous line.
-				m.col = li.StartColumn - trailingSpace
+				// Move one position before the current segment start
+				// to land in the previous visual line.
+				m.col = max(li.StartColumn-1, 0)
 			}
 			li = m.LineInfo()
 		}

--- a/internal/block/block.go
+++ b/internal/block/block.go
@@ -25,6 +25,7 @@ const (
 	DefinitionList                // term\n: definition
 	Embed                         // ![[path]] embedded note reference
 	Callout                       // > [!NOTE] callout/admonition
+	Table                         // GFM pipe table
 )
 
 // String returns the human-readable name of a BlockType.
@@ -56,6 +57,8 @@ func (bt BlockType) String() string {
 		return "Embed"
 	case Callout:
 		return "Callout"
+	case Table:
+		return "Table"
 	default:
 		return "Unknown"
 	}
@@ -100,6 +103,8 @@ func (bt BlockType) Short() string {
 		return "em"
 	case Callout:
 		return "co"
+	case Table:
+		return "tb"
 	default:
 		return "?"
 	}

--- a/internal/block/parse.go
+++ b/internal/block/parse.go
@@ -65,6 +65,20 @@ func Parse(markdown string) []Block {
 			continue
 		}
 
+		// --- Table (pipe-delimited) ---
+		if strings.HasPrefix(line, "|") {
+			var tableLines []string
+			for i < len(lines) && strings.HasPrefix(lines[i], "|") {
+				tableLines = append(tableLines, lines[i])
+				i++
+			}
+			blocks = append(blocks, Block{
+				Type:    Table,
+				Content: strings.Join(tableLines, "\n"),
+			})
+			continue
+		}
+
 		// --- Blank line ---
 		if line == "" {
 			blocks = append(blocks, Block{Type: Paragraph, Content: ""})
@@ -226,7 +240,8 @@ func isBlockStart(line string) bool {
 		strings.HasPrefix(line, "## ") ||
 		strings.HasPrefix(line, "### ") ||
 		strings.HasPrefix(line, "> ") ||
-		strings.HasPrefix(line, ": ") {
+		strings.HasPrefix(line, ": ") ||
+		strings.HasPrefix(line, "|") {
 		return true
 	}
 	_, stripped := stripListIndent(line)

--- a/internal/block/parse_test.go
+++ b/internal/block/parse_test.go
@@ -280,6 +280,38 @@ func TestParse(t *testing.T) {
 				{Type: Embed, Content: "my notebook/my note"},
 			},
 		},
+		{
+			name:  "simple 2x2 table",
+			input: "| A | B |\n| --- | --- |\n| 1 | 2 |",
+			expect: []Block{
+				{Type: Table, Content: "| A | B |\n| --- | --- |\n| 1 | 2 |"},
+			},
+		},
+		{
+			name:  "table with alignment markers",
+			input: "| Left | Center | Right |\n| :--- | :---: | ---: |\n| a | b | c |",
+			expect: []Block{
+				{Type: Table, Content: "| Left | Center | Right |\n| :--- | :---: | ---: |\n| a | b | c |"},
+			},
+		},
+		{
+			name:  "table with no body rows",
+			input: "| Name | Age |\n| --- | --- |",
+			expect: []Block{
+				{Type: Table, Content: "| Name | Age |\n| --- | --- |"},
+			},
+		},
+		{
+			name:  "table between other block types",
+			input: "# Title\n\n| X | Y |\n| - | - |\n| 1 | 2 |\n\nSome text",
+			expect: []Block{
+				{Type: Heading1, Content: "Title"},
+				{Type: Paragraph, Content: ""},
+				{Type: Table, Content: "| X | Y |\n| - | - |\n| 1 | 2 |"},
+				{Type: Paragraph, Content: ""},
+				{Type: Paragraph, Content: "Some text"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -337,6 +369,8 @@ func formatBlocks(blocks []Block) string {
 			b.WriteString("DefinitionList")
 		case Embed:
 			b.WriteString("Embed")
+		case Table:
+			b.WriteString("Table")
 		}
 		if bl.Content != "" {
 			b.WriteString(" " + bl.Content)

--- a/internal/block/serialize.go
+++ b/internal/block/serialize.go
@@ -99,6 +99,9 @@ func Serialize(blocks []Block) string {
 		case Embed:
 			lines = append(lines, "![["+b.Content+"]]")
 
+		case Table:
+			lines = append(lines, serializeTable(b.Content)...)
+
 		default:
 			if b.Content != "" {
 				lines = append(lines, strings.Split(b.Content, "\n")...)
@@ -107,4 +110,174 @@ func Serialize(blocks []Block) string {
 	}
 
 	return strings.Join(lines, "\n")
+}
+
+// isSeparatorCell reports whether a trimmed cell is a GFM separator
+// (e.g. "---", ":---", "---:", ":---:").
+func isSeparatorCell(s string) bool {
+	s = strings.TrimSpace(s)
+	if len(s) == 0 {
+		return false
+	}
+	// Strip optional leading/trailing colons.
+	t := strings.TrimPrefix(s, ":")
+	t = strings.TrimSuffix(t, ":")
+	if len(t) == 0 {
+		return false
+	}
+	for _, c := range t {
+		if c != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+// ParsePipeRow splits a pipe-delimited row into trimmed cells.
+// Leading and trailing pipes are removed: "| a | b |" → ["a", "b"].
+func ParsePipeRow(line string) []string {
+	line = strings.TrimSpace(line)
+	line = strings.TrimPrefix(line, "|")
+	line = strings.TrimSuffix(line, "|")
+	parts := strings.Split(line, "|")
+	cells := make([]string, len(parts))
+	for i, p := range parts {
+		cells[i] = strings.TrimSpace(p)
+	}
+	return cells
+}
+
+// IsSeparatorRow reports whether a full row is a GFM separator row.
+func IsSeparatorRow(line string) bool {
+	cells := ParsePipeRow(line)
+	if len(cells) == 0 {
+		return false
+	}
+	for _, c := range cells {
+		if !isSeparatorCell(c) {
+			return false
+		}
+	}
+	return true
+}
+
+// serializeTable formats pipe table content with auto-padded columns.
+// If the content includes a separator row, its alignment markers are
+// preserved. If no separator is found, one is auto-generated after the
+// first (header) row.
+func serializeTable(content string) []string {
+	rows := strings.Split(content, "\n")
+	if len(rows) == 0 {
+		return nil
+	}
+
+	// Parse all rows into cells and detect separator row.
+	type parsedRow struct {
+		cells []string
+		isSep bool
+		raw   string // original line for separator alignment extraction
+	}
+	var parsed []parsedRow
+	sepIdx := -1
+	maxCols := 0
+	for _, row := range rows {
+		isSep := IsSeparatorRow(row)
+		cells := ParsePipeRow(row)
+		if len(cells) > maxCols {
+			maxCols = len(cells)
+		}
+		if isSep && sepIdx == -1 {
+			sepIdx = len(parsed)
+		}
+		parsed = append(parsed, parsedRow{cells: cells, isSep: isSep, raw: row})
+	}
+
+	// Normalize all rows to the same column count.
+	for i := range parsed {
+		for len(parsed[i].cells) < maxCols {
+			parsed[i].cells = append(parsed[i].cells, "")
+		}
+	}
+
+	// Find max width per column (excluding separator rows).
+	colWidths := make([]int, maxCols)
+	for _, pr := range parsed {
+		if pr.isSep {
+			continue
+		}
+		for j, cell := range pr.cells {
+			if len(cell) > colWidths[j] {
+				colWidths[j] = len(cell)
+			}
+		}
+	}
+	for j := range colWidths {
+		if colWidths[j] < 3 {
+			colWidths[j] = 3
+		}
+	}
+
+	// Build output lines.
+	var out []string
+	hasSep := false
+	for _, pr := range parsed {
+		if pr.isSep {
+			hasSep = true
+			// Preserve alignment markers from the original separator.
+			var parts []string
+			for j, cell := range pr.cells {
+				w := colWidths[j]
+				cell = strings.TrimSpace(cell)
+				leftColon := strings.HasPrefix(cell, ":")
+				rightColon := strings.HasSuffix(cell, ":")
+				dashes := w
+				if leftColon {
+					dashes--
+				}
+				if rightColon {
+					dashes--
+				}
+				if dashes < 1 {
+					dashes = 1
+				}
+				sep := strings.Repeat("-", dashes)
+				if leftColon {
+					sep = ":" + sep
+				}
+				if rightColon {
+					sep = sep + ":"
+				}
+				parts = append(parts, " "+sep+" ")
+			}
+			out = append(out, "|"+strings.Join(parts, "|")+"|")
+		} else {
+			var parts []string
+			for j, cell := range pr.cells {
+				w := colWidths[j]
+				pad := w - len(cell)
+				if pad < 0 {
+					pad = 0
+				}
+				parts = append(parts, " "+cell+strings.Repeat(" ", pad)+" ")
+			}
+			out = append(out, "|"+strings.Join(parts, "|")+"|")
+		}
+	}
+
+	// If no separator was found, insert one after the first row.
+	if !hasSep && len(out) > 0 {
+		var sepParts []string
+		for _, w := range colWidths {
+			sepParts = append(sepParts, " "+strings.Repeat("-", w)+" ")
+		}
+		sepLine := "|" + strings.Join(sepParts, "|") + "|"
+		// Insert after first line.
+		newOut := make([]string, 0, len(out)+1)
+		newOut = append(newOut, out[0])
+		newOut = append(newOut, sepLine)
+		newOut = append(newOut, out[1:]...)
+		out = newOut
+	}
+
+	return out
 }

--- a/internal/block/serialize_test.go
+++ b/internal/block/serialize_test.go
@@ -153,6 +153,18 @@ func TestSerializeRoundTrip(t *testing.T) {
 			name: "embed between paragraphs",
 			md:   "text\n\n![[ref]]\n\nmore text",
 		},
+		{
+			name: "simple table",
+			md:   "| A   | B   |\n| --- | --- |\n| 1   | 2   |",
+		},
+		{
+			name: "table with alignment markers",
+			md:   "| Left | Center | Right |\n| :--- | :----: | ----: |\n| a    | b      | c     |",
+		},
+		{
+			name: "table with no body rows",
+			md:   "| Name | Age |\n| ---- | --- |",
+		},
 	}
 
 	for _, tt := range tests {
@@ -183,6 +195,8 @@ func TestSerializeIdempotent(t *testing.T) {
 		"API\n: Application Programming Interface\n\nSDK\n: Software Development Kit",
 		"![[notebook/note]]",
 		"text\n\n![[ref]]\n\nmore text",
+		"| A   | B   |\n| --- | --- |\n| 1   | 2   |",
+		"| Left | Center | Right |\n| :--- | :----: | ----: |\n| a    | b      | c     |",
 	}
 
 	for _, md := range inputs {
@@ -220,6 +234,29 @@ func TestSerializeNumberedListSequencing(t *testing.T) {
 	want := "1. alpha\n2. beta\n3. gamma"
 	if got != want {
 		t.Errorf("numbered sequencing:\n  got:  %q\n  want: %q", got, want)
+	}
+}
+
+func TestSerializeTablePadding(t *testing.T) {
+	// Uneven column widths should get padded.
+	blocks := []Block{
+		{Type: Table, Content: "| A | LongHeader |\n| --- | --- |\n| short | x |"},
+	}
+	got := Serialize(blocks)
+	want := "| A     | LongHeader |\n| ----- | ---------- |\n| short | x          |"
+	if got != want {
+		t.Errorf("table padding:\n  got:  %q\n  want: %q", got, want)
+	}
+}
+
+func TestSerializeTableAlignmentPreserved(t *testing.T) {
+	blocks := []Block{
+		{Type: Table, Content: "| L | C | R |\n| :--- | :---: | ---: |\n| a | b | c |"},
+	}
+	got := Serialize(blocks)
+	want := "| L   | C   | R   |\n| :-- | :-: | --: |\n| a   | b   | c   |"
+	if got != want {
+		t.Errorf("table alignment:\n  got:  %q\n  want: %q", got, want)
 	}
 }
 

--- a/internal/block/table.go
+++ b/internal/block/table.go
@@ -1,0 +1,129 @@
+package block
+
+import "strings"
+
+// ParseTableCells parses pipe-delimited content into a 2D cell grid and
+// alignment info. Separator rows are consumed for alignment and excluded
+// from the returned cells.
+func ParseTableCells(content string) (cells [][]string, aligns []string) {
+	if content == "" {
+		return nil, nil
+	}
+
+	rows := strings.Split(content, "\n")
+	maxCols := 0
+
+	for _, row := range rows {
+		if IsSeparatorRow(row) {
+			// Extract alignment from separator.
+			sepCells := ParsePipeRow(row)
+			aligns = make([]string, len(sepCells))
+			for i, c := range sepCells {
+				c = strings.TrimSpace(c)
+				left := strings.HasPrefix(c, ":")
+				right := strings.HasSuffix(c, ":")
+				switch {
+				case left && right:
+					aligns[i] = "center"
+				case right:
+					aligns[i] = "right"
+				default:
+					aligns[i] = "left"
+				}
+			}
+			continue
+		}
+		parsed := ParsePipeRow(row)
+		if len(parsed) > maxCols {
+			maxCols = len(parsed)
+		}
+		cells = append(cells, parsed)
+	}
+
+	// Normalize all rows to the same column count.
+	for i := range cells {
+		for len(cells[i]) < maxCols {
+			cells[i] = append(cells[i], "")
+		}
+	}
+
+	// Default alignment if no separator was found.
+	if aligns == nil && maxCols > 0 {
+		aligns = make([]string, maxCols)
+		for i := range aligns {
+			aligns[i] = "left"
+		}
+	}
+
+	// Normalize aligns to match column count.
+	for len(aligns) < maxCols {
+		aligns = append(aligns, "left")
+	}
+	if len(aligns) > maxCols && maxCols > 0 {
+		aligns = aligns[:maxCols]
+	}
+
+	return cells, aligns
+}
+
+// SerializeTableCells converts a 2D cell grid back to pipe-delimited content
+// with a separator row after the header. Alignment markers are preserved.
+func SerializeTableCells(cells [][]string, aligns []string) string {
+	if len(cells) == 0 {
+		return ""
+	}
+
+	maxCols := 0
+	for _, row := range cells {
+		if len(row) > maxCols {
+			maxCols = len(row)
+		}
+	}
+
+	// Normalize column counts.
+	for i := range cells {
+		for len(cells[i]) < maxCols {
+			cells[i] = append(cells[i], "")
+		}
+	}
+	for len(aligns) < maxCols {
+		aligns = append(aligns, "left")
+	}
+
+	// Build pipe rows with the separator inlined as content.
+	var contentRows []string
+	for i, row := range cells {
+		var parts []string
+		for _, cell := range row {
+			parts = append(parts, cell)
+		}
+		contentRows = append(contentRows, strings.Join(parts, "|"))
+		// Insert separator after the header row.
+		if i == 0 {
+			var sepParts []string
+			for j := 0; j < maxCols; j++ {
+				a := "left"
+				if j < len(aligns) {
+					a = aligns[j]
+				}
+				switch a {
+				case "center":
+					sepParts = append(sepParts, ":---:")
+				case "right":
+					sepParts = append(sepParts, "---:")
+				default:
+					sepParts = append(sepParts, "---")
+				}
+			}
+			contentRows = append(contentRows, strings.Join(sepParts, "|"))
+		}
+	}
+
+	// Re-join as pipe content and let serializeTable handle padding.
+	var pipeLines []string
+	for _, row := range contentRows {
+		pipeLines = append(pipeLines, "| "+strings.ReplaceAll(row, "|", " | ")+" |")
+	}
+	content := strings.Join(pipeLines, "\n")
+	return content
+}

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -98,6 +98,7 @@ type Model struct {
 	cascadeChecks bool // checking parent also checks/unchecks children
 	embedModal    embedModalState // overlay for viewing embedded note references
 	embedPicker   embedPicker     // note picker for embed block insertion
+	table         *tableState // active table cell state (non-nil when editing a Table block)
 }
 
 type statusKind int
@@ -204,6 +205,8 @@ func blockPrefixWidth(bt block.BlockType, indent int) int {
 			icon = "\u2197 "
 		}
 		base = lipgloss.Width(icon)
+	case block.Table:
+		base = 0
 	}
 	return indent*4 + base
 }
@@ -246,7 +249,7 @@ func New(cfg Config) Model {
 		dismissed = make(map[string]bool)
 	}
 
-	return Model{
+	m := Model{
 		blocks:         blocks,
 		textareas:      textareas,
 		active:         0,
@@ -262,6 +265,16 @@ func New(cfg Config) Model {
 		sortChecked:   config.BoolVal(cfg.HideChecked, true),
 		cascadeChecks: config.BoolVal(cfg.CascadeChecks, true),
 	}
+
+	// If first block is a Table, init table state.
+	if len(m.blocks) > 0 && m.blocks[0].Type == block.Table {
+		m.table = initTable(m.blocks[0].Content)
+		cw := tableCellWidth(defaultWidth-gutterWidth, m.table.numCols())
+		m.table.loadCell(&m.textareas[0], cw)
+		m.cursorCmd = m.textareas[0].Focus()
+	}
+
+	return m
 }
 
 // newTextareaForBlock creates a textarea configured for the given block type.
@@ -310,7 +323,14 @@ func (m Model) syncBlocks() []block.Block {
 	copy(result, m.blocks)
 	for i := range result {
 		if i < len(m.textareas) {
-			result[i].Content = m.textareas[i].Value()
+			if m.table != nil && i == m.active && m.blocks[i].Type == block.Table {
+				// For the active table, sync the current cell and serialize.
+				ts := *m.table // copy to avoid mutating receiver
+				ts.syncCell(m.textareas[i])
+				result[i].Content = ts.serialize()
+			} else {
+				result[i].Content = m.textareas[i].Value()
+			}
 		}
 	}
 	return result
@@ -481,7 +501,13 @@ func (m *Model) resizeTextareas() {
 		w = defaultWidth
 	}
 	for i, b := range m.blocks {
-		m.textareas[i].SetWidth(m.contentWidth(b))
+		if m.table != nil && i == m.active && b.Type == block.Table {
+			// Active table textarea shows a cell; size to cell width.
+			cw := tableCellWidth(w-gutterWidth, m.table.numCols())
+			m.textareas[i].SetWidth(cw)
+		} else {
+			m.textareas[i].SetWidth(m.contentWidth(b))
+		}
 		m.textareas[i].SetHeight(m.textareas[i].VisualLineCount())
 	}
 	// Update viewport dimensions, reserving space for the header and status bar
@@ -514,12 +540,30 @@ func (m *Model) focusBlock(idx int) {
 	if m.undoDirty {
 		m.pushUndo()
 	}
+
+	// Leaving a table: sync cell and serialize back to block content.
+	if m.table != nil && m.active >= 0 && m.active < len(m.textareas) {
+		m.table.syncCell(m.textareas[m.active])
+		serialized := m.table.serialize()
+		m.blocks[m.active].Content = serialized
+		m.textareas[m.active].SetValue(serialized)
+		m.table = nil
+	}
+
 	if m.active >= 0 && m.active < len(m.textareas) {
 		m.blocks[m.active].Content = m.textareas[m.active].Value()
 		m.textareas[m.active].Blur()
 	}
 	m.active = idx
 	m.cursorCmd = m.textareas[idx].Focus()
+
+	// Entering a table: init table state and load first cell.
+	if m.blocks[idx].Type == block.Table {
+		m.table = initTable(m.blocks[idx].Content)
+		cw := tableCellWidth(m.width-gutterWidth, m.table.numCols())
+		m.table.loadCell(&m.textareas[idx], cw)
+		m.cursorCmd = m.textareas[idx].Focus()
+	}
 }
 
 // navigateUp moves focus to the previous block, preserving horizontal position.
@@ -745,8 +789,18 @@ func (m *Model) swapBlocks(delta int) {
 
 	bStart, bEnd := m.blockBundle(m.active)
 
+	// Sync table cell before swapping.
+	if m.table != nil && m.blocks[m.active].Type == block.Table {
+		m.table.syncCell(m.textareas[m.active])
+		m.blocks[m.active].Content = m.table.serialize()
+		m.textareas[m.active].SetValue(m.blocks[m.active].Content)
+	}
+
 	// Sync textarea content in the active bundle.
 	for i := bStart; i < bEnd; i++ {
+		if m.table != nil && i == m.active && m.blocks[i].Type == block.Table {
+			continue // Already synced above.
+		}
 		m.blocks[i].Content = m.textareas[i].Value()
 	}
 
@@ -1051,8 +1105,8 @@ func (m *Model) handleBackspace() bool {
 		return true
 	}
 
-	// Don't merge content into code blocks, quote blocks, definition lists, or callout blocks.
-	if m.blocks[m.active-1].Type == block.CodeBlock || m.blocks[m.active-1].Type == block.Quote || m.blocks[m.active-1].Type == block.DefinitionList || m.blocks[m.active-1].Type == block.Callout {
+	// Don't merge content into code blocks, quote blocks, definition lists, callouts, or tables.
+	if m.blocks[m.active-1].Type == block.CodeBlock || m.blocks[m.active-1].Type == block.Quote || m.blocks[m.active-1].Type == block.DefinitionList || m.blocks[m.active-1].Type == block.Callout || m.blocks[m.active-1].Type == block.Table {
 		return false
 	}
 
@@ -1063,10 +1117,19 @@ func (m *Model) handleBackspace() bool {
 
 // cutBlock removes the active block and stores it in the block clipboard.
 func (m *Model) cutBlock() {
+	// Sync table cell before cutting.
+	if m.table != nil && m.blocks[m.active].Type == block.Table {
+		m.table.syncCell(m.textareas[m.active])
+		m.blocks[m.active].Content = m.table.serialize()
+		m.table = nil
+	}
+
 	if len(m.blocks) <= 1 {
 		// Don't remove the last block; store it and clear it instead.
 		b := m.blocks[m.active]
-		b.Content = m.textareas[m.active].Value()
+		if b.Type != block.Table {
+			b.Content = m.textareas[m.active].Value()
+		}
 		m.blockClip = &b
 		m.blocks[m.active] = block.Block{Type: block.Paragraph, Content: ""}
 		m.textareas[m.active].SetValue("")
@@ -1074,7 +1137,9 @@ func (m *Model) cutBlock() {
 	}
 
 	b := m.blocks[m.active]
-	b.Content = m.textareas[m.active].Value()
+	if b.Type != block.Table {
+		b.Content = m.textareas[m.active].Value()
+	}
 	m.blockClip = &b
 
 	idx := m.active
@@ -1127,6 +1192,20 @@ func (m *Model) applyPaletteSelection(bt block.BlockType) {
 		if len(targets) > 0 {
 			m.embedPicker.open(targets)
 		}
+	}
+	// Table: set default template and init table state.
+	if bt == block.Table {
+		content := m.textareas[m.active].Value()
+		if content == "" || !strings.Contains(content, "|") {
+			// Set a default 2x2 table template.
+			content = "| Header 1 | Header 2 |\n| --- | --- |\n|  |  |"
+		}
+		m.blocks[m.active].Content = content
+		m.textareas[m.active].SetValue(content)
+		m.table = initTable(content)
+		cw := tableCellWidth(m.width-gutterWidth, m.table.numCols())
+		m.table.loadCell(&m.textareas[m.active], cw)
+		m.cursorCmd = m.textareas[m.active].Focus()
 	}
 	m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount())
 }
@@ -1583,6 +1662,13 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// Re-focus the previously active block to restore cursor.
 				if m.active >= 0 && m.active < len(m.textareas) {
 					m.cursorCmd = m.textareas[m.active].Focus()
+					// Re-init table state if returning to a table block.
+					if m.blocks[m.active].Type == block.Table {
+						m.table = initTable(m.blocks[m.active].Content)
+						cw := tableCellWidth(m.width-gutterWidth, m.table.numCols())
+						m.table.loadCell(&m.textareas[m.active], cw)
+						m.cursorCmd = m.textareas[m.active].Focus()
+					}
 				}
 				m.updateViewport()
 				return m, nil
@@ -1644,7 +1730,13 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.hoverBlock = -1
 			// Blur the active textarea but preserve m.active.
 			if m.active >= 0 && m.active < len(m.textareas) {
-				m.blocks[m.active].Content = m.textareas[m.active].Value()
+				if m.table != nil && m.blocks[m.active].Type == block.Table {
+					m.table.syncCell(m.textareas[m.active])
+					m.blocks[m.active].Content = m.table.serialize()
+					m.textareas[m.active].SetValue(m.blocks[m.active].Content)
+				} else {
+					m.blocks[m.active].Content = m.textareas[m.active].Value()
+				}
 				m.textareas[m.active].Blur()
 			}
 			m.updateViewport()
@@ -1701,16 +1793,15 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 
 		case "up":
-			if m.isAtFirstLine() && m.active == 0 {
-				bt := m.blocks[0].Type
-				if bt == block.CodeBlock || bt == block.Quote || bt == block.Callout || bt == block.DefinitionList || bt == block.Divider {
-					// These types don't split on Enter, so there's no other
-					// way to insert content above them. Create a paragraph.
-					m.pushUndo()
-					m.insertBlockBefore(0, block.Block{Type: block.Paragraph})
-					m.updateViewport()
-					return m, nil
-				}
+			// Table blocks handle their own Up navigation.
+			if m.table != nil && m.blocks[m.active].Type == block.Table {
+				break
+			}
+			if m.isAtFirstLine() && m.active == 0 && m.blocks[0].Type != block.Paragraph {
+				m.pushUndo()
+				m.insertBlockBefore(0, block.Block{Type: block.Paragraph})
+				m.updateViewport()
+				return m, nil
 			}
 			if m.isAtFirstLine() && m.active > 0 {
 				m.navigateUp()
@@ -1719,6 +1810,10 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case "down":
+			// Table blocks handle their own Down navigation.
+			if m.table != nil && m.blocks[m.active].Type == block.Table {
+				break
+			}
 			if m.isAtLastLine() && m.active < len(m.textareas)-1 {
 				m.navigateDown()
 				m.updateViewport()
@@ -1776,6 +1871,10 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.scheduleStatusDismiss()
 
 		case "ctrl+u":
+			// Tables handle their own editing; skip block merge logic.
+			if m.table != nil && m.blocks[m.active].Type == block.Table {
+				break
+			}
 			ta := &m.textareas[m.active]
 			info := ta.LineInfo()
 			logicalCol := info.StartColumn + info.ColumnOffset
@@ -1875,6 +1974,117 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						return m, nil
 					}
 				}
+			}
+
+			// Table-specific key handling.
+			if m.table != nil && m.blocks[m.active].Type == block.Table {
+				ta := &m.textareas[m.active]
+				cw := tableCellWidth(m.width-gutterWidth, m.table.numCols())
+
+				switch {
+				case keyMsg.Code == tea.KeyTab && keyMsg.Mod.Contains(tea.ModShift):
+					// Shift+Tab: previous cell.
+					m.table.syncCell(*ta)
+					m.table.prevCell()
+					m.table.loadCell(ta, cw)
+					m.cursorCmd = ta.Focus()
+					m.updateViewport()
+					return m, nil
+
+				case keyMsg.Code == tea.KeyTab:
+					// Tab: next cell.
+					m.table.syncCell(*ta)
+					m.table.nextCell()
+					m.table.loadCell(ta, cw)
+					m.cursorCmd = ta.Focus()
+					m.updateViewport()
+					return m, nil
+
+				case keyMsg.Code == tea.KeyEnter:
+					// Enter: move to cell below (same column), add row if needed.
+					m.table.syncCell(*ta)
+					m.table.row++
+					if m.table.row >= len(m.table.cells) {
+						newRow := make([]string, m.table.numCols())
+						m.table.cells = append(m.table.cells, newRow)
+					}
+					m.table.loadCell(ta, cw)
+					m.cursorCmd = ta.Focus()
+					m.updateViewport()
+					return m, nil
+
+				case keyMsg.Code == tea.KeyBackspace:
+					// At position 0 in cell: no-op (don't merge blocks).
+					if ta.Line() == 0 && ta.LineInfo().ColumnOffset == 0 {
+						m.updateViewport()
+						return m, nil
+					}
+					// Otherwise let the textarea handle it normally below.
+
+				case keyMsg.String() == "up":
+					if m.isAtFirstLine() {
+						if m.table.row > 0 {
+							// Move to cell above.
+							m.table.syncCell(*ta)
+							m.table.row--
+							m.table.loadCell(ta, cw)
+							m.cursorCmd = ta.Focus()
+							m.updateViewport()
+							return m, nil
+						}
+						// At top row: navigate to previous block or insert paragraph.
+						if m.active > 0 {
+							m.navigateUp()
+							m.updateViewport()
+							return m, nil
+						}
+						// At block 0: insert paragraph above.
+						m.pushUndo()
+						m.insertBlockBefore(0, block.Block{Type: block.Paragraph})
+						m.updateViewport()
+						return m, nil
+					}
+
+				case keyMsg.String() == "down":
+					if m.isAtLastLine() {
+						if m.table.row < len(m.table.cells)-1 {
+							// Move to cell below.
+							m.table.syncCell(*ta)
+							m.table.row++
+							m.table.loadCell(ta, cw)
+							m.cursorCmd = ta.Focus()
+							m.updateViewport()
+							return m, nil
+						}
+						// At bottom row: navigate to next block.
+						if m.active < len(m.textareas)-1 {
+							m.navigateDown()
+							m.updateViewport()
+							return m, nil
+						}
+					}
+				}
+
+				// For all other keys, fall through to the textarea forwarding below.
+				// But skip Enter/Backspace/Tab/Divider handling that follows.
+				var preState editorState
+				if !m.undoDirty {
+					preState = m.captureState()
+				}
+
+				var cmd tea.Cmd
+				m.textareas[m.active], cmd = m.textareas[m.active].Update(msg)
+
+				if !m.undoDirty && m.textareas[m.active].Value() != preState.blocks[preState.active].Content {
+					m.undo.push(preState)
+					m.redo.clear()
+					m.undoDirty = true
+				}
+
+				m.textareas[m.active].SetWidth(cw)
+				m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount())
+				m.updateViewport()
+				return m, cmd
 			}
 
 			// Handle Enter key: always split/create via handleEnter.
@@ -2105,6 +2315,9 @@ func (m *Model) updateViewport() {
 		if m.blocks[m.active].Type == block.CodeBlock {
 			chromeLines = 1 // top border
 		}
+		if m.blocks[m.active].Type == block.Table {
+			chromeLines = 1 // top border
+		}
 
 		ta := m.textareas[m.active]
 
@@ -2113,7 +2326,13 @@ func (m *Model) updateViewport() {
 		// cursor occupy more visual lines than raw lines.
 		cursorRawLine := ta.Line()
 		visualLine := cursorRawLine
-		if m.wordWrap {
+
+		if m.table != nil && m.blocks[m.active].Type == block.Table {
+			// For tables, compute cursor line within the grid.
+			// Each row before the active row contributes: 1 content line + 1 separator.
+			// (Simplified: assume 1 visual line per cell for scroll purposes.)
+			visualLine = m.table.row*2 + cursorRawLine
+		} else if m.wordWrap {
 			contentWidth := m.width - gutterWidth - blockPrefixWidth(m.blocks[m.active].Type, m.blocks[m.active].Indent)
 			if contentWidth < 1 {
 				contentWidth = 1
@@ -2212,11 +2431,11 @@ func (m *Model) computeBlockLineOffsets() {
 				advance("")
 			case b.Type == block.Heading2 || b.Type == block.Heading3:
 				advance("")
-			case b.Type == block.CodeBlock || b.Type == block.Quote || b.Type == block.Callout:
+			case b.Type == block.CodeBlock || b.Type == block.Quote || b.Type == block.Callout || b.Type == block.Table:
 				if prev.Type != b.Type {
 					advance("")
 				}
-			case prev.Type == block.CodeBlock || prev.Type == block.Quote || prev.Type == block.Callout:
+			case prev.Type == block.CodeBlock || prev.Type == block.Quote || prev.Type == block.Callout || prev.Type == block.Table:
 				advance("")
 			case b.Type == block.Embed:
 				advance("")
@@ -2339,12 +2558,12 @@ func (m Model) renderViewContent() string {
 				parts = append(parts, "", "") // extra blank before H1
 			case b.Type == block.Heading2 || b.Type == block.Heading3:
 				parts = append(parts, "") // blank before H2/H3
-			case b.Type == block.CodeBlock || b.Type == block.Quote || b.Type == block.Callout:
+			case b.Type == block.CodeBlock || b.Type == block.Quote || b.Type == block.Callout || b.Type == block.Table:
 				if prev.Type != b.Type {
-					parts = append(parts, "") // blank before code/quote/callout blocks
+					parts = append(parts, "")
 				}
-			case prev.Type == block.CodeBlock || prev.Type == block.Quote || prev.Type == block.Callout:
-				parts = append(parts, "") // blank after code/quote/callout blocks
+			case prev.Type == block.CodeBlock || prev.Type == block.Quote || prev.Type == block.Callout || prev.Type == block.Table:
+				parts = append(parts, "")
 			case b.Type == block.Embed:
 				parts = append(parts, "") // blank before embeds
 			case prev.Type == block.Embed:

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -1035,6 +1035,11 @@ func (m *Model) handleBackspace() bool {
 	content := ta.Value()
 	bt := m.blocks[m.active].Type
 
+	// Table cell: never merge/delete — just no-op at position 0.
+	if bt == block.Table {
+		return true
+	}
+
 	// Divider: backspace always deletes the divider (selected as a unit).
 	if bt == block.Divider {
 		m.pushUndo()
@@ -1793,9 +1798,16 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 
 		case "up":
-			// Table blocks handle their own Up navigation.
-			if m.table != nil && m.blocks[m.active].Type == block.Table {
-				break
+			// Table: move to cell above before block navigation.
+			if m.isAtFirstLine() && m.table != nil && m.table.row > 0 {
+				ta := &m.textareas[m.active]
+				cw := tableCellWidth(m.width-gutterWidth, m.table.numCols())
+				m.table.syncCell(*ta)
+				m.table.row--
+				m.table.loadCell(ta, cw)
+				m.cursorCmd = ta.Focus()
+				m.updateViewport()
+				return m, nil
 			}
 			if m.isAtFirstLine() && m.active == 0 && m.blocks[0].Type != block.Paragraph {
 				m.pushUndo()
@@ -1810,6 +1822,17 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case "down":
+			// Table: move to cell below before block navigation.
+			if m.isAtLastLine() && m.table != nil && m.table.row < len(m.table.cells)-1 {
+				ta := &m.textareas[m.active]
+				cw := tableCellWidth(m.width-gutterWidth, m.table.numCols())
+				m.table.syncCell(*ta)
+				m.table.row++
+				m.table.loadCell(ta, cw)
+				m.cursorCmd = ta.Focus()
+				m.updateViewport()
+				return m, nil
+			}
 			if m.isAtLastLine() && m.active < len(m.textareas)-1 {
 				m.navigateDown()
 				m.updateViewport()
@@ -1974,7 +1997,6 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				ta := &m.textareas[m.active]
 				cw := tableCellWidth(m.width-gutterWidth, m.table.numCols())
 
-				// Tab / Shift+Tab: cell navigation.
 				if keyMsg.Code == tea.KeyTab {
 					m.table.syncCell(*ta)
 					if keyMsg.Mod.Contains(tea.ModShift) {
@@ -1988,7 +2010,6 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, nil
 				}
 
-				// Enter: move to cell below.
 				if keyMsg.Code == tea.KeyEnter {
 					m.table.syncCell(*ta)
 					m.table.row++
@@ -2002,55 +2023,7 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, nil
 				}
 
-				// Backspace at position 0: no-op (cells don't merge).
-				if keyMsg.Code == tea.KeyBackspace && ta.Line() == 0 && ta.LineInfo().ColumnOffset == 0 {
-					return m, nil
-				}
-
-				// Up at first line: move to cell above or leave table.
-				if keyMsg.Code == tea.KeyUp && m.isAtFirstLine() {
-					if m.table.row > 0 {
-						m.table.syncCell(*ta)
-						m.table.row--
-						m.table.loadCell(ta, cw)
-						m.cursorCmd = ta.Focus()
-						m.updateViewport()
-						return m, nil
-					}
-					if m.active > 0 {
-						m.navigateUp()
-						m.updateViewport()
-						return m, nil
-					}
-					m.pushUndo()
-					m.insertBlockBefore(0, block.Block{Type: block.Paragraph})
-					m.updateViewport()
-					return m, nil
-				}
-
-				// Down at last line: move to cell below or leave table.
-				if keyMsg.Code == tea.KeyDown && m.isAtLastLine() {
-					if m.table.row < len(m.table.cells)-1 {
-						m.table.syncCell(*ta)
-						m.table.row++
-						m.table.loadCell(ta, cw)
-						m.cursorCmd = ta.Focus()
-						m.updateViewport()
-						return m, nil
-					}
-					if m.active < len(m.textareas)-1 {
-						m.navigateDown()
-						m.updateViewport()
-						return m, nil
-					}
-				}
-
-				// Everything else: forward to the textarea as-is.
-				m.textareas[m.active], _ = m.textareas[m.active].Update(msg)
-				m.textareas[m.active].SetWidth(cw)
-				m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount())
-				m.updateViewport()
-				return m, nil
+				// Fall through — let normal textarea forwarding handle it.
 			}
 
 			// Handle Enter key: always split/create via handleEnter.

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -593,7 +593,7 @@ func (m *Model) navigateDown() {
 
 // isMultiLine returns true if the block type allows multi-line content.
 func isMultiLine(bt block.BlockType) bool {
-	return bt == block.Paragraph || bt == block.CodeBlock || bt == block.Quote || bt == block.DefinitionList || bt == block.Callout
+	return bt == block.Paragraph || bt == block.CodeBlock || bt == block.Quote || bt == block.DefinitionList || bt == block.Callout || bt == block.Table
 }
 
 // insertBlockBefore inserts a new block before the given index, creates a
@@ -2065,24 +2065,13 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 				}
 
-				// For all other keys, fall through to the textarea forwarding below.
-				// But skip Enter/Backspace/Tab/Divider handling that follows.
-				var preState editorState
-				if !m.undoDirty {
-					preState = m.captureState()
-				}
-
+				// For all other keys, forward to the textarea.
 				var cmd tea.Cmd
 				m.textareas[m.active], cmd = m.textareas[m.active].Update(msg)
 
-				if !m.undoDirty && m.textareas[m.active].Value() != preState.blocks[preState.active].Content {
-					m.undo.push(preState)
-					m.redo.clear()
-					m.undoDirty = true
-				}
-
 				m.textareas[m.active].SetWidth(cw)
 				m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount())
+				m.cursorCmd = m.textareas[m.active].Focus()
 				m.updateViewport()
 				return m, cmd
 			}

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -228,6 +228,37 @@ func (m Model) contentWidth(b block.Block) int {
 	return w
 }
 
+// tableCellTAWidth returns the textarea width for a table cell.
+// In word-wrap mode this is the visual cell width so text wraps within
+// the cell. In no-wrap mode this is noWrapWidth so text stays on one
+// line; the render handles per-cell scrolling with ← → indicators.
+func (m Model) tableCellTAWidth() int {
+	if !m.wordWrap {
+		return noWrapWidth
+	}
+	if m.table == nil {
+		return 5
+	}
+	mw := m.width
+	if mw <= 0 {
+		mw = defaultWidth
+	}
+	return tableCellWidth(mw-gutterWidth, m.table.numCols())
+}
+
+// tableCellDisplayWidth returns the visual column width for rendering,
+// always based on the window width regardless of word-wrap.
+func (m Model) tableCellDisplayWidth() int {
+	if m.table == nil {
+		return 5
+	}
+	mw := m.width
+	if mw <= 0 {
+		mw = defaultWidth
+	}
+	return tableCellWidth(mw-gutterWidth, m.table.numCols())
+}
+
 // New creates a new editor Model from the given config.
 func New(cfg Config) Model {
 	blocks := block.Parse(cfg.Content)
@@ -269,8 +300,8 @@ func New(cfg Config) Model {
 	// If first block is a Table, init table state.
 	if len(m.blocks) > 0 && m.blocks[0].Type == block.Table {
 		m.table = initTable(m.blocks[0].Content)
-		cw := tableCellWidth(defaultWidth-gutterWidth, m.table.numCols())
-		m.table.loadCell(&m.textareas[0], cw)
+		cw := m.tableCellTAWidth()
+		m.table.loadCell(&m.textareas[0], cw, false)
 		m.cursorCmd = m.textareas[0].Focus()
 	}
 
@@ -503,7 +534,7 @@ func (m *Model) resizeTextareas() {
 	for i, b := range m.blocks {
 		if m.table != nil && i == m.active && b.Type == block.Table {
 			// Active table textarea shows a cell; size to cell width.
-			cw := tableCellWidth(w-gutterWidth, m.table.numCols())
+			cw := m.tableCellTAWidth()
 			m.textareas[i].SetWidth(cw)
 		} else {
 			m.textareas[i].SetWidth(m.contentWidth(b))
@@ -560,8 +591,8 @@ func (m *Model) focusBlock(idx int) {
 	// Entering a table: init table state and load first cell.
 	if m.blocks[idx].Type == block.Table {
 		m.table = initTable(m.blocks[idx].Content)
-		cw := tableCellWidth(m.width-gutterWidth, m.table.numCols())
-		m.table.loadCell(&m.textareas[idx], cw)
+		cw := m.tableCellTAWidth()
+		m.table.loadCell(&m.textareas[idx], cw, false)
 		m.cursorCmd = m.textareas[idx].Focus()
 	}
 }
@@ -1208,8 +1239,8 @@ func (m *Model) applyPaletteSelection(bt block.BlockType) {
 		m.blocks[m.active].Content = content
 		m.textareas[m.active].SetValue(content)
 		m.table = initTable(content)
-		cw := tableCellWidth(m.width-gutterWidth, m.table.numCols())
-		m.table.loadCell(&m.textareas[m.active], cw)
+		cw := m.tableCellTAWidth()
+		m.table.loadCell(&m.textareas[m.active], cw, false)
 		m.cursorCmd = m.textareas[m.active].Focus()
 	}
 	m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount())
@@ -1670,8 +1701,8 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					// Re-init table state if returning to a table block.
 					if m.blocks[m.active].Type == block.Table {
 						m.table = initTable(m.blocks[m.active].Content)
-						cw := tableCellWidth(m.width-gutterWidth, m.table.numCols())
-						m.table.loadCell(&m.textareas[m.active], cw)
+						cw := m.tableCellTAWidth()
+						m.table.loadCell(&m.textareas[m.active], cw, false)
 						m.cursorCmd = m.textareas[m.active].Focus()
 					}
 				}
@@ -1798,13 +1829,16 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 
 		case "up":
-			// Table: move to cell above before block navigation.
+			// Table: move to cell above, preserving horizontal position.
 			if m.isAtFirstLine() && m.table != nil && m.table.row > 0 {
 				ta := &m.textareas[m.active]
-				cw := tableCellWidth(m.width-gutterWidth, m.table.numCols())
+				charOffset := ta.LineInfo().CharOffset
+				cw := m.tableCellTAWidth()
 				m.table.syncCell(*ta)
 				m.table.row--
-				m.table.loadCell(ta, cw)
+				m.table.loadCell(ta, cw, true)
+				li := ta.LineInfo()
+				ta.SetCursorColumn(li.StartColumn + charOffset)
 				m.cursorCmd = ta.Focus()
 				m.updateViewport()
 				return m, nil
@@ -1822,13 +1856,15 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case "down":
-			// Table: move to cell below before block navigation.
+			// Table: move to cell below, preserving horizontal position.
 			if m.isAtLastLine() && m.table != nil && m.table.row < len(m.table.cells)-1 {
 				ta := &m.textareas[m.active]
-				cw := tableCellWidth(m.width-gutterWidth, m.table.numCols())
+				charOffset := ta.LineInfo().CharOffset
+				cw := m.tableCellTAWidth()
 				m.table.syncCell(*ta)
 				m.table.row++
-				m.table.loadCell(ta, cw)
+				m.table.loadCell(ta, cw, false)
+				ta.SetCursorColumn(charOffset)
 				m.cursorCmd = ta.Focus()
 				m.updateViewport()
 				return m, nil
@@ -1995,16 +2031,17 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// boundary navigation. Everything else goes to the textarea.
 			if m.table != nil && m.blocks[m.active].Type == block.Table {
 				ta := &m.textareas[m.active]
-				cw := tableCellWidth(m.width-gutterWidth, m.table.numCols())
+				cw := m.tableCellTAWidth()
 
 				if keyMsg.Code == tea.KeyTab {
 					m.table.syncCell(*ta)
 					if keyMsg.Mod.Contains(tea.ModShift) {
 						m.table.prevCell()
+						m.table.loadCell(ta, cw, true)
 					} else {
 						m.table.nextCell()
+						m.table.loadCell(ta, cw, false)
 					}
-					m.table.loadCell(ta, cw)
 					m.cursorCmd = ta.Focus()
 					m.updateViewport()
 					return m, nil
@@ -2017,9 +2054,90 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						newRow := make([]string, m.table.numCols())
 						m.table.cells = append(m.table.cells, newRow)
 					}
-					m.table.loadCell(ta, cw)
+					m.table.loadCell(ta, cw, false)
 					m.cursorCmd = ta.Focus()
 					m.updateViewport()
+					return m, nil
+				}
+
+				// Left at position 0: move to previous cell.
+				if keyMsg.Code == tea.KeyLeft && !keyMsg.Mod.Contains(tea.ModAlt) {
+					if ta.Line() == 0 && ta.LineInfo().ColumnOffset == 0 && ta.LineInfo().RowOffset == 0 {
+						if m.table.row > 0 || m.table.col > 0 {
+							m.table.syncCell(*ta)
+							m.table.prevCell()
+							m.table.loadCell(ta, cw, true)
+							m.cursorCmd = ta.Focus()
+							m.updateViewport()
+							return m, nil
+						}
+					}
+				}
+
+				// Right at end of text: move to next cell.
+				if keyMsg.Code == tea.KeyRight && !keyMsg.Mod.Contains(tea.ModAlt) {
+					if m.isAtLastLine() {
+						li := ta.LineInfo()
+						lineLen := len([]rune(strings.Split(ta.Value(), "\n")[ta.Line()]))
+						atEnd := li.StartColumn+li.ColumnOffset >= lineLen
+						if atEnd && (m.table.row < len(m.table.cells)-1 || m.table.col < m.table.numCols()-1) {
+							m.table.syncCell(*ta)
+							m.table.nextCell()
+							m.table.loadCell(ta, cw, false)
+							m.cursorCmd = ta.Focus()
+							m.updateViewport()
+							return m, nil
+						}
+					}
+				}
+
+				// Alt+R: insert row below.
+				if keyMsg.Code == 'r' && keyMsg.Mod.Contains(tea.ModAlt) {
+					m.pushUndo()
+					m.table.syncCell(*ta)
+					m.table.addRow()
+					m.table.loadCell(ta, cw, false)
+					m.cursorCmd = ta.Focus()
+					m.updateViewport()
+					return m, nil
+				}
+
+				// Alt+C: insert column after.
+				if keyMsg.Code == 'c' && keyMsg.Mod.Contains(tea.ModAlt) {
+					m.pushUndo()
+					m.table.syncCell(*ta)
+					m.table.addCol()
+					cw = m.tableCellTAWidth() // recompute — column count changed
+					m.table.loadCell(ta, cw, false)
+					m.cursorCmd = ta.Focus()
+					m.resizeTextareas()
+					m.updateViewport()
+					return m, nil
+				}
+
+				// Alt+Backspace: delete current row (if more than one).
+				if keyMsg.Code == tea.KeyBackspace && keyMsg.Mod.Contains(tea.ModAlt) {
+					m.pushUndo()
+					m.table.syncCell(*ta)
+					if m.table.deleteRow() {
+						m.table.loadCell(ta, cw, false)
+						m.cursorCmd = ta.Focus()
+						m.updateViewport()
+					}
+					return m, nil
+				}
+
+				// Alt+D: delete current column (if more than one).
+				if keyMsg.Code == 'd' && keyMsg.Mod.Contains(tea.ModAlt) {
+					m.pushUndo()
+					m.table.syncCell(*ta)
+					if m.table.deleteCol() {
+						cw = m.tableCellTAWidth()
+						m.table.loadCell(ta, cw, false)
+						m.cursorCmd = ta.Focus()
+						m.resizeTextareas()
+						m.updateViewport()
+					}
 					return m, nil
 				}
 
@@ -2151,6 +2269,14 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			preState = m.captureState()
 		}
 
+		// Enforce correct width BEFORE the textarea processes the key,
+		// so cursor movement uses the right wrapping.
+		if m.table != nil && m.blocks[m.active].Type == block.Table {
+			cw := m.tableCellTAWidth()
+			m.textareas[m.active].SetWidth(cw)
+			m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount())
+		}
+
 		var cmd tea.Cmd
 		m.textareas[m.active], cmd = m.textareas[m.active].Update(msg)
 
@@ -2197,7 +2323,12 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Re-enforce width and recalculate height after every keystroke.
 		// This ensures the textarea re-wraps correctly after content changes
 		// (e.g. deleting a newline inserted via Ctrl+J).
-		m.textareas[m.active].SetWidth(m.contentWidth(m.blocks[m.active]))
+		if m.table != nil && m.blocks[m.active].Type == block.Table {
+			cw := m.tableCellTAWidth()
+			m.textareas[m.active].SetWidth(cw)
+		} else {
+			m.textareas[m.active].SetWidth(m.contentWidth(m.blocks[m.active]))
+		}
 		m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount())
 
 		m.updateViewport()
@@ -2644,6 +2775,9 @@ func (m Model) renderStatusBar() string {
 			hint = "click checkboxes to toggle!  [h]ide"
 		}
 		right = ": defs \u00B7 \u2303R edit \u00B7 Esc quit"
+	} else if m.table != nil && m.active >= 0 && m.active < len(m.blocks) && m.blocks[m.active].Type == block.Table {
+		hint = "\u2325R +row \u00B7 \u2325C +col \u00B7 \u2325\u232B del row \u00B7 \u2325D del col"
+		right = "/ blocks \u00B7 : defs \u00B7 \u2303G help \u00B7 Esc quit"
 	} else {
 		right = "/ blocks \u00B7 : defs \u00B7 \u2303G help \u00B7 Esc quit"
 	}

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -1810,10 +1810,6 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case "down":
-			// Table blocks handle their own Down navigation.
-			if m.table != nil && m.blocks[m.active].Type == block.Table {
-				break
-			}
 			if m.isAtLastLine() && m.active < len(m.textareas)-1 {
 				m.navigateDown()
 				m.updateViewport()
@@ -1871,10 +1867,6 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.scheduleStatusDismiss()
 
 		case "ctrl+u":
-			// Tables handle their own editing; skip block merge logic.
-			if m.table != nil && m.blocks[m.active].Type == block.Table {
-				break
-			}
 			ta := &m.textareas[m.active]
 			info := ta.LineInfo()
 			logicalCol := info.StartColumn + info.ColumnOffset
@@ -1976,32 +1968,28 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 
-			// Table-specific key handling.
+			// Table-specific key handling: only intercept Tab, Enter, and
+			// boundary navigation. Everything else goes to the textarea.
 			if m.table != nil && m.blocks[m.active].Type == block.Table {
 				ta := &m.textareas[m.active]
 				cw := tableCellWidth(m.width-gutterWidth, m.table.numCols())
 
-				switch {
-				case keyMsg.Code == tea.KeyTab && keyMsg.Mod.Contains(tea.ModShift):
-					// Shift+Tab: previous cell.
+				// Tab / Shift+Tab: cell navigation.
+				if keyMsg.Code == tea.KeyTab {
 					m.table.syncCell(*ta)
-					m.table.prevCell()
+					if keyMsg.Mod.Contains(tea.ModShift) {
+						m.table.prevCell()
+					} else {
+						m.table.nextCell()
+					}
 					m.table.loadCell(ta, cw)
 					m.cursorCmd = ta.Focus()
 					m.updateViewport()
 					return m, nil
+				}
 
-				case keyMsg.Code == tea.KeyTab:
-					// Tab: next cell.
-					m.table.syncCell(*ta)
-					m.table.nextCell()
-					m.table.loadCell(ta, cw)
-					m.cursorCmd = ta.Focus()
-					m.updateViewport()
-					return m, nil
-
-				case keyMsg.Code == tea.KeyEnter:
-					// Enter: move to cell below (same column), add row if needed.
+				// Enter: move to cell below.
+				if keyMsg.Code == tea.KeyEnter {
 					m.table.syncCell(*ta)
 					m.table.row++
 					if m.table.row >= len(m.table.cells) {
@@ -2012,68 +2000,57 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.cursorCmd = ta.Focus()
 					m.updateViewport()
 					return m, nil
+				}
 
-				case keyMsg.Code == tea.KeyBackspace:
-					// At position 0 in cell: no-op (don't merge blocks).
-					if ta.Line() == 0 && ta.LineInfo().ColumnOffset == 0 {
+				// Backspace at position 0: no-op (cells don't merge).
+				if keyMsg.Code == tea.KeyBackspace && ta.Line() == 0 && ta.LineInfo().ColumnOffset == 0 {
+					return m, nil
+				}
+
+				// Up at first line: move to cell above or leave table.
+				if keyMsg.Code == tea.KeyUp && m.isAtFirstLine() {
+					if m.table.row > 0 {
+						m.table.syncCell(*ta)
+						m.table.row--
+						m.table.loadCell(ta, cw)
+						m.cursorCmd = ta.Focus()
 						m.updateViewport()
 						return m, nil
 					}
-					// Otherwise let the textarea handle it normally below.
-
-				case keyMsg.String() == "up":
-					if m.isAtFirstLine() {
-						if m.table.row > 0 {
-							// Move to cell above.
-							m.table.syncCell(*ta)
-							m.table.row--
-							m.table.loadCell(ta, cw)
-							m.cursorCmd = ta.Focus()
-							m.updateViewport()
-							return m, nil
-						}
-						// At top row: navigate to previous block or insert paragraph.
-						if m.active > 0 {
-							m.navigateUp()
-							m.updateViewport()
-							return m, nil
-						}
-						// At block 0: insert paragraph above.
-						m.pushUndo()
-						m.insertBlockBefore(0, block.Block{Type: block.Paragraph})
+					if m.active > 0 {
+						m.navigateUp()
 						m.updateViewport()
 						return m, nil
 					}
+					m.pushUndo()
+					m.insertBlockBefore(0, block.Block{Type: block.Paragraph})
+					m.updateViewport()
+					return m, nil
+				}
 
-				case keyMsg.String() == "down":
-					if m.isAtLastLine() {
-						if m.table.row < len(m.table.cells)-1 {
-							// Move to cell below.
-							m.table.syncCell(*ta)
-							m.table.row++
-							m.table.loadCell(ta, cw)
-							m.cursorCmd = ta.Focus()
-							m.updateViewport()
-							return m, nil
-						}
-						// At bottom row: navigate to next block.
-						if m.active < len(m.textareas)-1 {
-							m.navigateDown()
-							m.updateViewport()
-							return m, nil
-						}
+				// Down at last line: move to cell below or leave table.
+				if keyMsg.Code == tea.KeyDown && m.isAtLastLine() {
+					if m.table.row < len(m.table.cells)-1 {
+						m.table.syncCell(*ta)
+						m.table.row++
+						m.table.loadCell(ta, cw)
+						m.cursorCmd = ta.Focus()
+						m.updateViewport()
+						return m, nil
+					}
+					if m.active < len(m.textareas)-1 {
+						m.navigateDown()
+						m.updateViewport()
+						return m, nil
 					}
 				}
 
-				// For all other keys, forward to the textarea.
-				var cmd tea.Cmd
-				m.textareas[m.active], cmd = m.textareas[m.active].Update(msg)
-
+				// Everything else: forward to the textarea as-is.
+				m.textareas[m.active], _ = m.textareas[m.active].Update(msg)
 				m.textareas[m.active].SetWidth(cw)
 				m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount())
-				m.cursorCmd = m.textareas[m.active].Focus()
 				m.updateViewport()
-				return m, cmd
+				return m, nil
 			}
 
 			// Handle Enter key: always split/create via handleEnter.

--- a/internal/editor/palette.go
+++ b/internal/editor/palette.go
@@ -38,6 +38,7 @@ func defaultPaletteItems() []paletteItem {
 		{Icon: "1.", Label: "Numbered List", Type: block.NumberedList},
 		{Icon: "\u2610", Label: "Checklist", Type: block.Checklist},
 		{Icon: "``", Label: "Code Block", Type: block.CodeBlock},
+		{Icon: "\u229e", Label: "Table", Type: block.Table},
 		{Icon: ">", Label: "Quote", Type: block.Quote},
 		{Icon: ":", Label: "Definition", Type: block.DefinitionList},
 		{Icon: "!", Label: "Callout", Type: block.Callout},

--- a/internal/editor/render.go
+++ b/internal/editor/render.go
@@ -423,6 +423,10 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 		}
 		rendered = strings.Join(result, "\n")
 
+	case block.Table:
+		// Table rendering is handled entirely by renderActiveTableFull.
+		return m.renderActiveTableFull(idx, b)
+
 	default:
 		rendered = taView
 	}
@@ -852,6 +856,13 @@ func renderInactiveBlock(b block.Block, content string, width int, wordWrap bool
 			Render(icon + wrapped)
 		rendered = pill
 
+	case block.Table:
+		tableWidth := width - gutterWidth
+		if tableWidth < 10 {
+			tableWidth = 10
+		}
+		rendered = renderTableGrid(content, tableWidth, th.Border, th.Blocks.Table.HeaderBold, wordWrap)
+
 	default:
 		rendered = wrapped
 	}
@@ -1055,6 +1066,9 @@ func renderViewBlock(b block.Block, content string, width int, wordWrap bool, bl
 			style = style.Underline(true)
 		}
 		rendered = style.Render(icon + wrapped)
+
+	case block.Table:
+		rendered = renderTableGrid(content, contentWidth, th.Border, th.Blocks.Table.HeaderBold, true)
 
 	default:
 		rendered = wrapped

--- a/internal/editor/table.go
+++ b/internal/editor/table.go
@@ -1,0 +1,414 @@
+package editor
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/textarea"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/oobagi/notebook-cli/internal/block"
+	"github.com/oobagi/notebook-cli/internal/format"
+	"github.com/oobagi/notebook-cli/internal/theme"
+)
+
+// tableState tracks the cell grid and active cell position for a Table block.
+type tableState struct {
+	cells  [][]string
+	aligns []string
+	row    int
+	col    int
+}
+
+// initTable parses table content into a tableState.
+func initTable(content string) *tableState {
+	cells, aligns := block.ParseTableCells(content)
+	if len(cells) == 0 {
+		cells = [][]string{{"", ""}, {"", ""}}
+		aligns = []string{"left", "left"}
+	}
+	return &tableState{cells: cells, aligns: aligns}
+}
+
+// syncCell writes the textarea's current value back to cells[row][col].
+func (ts *tableState) syncCell(ta textarea.Model) {
+	if ts.row < 0 || ts.row >= len(ts.cells) {
+		return
+	}
+	if ts.col < 0 || ts.col >= len(ts.cells[ts.row]) {
+		return
+	}
+	ts.cells[ts.row][ts.col] = ta.Value()
+}
+
+// loadCell sets the textarea's value to cells[row][col] and configures width.
+func (ts *tableState) loadCell(ta *textarea.Model, width int) {
+	val := ""
+	if ts.row >= 0 && ts.row < len(ts.cells) && ts.col >= 0 && ts.col < len(ts.cells[ts.row]) {
+		val = ts.cells[ts.row][ts.col]
+	}
+	ta.SetWidth(width)
+	ta.SetValue(val)
+	ta.SetHeight(ta.VisualLineCount())
+	ta.MoveToEnd()
+}
+
+// serialize converts cells back to pipe content.
+func (ts *tableState) serialize() string {
+	return block.SerializeTableCells(ts.cells, ts.aligns)
+}
+
+// numCols returns the column count.
+func (ts *tableState) numCols() int {
+	if len(ts.cells) == 0 {
+		return 0
+	}
+	return len(ts.cells[0])
+}
+
+// nextCell advances to the next cell. Returns true if a new row was added.
+func (ts *tableState) nextCell() bool {
+	nc := ts.numCols()
+	if nc == 0 {
+		return false
+	}
+	ts.col++
+	if ts.col >= nc {
+		ts.col = 0
+		ts.row++
+	}
+	if ts.row >= len(ts.cells) {
+		// Append new empty row.
+		newRow := make([]string, nc)
+		ts.cells = append(ts.cells, newRow)
+		return true
+	}
+	return false
+}
+
+// prevCell retreats to the previous cell.
+func (ts *tableState) prevCell() {
+	nc := ts.numCols()
+	if nc == 0 {
+		return
+	}
+	ts.col--
+	if ts.col < 0 {
+		ts.col = nc - 1
+		ts.row--
+	}
+	if ts.row < 0 {
+		ts.row = 0
+		ts.col = 0
+	}
+}
+
+// tableCellWidth computes the width for each cell column given available terminal width.
+// Layout: | pad content pad | pad content pad | ...
+// = (numCols+1) border chars + numCols * (2 padding + cellWidth)
+func tableCellWidth(totalWidth, numCols int) int {
+	if numCols <= 0 {
+		return 5
+	}
+	// totalWidth = (numCols+1)*1 + numCols*(2+cw)
+	// cw = (totalWidth - numCols - 1 - 2*numCols) / numCols
+	cw := (totalWidth - numCols - 1 - 2*numCols) / numCols
+	if cw < 5 {
+		cw = 5
+	}
+	return cw
+}
+
+// renderActiveTable renders the table grid with one cell showing the textarea cursor.
+func renderActiveTable(m Model, idx int, ta textarea.Model, width int, wordWrap bool) string {
+	ts := m.table
+	if ts == nil {
+		return ""
+	}
+	th := theme.Current()
+	numCols := ts.numCols()
+	if numCols == 0 {
+		return ""
+	}
+
+	// Content width for the table area (no prefix for tables).
+	tableWidth := width - gutterWidth
+	if tableWidth < 10 {
+		tableWidth = 10
+	}
+	cw := tableCellWidth(tableWidth, numCols)
+
+	bc := lipgloss.NewStyle().Foreground(lipgloss.Color(th.Border))
+
+	// Get cursor info from the textarea for the active cell.
+	cursorRawRow := ta.Line()
+	li := ta.LineInfo()
+	cursorColInWrap := li.ColumnOffset
+	cursorWrapRow := li.RowOffset
+
+	var gridRows [][]cellRender
+	for r, row := range ts.cells {
+		var cellRenders []cellRender
+		for c, cell := range row {
+			if r == ts.row && c == ts.col {
+				// Active cell: render with cursor.
+				cr := renderCellWithCursor(ta, cell, cw, cursorRawRow, cursorColInWrap, cursorWrapRow, r == 0 && th.Blocks.Table.HeaderBold)
+				cellRenders = append(cellRenders, cr)
+			} else {
+				// Inactive cell: wrap and apply inline markdown.
+				cr := renderStaticCell(cell, cw, r == 0 && th.Blocks.Table.HeaderBold)
+				cellRenders = append(cellRenders, cr)
+			}
+		}
+		gridRows = append(gridRows, cellRenders)
+	}
+
+	return buildGrid(gridRows, cw, numCols, tableWidth, bc, ts.row, ts.col)
+}
+
+// cellRender holds pre-rendered cell lines for grid assembly.
+type cellRender struct {
+	lines []string
+}
+
+// renderCellWithCursor renders the active cell with the textarea cursor.
+func renderCellWithCursor(ta textarea.Model, _ string, cw int, cursorRawRow, cursorColInWrap, cursorWrapRow int, bold bool) cellRender {
+	content := ta.Value()
+	rawLines := strings.Split(content, "\n")
+	boldStyle := lipgloss.NewStyle()
+	if bold {
+		boldStyle = boldStyle.Bold(true)
+	}
+
+	var visualLines []string
+	for rawIdx, raw := range rawLines {
+		segs := textarea.Wrap([]rune(raw), cw)
+		if len(segs) == 0 {
+			segs = [][]rune{{}}
+		}
+		for wIdx, seg := range segs {
+			line := strings.TrimSuffix(string(seg), " ")
+
+			if rawIdx == cursorRawRow && wIdx == cursorWrapRow {
+				runes := []rune(line)
+				col := cursorColInWrap
+				if col > len(runes) {
+					col = len(runes)
+				}
+				before := string(runes[:col])
+				curChar := " "
+				after := ""
+				if col < len(runes) {
+					curChar = string(runes[col : col+1])
+					after = string(runes[col+1:])
+				}
+				ta.CursorSetChar(curChar)
+				if bold {
+					line = boldStyle.Render(before) + ta.CursorView() + boldStyle.Render(after)
+				} else {
+					line = before + ta.CursorView() + after
+				}
+			} else if bold {
+				line = boldStyle.Render(line)
+			}
+
+			// Pad to cw.
+			if pad := cw - lipgloss.Width(line); pad > 0 {
+				line += strings.Repeat(" ", pad)
+			}
+			visualLines = append(visualLines, line)
+		}
+	}
+
+	return cellRender{lines: visualLines}
+}
+
+// renderStaticCell renders an inactive cell with wrapping and inline markdown.
+func renderStaticCell(content string, cw int, bold bool) cellRender {
+	wrapped := wrapText(content, cw)
+	wrapped = format.RenderInlineMarkdown(wrapped)
+
+	boldStyle := lipgloss.NewStyle()
+	if bold {
+		boldStyle = boldStyle.Bold(true)
+	}
+
+	lines := strings.Split(wrapped, "\n")
+	for i, l := range lines {
+		if bold {
+			l = boldStyle.Render(l)
+		}
+		if pad := cw - lipgloss.Width(l); pad > 0 {
+			l += strings.Repeat(" ", pad)
+		}
+		lines[i] = l
+	}
+
+	return cellRender{lines: lines}
+}
+
+// buildGrid assembles the visual grid from cell renders.
+func buildGrid(gridRows [][]cellRender, cw, numCols, tableWidth int, bc lipgloss.Style, activeRow, activeCol int) string {
+	pipe := bc.Render("\u2502")
+
+	// Build border lines.
+	cellDash := strings.Repeat("\u2500", cw+2) // +2 for padding spaces
+	topBorder := bc.Render("\u256D" + strings.Join(repeatStr(cellDash, numCols), "\u252C") + "\u256E")
+	midBorder := bc.Render("\u251C" + strings.Join(repeatStr(cellDash, numCols), "\u253C") + "\u2524")
+	botBorder := bc.Render("\u2570" + strings.Join(repeatStr(cellDash, numCols), "\u2534") + "\u256F")
+
+	var out []string
+	out = append(out, topBorder)
+
+	for r, rowCells := range gridRows {
+		if r > 0 {
+			out = append(out, midBorder)
+		}
+
+		// Determine max visual lines in this row.
+		maxLines := 1
+		for _, cr := range rowCells {
+			if len(cr.lines) > maxLines {
+				maxLines = len(cr.lines)
+			}
+		}
+
+		// Pad cells with fewer lines.
+		for c := range rowCells {
+			for len(rowCells[c].lines) < maxLines {
+				rowCells[c].lines = append(rowCells[c].lines, strings.Repeat(" ", cw))
+			}
+		}
+
+		// Build each visual line of this row.
+		for lineIdx := 0; lineIdx < maxLines; lineIdx++ {
+			var parts []string
+			for _, cr := range rowCells {
+				parts = append(parts, " "+cr.lines[lineIdx]+" ")
+			}
+			out = append(out, pipe+strings.Join(parts, pipe)+pipe)
+		}
+	}
+
+	out = append(out, botBorder)
+	return strings.Join(out, "\n")
+}
+
+// repeatStr returns a slice of n copies of s.
+func repeatStr(s string, n int) []string {
+	result := make([]string, n)
+	for i := range result {
+		result[i] = s
+	}
+	return result
+}
+
+// renderTableGrid renders a static table grid (for inactive blocks and view mode).
+func renderTableGrid(content string, width int, borderColor string, headerBold bool, wordWrap bool) string {
+	cells, _ := block.ParseTableCells(content)
+	if len(cells) == 0 {
+		return ""
+	}
+
+	numCols := 0
+	for _, row := range cells {
+		if len(row) > numCols {
+			numCols = len(row)
+		}
+	}
+	if numCols == 0 {
+		return ""
+	}
+
+	var cw int
+	if wordWrap {
+		cw = tableCellWidth(width, numCols)
+	} else {
+		// Natural content-width columns.
+		cw = 3
+		for _, row := range cells {
+			for _, cell := range row {
+				if len(cell) > cw {
+					cw = len(cell)
+				}
+			}
+		}
+	}
+
+	bc := lipgloss.NewStyle().Foreground(lipgloss.Color(borderColor))
+
+	var gridRows [][]cellRender
+	for r, row := range cells {
+		var cellRenders []cellRender
+		for _, cell := range row {
+			cr := renderStaticCell(cell, cw, r == 0 && headerBold)
+			cellRenders = append(cellRenders, cr)
+		}
+		// Normalize column count.
+		for len(cellRenders) < numCols {
+			cellRenders = append(cellRenders, renderStaticCell("", cw, false))
+		}
+		gridRows = append(gridRows, cellRenders)
+	}
+
+	return buildGrid(gridRows, cw, numCols, width, bc, -1, -1)
+}
+
+// renderActiveTableFull renders the active table block with gutter and scroll handling.
+func (m Model) renderActiveTableFull(idx int, b block.Block) string {
+	if idx < 0 || idx >= len(m.textareas) || m.table == nil {
+		return ""
+	}
+
+	ta := m.textareas[idx]
+	th := theme.Current()
+
+	tableWidth := m.width - gutterWidth
+	if tableWidth < 10 {
+		tableWidth = 10
+	}
+
+	rendered := renderActiveTable(m, idx, ta, m.width, m.wordWrap)
+
+	// Build gutter with block type label.
+	label := fmt.Sprintf("%2s", b.Type.Short())
+	accentStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(th.Accent))
+	sepStr := accentStyle.Render("\u2502")
+	labelStr := accentStyle.Render(label)
+	blankLabel := accentStyle.Render("  ")
+
+	lines := strings.Split(rendered, "\n")
+	for i, l := range lines {
+		if i == 0 {
+			lines[i] = labelStr + " " + sepStr + " " + l
+		} else {
+			lines[i] = blankLabel + " " + sepStr + " " + l
+		}
+	}
+
+	// Scroll/truncate for no-wrap mode.
+	if !m.wordWrap {
+		// Compute cursor column: gutter + border + padding + cell cursor position.
+		cursorCol := gutterWidth + 1 + 1 + ta.LineInfo().ColumnOffset
+		// Add offset for columns before the active one.
+		cw := tableCellWidth(tableWidth, m.table.numCols())
+		cursorCol += m.table.col * (cw + 3) // each col: pad + content + pad + border
+
+		// Find which line has the cursor.
+		// The cursor is in the active row. Account for top border (1 line)
+		// + rows before active * (max_lines_per_row + 1 separator).
+		// For simplicity, don't try to compute exact cursor line for scroll;
+		// just truncate all lines.
+		for i, l := range lines {
+			lines[i] = scrollOrTruncate(l, m.width, cursorCol, false)
+		}
+	} else {
+		for i, l := range lines {
+			if lipgloss.Width(l) > m.width {
+				lines[i] = ansi.Truncate(l, m.width, "")
+			}
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}

--- a/internal/editor/table.go
+++ b/internal/editor/table.go
@@ -42,7 +42,8 @@ func (ts *tableState) syncCell(ta textarea.Model) {
 }
 
 // loadCell sets the textarea's value to cells[row][col] and configures width.
-func (ts *tableState) loadCell(ta *textarea.Model, width int) {
+// If toEnd is true the cursor is placed at the end; otherwise at the beginning.
+func (ts *tableState) loadCell(ta *textarea.Model, width int, toEnd bool) {
 	val := ""
 	if ts.row >= 0 && ts.row < len(ts.cells) && ts.col >= 0 && ts.col < len(ts.cells[ts.row]) {
 		val = ts.cells[ts.row][ts.col]
@@ -50,7 +51,11 @@ func (ts *tableState) loadCell(ta *textarea.Model, width int) {
 	ta.SetWidth(width)
 	ta.SetValue(val)
 	ta.SetHeight(ta.VisualLineCount())
-	ta.MoveToEnd()
+	if toEnd {
+		ta.MoveToEnd()
+	} else {
+		ta.MoveToBegin()
+	}
 }
 
 // serialize converts cells back to pipe content.
@@ -103,20 +108,103 @@ func (ts *tableState) prevCell() {
 	}
 }
 
-// tableCellWidth computes the width for each cell column given available terminal width.
-// Layout: | pad content pad | pad content pad | ...
-// = (numCols+1) border chars + numCols * (2 padding + cellWidth)
+// addRow inserts an empty row after the current row and moves to it.
+func (ts *tableState) addRow() {
+	nc := ts.numCols()
+	if nc == 0 {
+		return
+	}
+	newRow := make([]string, nc)
+	insertAt := ts.row + 1
+	ts.cells = append(ts.cells[:insertAt], append([][]string{newRow}, ts.cells[insertAt:]...)...)
+	ts.row = insertAt
+	ts.col = 0
+}
+
+// addCol inserts an empty column after the current column and moves to it.
+func (ts *tableState) addCol() {
+	insertAt := ts.col + 1
+	for i := range ts.cells {
+		row := ts.cells[i]
+		newRow := make([]string, len(row)+1)
+		copy(newRow, row[:insertAt])
+		newRow[insertAt] = ""
+		copy(newRow[insertAt+1:], row[insertAt:])
+		ts.cells[i] = newRow
+	}
+	ts.aligns = append(ts.aligns[:insertAt], append([]string{"left"}, ts.aligns[insertAt:]...)...)
+	ts.col = insertAt
+}
+
+// deleteRow removes the current row. Returns false if only one data row remains.
+func (ts *tableState) deleteRow() bool {
+	if len(ts.cells) <= 1 {
+		return false
+	}
+	ts.cells = append(ts.cells[:ts.row], ts.cells[ts.row+1:]...)
+	if ts.row >= len(ts.cells) {
+		ts.row = len(ts.cells) - 1
+	}
+	return true
+}
+
+// deleteCol removes the current column. Returns false if only one column remains.
+func (ts *tableState) deleteCol() bool {
+	nc := ts.numCols()
+	if nc <= 1 {
+		return false
+	}
+	for i := range ts.cells {
+		ts.cells[i] = append(ts.cells[i][:ts.col], ts.cells[i][ts.col+1:]...)
+	}
+	if ts.col < len(ts.aligns) {
+		ts.aligns = append(ts.aligns[:ts.col], ts.aligns[ts.col+1:]...)
+	}
+	if ts.col >= ts.numCols() {
+		ts.col = ts.numCols() - 1
+	}
+	return true
+}
+
+// tableCellWidth computes the base content width for each cell column.
+// This is the minimum width; some columns may be 1 wider to fill the
+// available space (see tableCellWidths).
 func tableCellWidth(totalWidth, numCols int) int {
 	if numCols <= 0 {
 		return 5
 	}
-	// totalWidth = (numCols+1)*1 + numCols*(2+cw)
-	// cw = (totalWidth - numCols - 1 - 2*numCols) / numCols
-	cw := (totalWidth - numCols - 1 - 2*numCols) / numCols
+	avail := totalWidth - numCols - 1 - 2*numCols
+	cw := avail / numCols
 	if cw < 5 {
 		cw = 5
 	}
 	return cw
+}
+
+// tableCellWidths returns per-column widths that exactly fill totalWidth.
+// The first `remainder` columns are 1 wider than the rest so the table
+// grid spans the full available width without gaps.
+func tableCellWidths(totalWidth, numCols int) []int {
+	if numCols <= 0 {
+		return nil
+	}
+	avail := totalWidth - numCols - 1 - 2*numCols
+	base := avail / numCols
+	if base < 5 {
+		base = 5
+	}
+	rem := avail - base*numCols
+	if rem < 0 {
+		rem = 0
+	}
+	widths := make([]int, numCols)
+	for i := range widths {
+		widths[i] = base
+		if i < rem {
+			widths[i]++
+		}
+	}
+	return widths
 }
 
 // renderActiveTable renders the table grid with one cell showing the textarea cursor.
@@ -136,7 +224,8 @@ func renderActiveTable(m Model, idx int, ta textarea.Model, width int, wordWrap 
 	if tableWidth < 10 {
 		tableWidth = 10
 	}
-	cw := tableCellWidth(tableWidth, numCols)
+	colWidths := tableCellWidths(tableWidth, numCols)
+	cw := tableCellWidth(tableWidth, numCols) // base width for textarea
 
 	bc := lipgloss.NewStyle().Foreground(lipgloss.Color(th.Border))
 
@@ -150,20 +239,22 @@ func renderActiveTable(m Model, idx int, ta textarea.Model, width int, wordWrap 
 	for r, row := range ts.cells {
 		var cellRenders []cellRender
 		for c, cell := range row {
+			cellCW := cw
+			if c < len(colWidths) {
+				cellCW = colWidths[c]
+			}
 			if r == ts.row && c == ts.col {
-				// Active cell: render with cursor.
-				cr := renderCellWithCursor(ta, cell, cw, cursorRawRow, cursorColInWrap, cursorWrapRow, r == 0 && th.Blocks.Table.HeaderBold)
+				cr := renderCellWithCursor(ta, cell, cellCW, cursorRawRow, cursorColInWrap, cursorWrapRow, r == 0 && th.Blocks.Table.HeaderBold, wordWrap)
 				cellRenders = append(cellRenders, cr)
 			} else {
-				// Inactive cell: wrap and apply inline markdown.
-				cr := renderStaticCell(cell, cw, r == 0 && th.Blocks.Table.HeaderBold)
+				cr := renderStaticCell(cell, cellCW, r == 0 && th.Blocks.Table.HeaderBold, wordWrap)
 				cellRenders = append(cellRenders, cr)
 			}
 		}
 		gridRows = append(gridRows, cellRenders)
 	}
 
-	return buildGrid(gridRows, cw, numCols, tableWidth, bc, ts.row, ts.col)
+	return buildGrid(gridRows, colWidths, numCols, tableWidth, bc, ts.row, ts.col)
 }
 
 // cellRender holds pre-rendered cell lines for grid assembly.
@@ -172,7 +263,7 @@ type cellRender struct {
 }
 
 // renderCellWithCursor renders the active cell with the textarea cursor.
-func renderCellWithCursor(ta textarea.Model, _ string, cw int, cursorRawRow, cursorColInWrap, cursorWrapRow int, bold bool) cellRender {
+func renderCellWithCursor(ta textarea.Model, _ string, cw int, cursorRawRow, cursorColInWrap, cursorWrapRow int, bold bool, wordWrap bool) cellRender {
 	content := ta.Value()
 	rawLines := strings.Split(content, "\n")
 	boldStyle := lipgloss.NewStyle()
@@ -180,6 +271,50 @@ func renderCellWithCursor(ta textarea.Model, _ string, cw int, cursorRawRow, cur
 		boldStyle = boldStyle.Bold(true)
 	}
 
+	if !wordWrap {
+		// No-wrap: one visual line per raw line, scrolled to cursor.
+		var visualLines []string
+		for rawIdx, raw := range rawLines {
+			line := raw
+			isCursorLine := rawIdx == cursorRawRow
+
+			if isCursorLine {
+				runes := []rune(line)
+				col := cursorColInWrap
+				if col > len(runes) {
+					col = len(runes)
+				}
+				before := string(runes[:col])
+				curChar := " "
+				after := ""
+				if col < len(runes) {
+					curChar = string(runes[col : col+1])
+					after = string(runes[col+1:])
+				}
+				ta.CursorSetChar(curChar)
+				if bold {
+					line = boldStyle.Render(before) + ta.CursorView() + boldStyle.Render(after)
+				} else {
+					line = before + ta.CursorView() + after
+				}
+				line = scrollOrTruncate(line, cw, col, true)
+			} else {
+				if bold {
+					line = boldStyle.Render(line)
+				}
+				line = scrollOrTruncate(line, cw, 0, false)
+			}
+
+			// Pad to cw after truncation.
+			if pad := cw - lipgloss.Width(line); pad > 0 {
+				line += strings.Repeat(" ", pad)
+			}
+			visualLines = append(visualLines, line)
+		}
+		return cellRender{lines: visualLines}
+	}
+
+	// Word-wrap: wrap text within the cell.
 	var visualLines []string
 	for rawIdx, raw := range rawLines {
 		segs := textarea.Wrap([]rune(raw), cw)
@@ -224,19 +359,27 @@ func renderCellWithCursor(ta textarea.Model, _ string, cw int, cursorRawRow, cur
 }
 
 // renderStaticCell renders an inactive cell with wrapping and inline markdown.
-func renderStaticCell(content string, cw int, bold bool) cellRender {
-	wrapped := wrapText(content, cw)
-	wrapped = format.RenderInlineMarkdown(wrapped)
+func renderStaticCell(content string, cw int, bold bool, wordWrap bool) cellRender {
+	var rendered string
+	if wordWrap {
+		rendered = wrapText(content, cw)
+	} else {
+		rendered = content
+	}
+	rendered = format.RenderInlineMarkdown(rendered)
 
 	boldStyle := lipgloss.NewStyle()
 	if bold {
 		boldStyle = boldStyle.Bold(true)
 	}
 
-	lines := strings.Split(wrapped, "\n")
+	lines := strings.Split(rendered, "\n")
 	for i, l := range lines {
 		if bold {
 			l = boldStyle.Render(l)
+		}
+		if !wordWrap {
+			l = scrollOrTruncate(l, cw, 0, false)
 		}
 		if pad := cw - lipgloss.Width(l); pad > 0 {
 			l += strings.Repeat(" ", pad)
@@ -248,14 +391,17 @@ func renderStaticCell(content string, cw int, bold bool) cellRender {
 }
 
 // buildGrid assembles the visual grid from cell renders.
-func buildGrid(gridRows [][]cellRender, cw, numCols, tableWidth int, bc lipgloss.Style, activeRow, activeCol int) string {
+func buildGrid(gridRows [][]cellRender, colWidths []int, numCols, tableWidth int, bc lipgloss.Style, activeRow, activeCol int) string {
 	pipe := bc.Render("\u2502")
 
-	// Build border lines.
-	cellDash := strings.Repeat("\u2500", cw+2) // +2 for padding spaces
-	topBorder := bc.Render("\u256D" + strings.Join(repeatStr(cellDash, numCols), "\u252C") + "\u256E")
-	midBorder := bc.Render("\u251C" + strings.Join(repeatStr(cellDash, numCols), "\u253C") + "\u2524")
-	botBorder := bc.Render("\u2570" + strings.Join(repeatStr(cellDash, numCols), "\u2534") + "\u256F")
+	// Build border lines with per-column widths.
+	var dashes []string
+	for _, w := range colWidths {
+		dashes = append(dashes, strings.Repeat("\u2500", w+2))
+	}
+	topBorder := bc.Render("\u256D" + strings.Join(dashes, "\u252C") + "\u256E")
+	midBorder := bc.Render("\u251C" + strings.Join(dashes, "\u253C") + "\u2524")
+	botBorder := bc.Render("\u2570" + strings.Join(dashes, "\u2534") + "\u256F")
 
 	var out []string
 	out = append(out, topBorder)
@@ -273,10 +419,14 @@ func buildGrid(gridRows [][]cellRender, cw, numCols, tableWidth int, bc lipgloss
 			}
 		}
 
-		// Pad cells with fewer lines.
+		// Pad cells with fewer lines using per-column widths.
 		for c := range rowCells {
+			w := colWidths[0]
+			if c < len(colWidths) {
+				w = colWidths[c]
+			}
 			for len(rowCells[c].lines) < maxLines {
-				rowCells[c].lines = append(rowCells[c].lines, strings.Repeat(" ", cw))
+				rowCells[c].lines = append(rowCells[c].lines, strings.Repeat(" ", w))
 			}
 		}
 
@@ -320,38 +470,33 @@ func renderTableGrid(content string, width int, borderColor string, headerBold b
 		return ""
 	}
 
-	var cw int
-	if wordWrap {
-		cw = tableCellWidth(width, numCols)
-	} else {
-		// Natural content-width columns.
-		cw = 3
-		for _, row := range cells {
-			for _, cell := range row {
-				if len(cell) > cw {
-					cw = len(cell)
-				}
-			}
-		}
-	}
+	colWidths := tableCellWidths(width, numCols)
 
 	bc := lipgloss.NewStyle().Foreground(lipgloss.Color(borderColor))
 
 	var gridRows [][]cellRender
 	for r, row := range cells {
 		var cellRenders []cellRender
-		for _, cell := range row {
-			cr := renderStaticCell(cell, cw, r == 0 && headerBold)
+		for c, cell := range row {
+			cellCW := colWidths[0]
+			if c < len(colWidths) {
+				cellCW = colWidths[c]
+			}
+			cr := renderStaticCell(cell, cellCW, r == 0 && headerBold, wordWrap)
 			cellRenders = append(cellRenders, cr)
 		}
 		// Normalize column count.
-		for len(cellRenders) < numCols {
-			cellRenders = append(cellRenders, renderStaticCell("", cw, false))
+		for c := len(cellRenders); c < numCols; c++ {
+			cellCW := colWidths[0]
+			if c < len(colWidths) {
+				cellCW = colWidths[c]
+			}
+			cellRenders = append(cellRenders, renderStaticCell("", cellCW, false, wordWrap))
 		}
 		gridRows = append(gridRows, cellRenders)
 	}
 
-	return buildGrid(gridRows, cw, numCols, width, bc, -1, -1)
+	return buildGrid(gridRows, colWidths, numCols, width, bc, -1, -1)
 }
 
 // renderActiveTableFull renders the active table block with gutter and scroll handling.
@@ -391,8 +536,10 @@ func (m Model) renderActiveTableFull(idx int, b block.Block) string {
 		// Compute cursor column: gutter + border + padding + cell cursor position.
 		cursorCol := gutterWidth + 1 + 1 + ta.LineInfo().ColumnOffset
 		// Add offset for columns before the active one.
-		cw := tableCellWidth(tableWidth, m.table.numCols())
-		cursorCol += m.table.col * (cw + 3) // each col: pad + content + pad + border
+		colWidths := tableCellWidths(tableWidth, m.table.numCols())
+		for c := 0; c < m.table.col && c < len(colWidths); c++ {
+			cursorCol += colWidths[c] + 3 // content + pad + pad + border
+		}
 
 		// Find which line has the cursor.
 		// The cursor is in the active row. Account for top border (1 line)

--- a/internal/editor/undo.go
+++ b/internal/editor/undo.go
@@ -112,8 +112,8 @@ func (m *Model) restoreState(state editorState) {
 	// If active block is a Table, init table state.
 	if active < len(m.blocks) && m.blocks[active].Type == block.Table {
 		m.table = initTable(m.blocks[active].Content)
-		cw := tableCellWidth(m.width-gutterWidth, m.table.numCols())
-		m.table.loadCell(&m.textareas[active], cw)
+		cw := m.tableCellTAWidth()
+		m.table.loadCell(&m.textareas[active], cw, false)
 		m.cursorCmd = m.textareas[active].Focus()
 	}
 }

--- a/internal/editor/undo.go
+++ b/internal/editor/undo.go
@@ -54,7 +54,13 @@ func (m *Model) captureState() editorState {
 	blocks := make([]block.Block, len(m.blocks))
 	copy(blocks, m.blocks)
 	if m.active >= 0 && m.active < len(m.textareas) {
-		blocks[m.active].Content = m.textareas[m.active].Value()
+		if m.table != nil && m.blocks[m.active].Type == block.Table {
+			ts := *m.table
+			ts.syncCell(m.textareas[m.active])
+			blocks[m.active].Content = ts.serialize()
+		} else {
+			blocks[m.active].Content = m.textareas[m.active].Value()
+		}
 	}
 	return editorState{
 		blocks: blocks,
@@ -100,7 +106,16 @@ func (m *Model) restoreState(state editorState) {
 	// (resizeTextareas respects wordWrap and sets correct viewport size).
 	m.palette.close()
 	m.undoDirty = false
+	m.table = nil
 	m.resizeTextareas()
+
+	// If active block is a Table, init table state.
+	if active < len(m.blocks) && m.blocks[active].Type == block.Table {
+		m.table = initTable(m.blocks[active].Content)
+		cw := tableCellWidth(m.width-gutterWidth, m.table.numCols())
+		m.table.loadCell(&m.textareas[active], cw)
+		m.cursorCmd = m.textareas[active].Focus()
+	}
 }
 
 // performUndo restores the previous state. Returns true if undo was performed.
@@ -110,7 +125,12 @@ func (m *Model) performUndo() bool {
 	}
 	// Flush any pending dirty content before capturing current state for redo.
 	if m.active >= 0 && m.active < len(m.textareas) {
-		m.blocks[m.active].Content = m.textareas[m.active].Value()
+		if m.table != nil && m.blocks[m.active].Type == block.Table {
+			m.table.syncCell(m.textareas[m.active])
+			m.blocks[m.active].Content = m.table.serialize()
+		} else {
+			m.blocks[m.active].Content = m.textareas[m.active].Value()
+		}
 	}
 	m.redo.push(m.captureState())
 	state, _ := m.undo.pop()
@@ -124,7 +144,12 @@ func (m *Model) performRedo() bool {
 		return false
 	}
 	if m.active >= 0 && m.active < len(m.textareas) {
-		m.blocks[m.active].Content = m.textareas[m.active].Value()
+		if m.table != nil && m.blocks[m.active].Type == block.Table {
+			m.table.syncCell(m.textareas[m.active])
+			m.blocks[m.active].Content = m.table.serialize()
+		} else {
+			m.blocks[m.active].Content = m.textareas[m.active].Value()
+		}
 	}
 	m.undo.push(m.captureState())
 	state, _ := m.redo.pop()

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -113,6 +113,11 @@ type EmbedStyle struct {
 	Color string // hex; "" means theme.Accent
 }
 
+// TableStyle controls table rendering.
+type TableStyle struct {
+	HeaderBold bool // whether header row is rendered bold
+}
+
 // BlockStyles groups all per-block-type formatting.
 type BlockStyles struct {
 	Heading1   HeadingStyle
@@ -127,6 +132,7 @@ type BlockStyles struct {
 	Divider    DividerStyle
 	Definition DefinitionStyle
 	Embed      EmbedStyle
+	Table      TableStyle
 }
 
 // DefaultBlockStyles returns the baseline block styles that match the original
@@ -158,6 +164,7 @@ func DefaultBlockStyles() BlockStyles {
 		Divider:    DividerStyle{Char: "\u2500", MaxWidth: 40},
 		Definition: DefinitionStyle{Marker: "  : ", TermBold: true},
 		Embed:      EmbedStyle{Icon: "\u2197 "},
+		Table:      TableStyle{HeaderBold: true},
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Table block type** — GFM pipe-delimited tables with full parse/serialize round-trip and alignment marker support
- **Cell editing** — single textarea swaps between cells; Tab/Shift+Tab navigate, Enter moves down, arrow keys cross cell boundaries
- **Row/column ops** — Alt+R add row, Alt+C add col, Alt+Backspace delete row, Alt+D delete col
- **No-wrap mode** — cells use `scrollOrTruncate` with `← →` indicators, matching the rest of the app
- **Cursor fixes** — `setCursorLineRelative` overshoot on hard-broken wrapped segments fixed (removed `trailingSpace` constant); charOffset preserved across row navigation
- **Per-column widths** — integer division remainder distributed across first N columns so table always fills available width
- **Undo/redo** — table state captured via serialization, properly restored including cell position
- **Footer hint** — shows table-specific keybinds when editing a table cell

## Test plan
- [ ] Create table via `/` → Table, verify 2x2 default template
- [ ] Tab/Shift+Tab navigates between cells, wraps rows
- [ ] Enter moves to cell below, auto-adds row at bottom
- [ ] Up/Down arrows cross cell boundaries, preserve horizontal cursor position
- [ ] Alt+R/C adds rows/columns, Alt+Backspace/D deletes them
- [ ] Toggle word wrap — cells use scroll/truncate in no-wrap mode
- [ ] Undo/redo works across cell edits and row/col operations
- [ ] Save and reopen — table content preserved with alignment markers
- [ ] Adding/removing columns doesn't change total table width
- [ ] Word-wrapped text in narrow cells: cursor tracks correctly on up/down

🤖 Generated with [Claude Code](https://claude.com/claude-code)