### PR TITLE
release: v1.2.1 — unified block behavior, input controls, placeholders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Terminal-native note manager with a block-based editor supporting 14 block types
 ```bash
 go install ./cmd/notebook/    # Install as "notebook" binary
 go run ./cmd/notebook/        # Run from source
-go test ./...                 # Test (650+ tests across 14 packages)
+go test ./...                 # Test (649 tests across 13 packages)
 go vet ./...                  # Lint
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.3.0] - 2026-04-09
+## [1.2.1] - 2026-04-09
 
 ### Added
 - Placeholder text for empty blocks: callout ("Empty callout"), definition ("Term" / "Definition"), code block ("language"), and embed ("Link or note path") now show placeholder hints in edit, inactive, and view modes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.3.0] - 2026-04-09
+
+### Added
+- Placeholder text for empty blocks: callout ("Empty callout"), definition ("Term" / "Definition"), code block ("language"), and embed ("Link or note path") now show placeholder hints in edit, inactive, and view modes.
+- Keyboard controls for browser inputs: word jump (Alt+Left/Right), word delete (Alt+Backspace), line start/end (Home/End, Ctrl+A/E), and line delete (Ctrl+U/K) in search, rename, settings, and picker inputs.
+- Picker inputs support Alt+Backspace (delete word) and Ctrl+U (clear filter).
+
+### Changed
+- **Unified empty-block behavior**: Enter on an empty code block, quote, callout, or embed now converts it to a paragraph (previously inserted a newline or did nothing).
+- **Unified Backspace at position 0**: any non-paragraph block type converts to paragraph on Backspace (unwrap), matching list item behavior. Headings, code blocks, quotes, callouts, embeds, and definitions all behave consistently. A second Backspace merges or deletes the paragraph.
+- Code block language cursor and all placeholder cursors use plain reverse styling instead of accent color.
+- Default `hide_checked` setting changed from `true` to `false`.
+- Table headers no longer use forced bold styling or "Header 1" / "Header 2" default text.
+- Definition list Enter on term line moves cursor to existing definition line instead of inserting a duplicate.
+- Code block cursor starts on the language line when created via palette.
+- Navigating up into a table places the cursor at the last data cell instead of the top-left.
+
+### Fixed
+- Browser input fields (search, filter, rename, settings, palette) now support standard cursor controls instead of character-by-character only.
+- Code block Backspace at position 0 no longer merges newline content into the previous block.
+- Empty embed blocks can now be dismissed with Enter (converts to paragraph).
+
+## [1.2.0] - 2026-04-07
+
+### Added
+- Table block type with cell editing, per-column widths, row/column operations.
+- Callout block type with five admonition variants (Note, Tip, Important, Warning, Caution).
+- Definition list block type with term/definition pairs and lookup palette.
+- Embed block type for cross-referencing notes inline.
+- Ctrl+X as universal interact/activate key.
+- Large ASCII-art headings in view mode.
+- Directory browser mode for filesystem browsing with split-pane preview.
+- Block type transformation via palette on non-empty blocks.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ Config lives at `~/.config/notebook/config.toml`. Set values with `notebook conf
 | `editor` | built-in | External editor command (leave empty for built-in) |
 | `theme` | `dark` | Theme name (see `notebook theme` for options) |
 | `date_format` | `relative` | How dates are displayed |
+| `hide_checked` | `false` | Sort checked items to bottom of lists |
+| `cascade_checks` | `true` | Toggle parent/child checklists together |
+| `show_preview` | `true` | Show preview pane in browser |
+| `word_wrap` | `true` | Wrap long lines in the editor |
 
 ## License
 

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -525,19 +525,85 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 }
 
-// insertAtCursor inserts ch into s at the given cursor position and returns the
-// updated string and new cursor position.
-func insertAtCursor(s string, cursor int, ch string) (string, int) {
-	return s[:cursor] + ch + s[cursor:], cursor + len(ch)
+// lineEdit handles common single-line text editing keys (movement, deletion,
+// insertion) on a (string, cursor) pair. Returns the updated string, cursor,
+// and whether the key was consumed. Callers handle mode-specific keys (esc,
+// enter, tab, up/down) before calling this.
+func lineEdit(s string, cursor int, key string, text string) (string, int, bool) {
+	switch key {
+	case "left":
+		if cursor > 0 {
+			cursor--
+		}
+	case "right":
+		if cursor < len(s) {
+			cursor++
+		}
+	case "alt+left", "alt+b":
+		cursor = wordLeft(s, cursor)
+	case "alt+right", "alt+f":
+		cursor = wordRight(s, cursor)
+	case "home", "ctrl+a":
+		cursor = 0
+	case "end", "ctrl+e":
+		cursor = len(s)
+	case "backspace":
+		if cursor > 0 {
+			s = s[:cursor-1] + s[cursor:]
+			cursor--
+		}
+	case "alt+backspace", "ctrl+w":
+		newPos := wordLeft(s, cursor)
+		s = s[:newPos] + s[cursor:]
+		cursor = newPos
+	case "ctrl+u":
+		s = s[cursor:]
+		cursor = 0
+	case "ctrl+k":
+		s = s[:cursor]
+	case "space":
+		s = s[:cursor] + " " + s[cursor:]
+		cursor++
+	default:
+		if len(text) > 0 {
+			s = s[:cursor] + text + s[cursor:]
+			cursor += len(text)
+		} else {
+			return s, cursor, false
+		}
+	}
+	return s, cursor, true
 }
 
-// backspaceAtCursor removes the character before cursor and returns the updated
-// string and new cursor position. If cursor is already at 0, s is unchanged.
-func backspaceAtCursor(s string, cursor int) (string, int) {
-	if cursor > 0 {
-		return s[:cursor-1] + s[cursor:], cursor - 1
+// wordLeft returns the cursor position of the start of the previous word.
+func wordLeft(s string, cursor int) int {
+	if cursor <= 0 {
+		return 0
 	}
-	return s, cursor
+	i := cursor - 1
+	for i > 0 && s[i] == ' ' {
+		i--
+	}
+	for i > 0 && s[i-1] != ' ' {
+		i--
+	}
+	return i
+}
+
+// wordRight returns the cursor position past the end of the next word.
+func wordRight(s string, cursor int) int {
+	n := len(s)
+	if cursor >= n {
+		return n
+	}
+	i := cursor
+	for i < n && s[i] != ' ' {
+		i++
+	}
+	for i < n && s[i] == ' ' {
+		i++
+	}
+	return i
 }
 
 func (m Model) handleFilterKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
@@ -550,39 +616,18 @@ func (m Model) handleFilterKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.resetFilter()
 		m.inputCur.Blur()
 		return m, nil
-
 	case "enter":
 		m.filtering = false
 		m.inputCur.Blur()
 		return m.handleEnter()
-
-	case "left":
-		if m.filterCursor > 0 {
-			m.filterCursor--
-		}
-		return m, nil
-
-	case "right":
-		if m.filterCursor < len(m.filter) {
-			m.filterCursor++
-		}
-		return m, nil
-
 	case "tab":
 		m.tabNextSection()
 		return m, nil
-
-	case "backspace":
-		m.filter, m.filterCursor = backspaceAtCursor(m.filter, m.filterCursor)
-		m.applyFilter()
-		return m, nil
-
 	case "up":
 		if m.cursor > 0 {
 			m.cursor--
 		}
 		return m, nil
-
 	case "down":
 		max := m.listLen() - 1
 		if max < 0 {
@@ -592,20 +637,13 @@ func (m Model) handleFilterKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.cursor++
 		}
 		return m, nil
-
-	case "space":
-		m.filter, m.filterCursor = insertAtCursor(m.filter, m.filterCursor, " ")
-		m.applyFilter()
-		return m, nil
-
 	default:
-		if len(msg.Text) > 0 {
-			m.filter, m.filterCursor = insertAtCursor(m.filter, m.filterCursor, msg.Text)
+		prev := m.filter
+		m.filter, m.filterCursor, _ = lineEdit(m.filter, m.filterCursor, msg.String(), msg.Text)
+		if m.filter != prev {
 			m.applyFilter()
-			return m, nil
 		}
 	}
-
 	return m, nil
 }
 
@@ -620,7 +658,6 @@ func (m Model) handleInputKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.inputAction = nil
 		m.inputCur.Blur()
 		return m, nil
-
 	case "enter":
 		action := m.inputAction
 		value := m.inputValue
@@ -634,34 +671,9 @@ func (m Model) handleInputKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, action(value)
 		}
 		return m, nil
-
-	case "left":
-		if m.inputCursor > 0 {
-			m.inputCursor--
-		}
-		return m, nil
-
-	case "right":
-		if m.inputCursor < len(m.inputValue) {
-			m.inputCursor++
-		}
-		return m, nil
-
-	case "backspace":
-		m.inputValue, m.inputCursor = backspaceAtCursor(m.inputValue, m.inputCursor)
-		return m, nil
-
-	case "space":
-		m.inputValue, m.inputCursor = insertAtCursor(m.inputValue, m.inputCursor, " ")
-		return m, nil
-
 	default:
-		if len(msg.Text) > 0 {
-			m.inputValue, m.inputCursor = insertAtCursor(m.inputValue, m.inputCursor, msg.Text)
-			return m, nil
-		}
+		m.inputValue, m.inputCursor, _ = lineEdit(m.inputValue, m.inputCursor, msg.String(), msg.Text)
 	}
-
 	return m, nil
 }
 
@@ -689,27 +701,8 @@ func (m Model) handleSettingsInputKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 			return m, action(value)
 		}
 		return m, nil
-	case "left":
-		if m.inputCursor > 0 {
-			m.inputCursor--
-		}
-		return m, nil
-	case "right":
-		if m.inputCursor < len(m.inputValue) {
-			m.inputCursor++
-		}
-		return m, nil
-	case "backspace":
-		m.inputValue, m.inputCursor = backspaceAtCursor(m.inputValue, m.inputCursor)
-		return m, nil
-	case "space":
-		m.inputValue, m.inputCursor = insertAtCursor(m.inputValue, m.inputCursor, " ")
-		return m, nil
 	default:
-		if len(msg.Text) > 0 {
-			m.inputValue, m.inputCursor = insertAtCursor(m.inputValue, m.inputCursor, msg.Text)
-			return m, nil
-		}
+		m.inputValue, m.inputCursor, _ = lineEdit(m.inputValue, m.inputCursor, msg.String(), msg.Text)
 	}
 	return m, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -228,7 +228,7 @@ func Get(cfg Config, key string) (string, error) {
 	case "date_format":
 		return cfg.DateFormat, nil
 	case "hide_checked":
-		return fmt.Sprintf("%t", BoolVal(cfg.HideChecked, true)), nil
+		return fmt.Sprintf("%t", BoolVal(cfg.HideChecked, false)), nil
 	case "cascade_checks":
 		return fmt.Sprintf("%t", BoolVal(cfg.CascadeChecks, true)), nil
 	case "show_preview":

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -296,7 +296,7 @@ func New(cfg Config) Model {
 		wordWrap:       config.BoolVal(cfg.WordWrap, true),
 		dismissedHints: dismissed,
 		hoverBlock:     -1,
-		sortChecked:   config.BoolVal(cfg.HideChecked, true),
+		sortChecked:   config.BoolVal(cfg.HideChecked, false),
 		cascadeChecks: config.BoolVal(cfg.CascadeChecks, true),
 	}
 
@@ -607,6 +607,22 @@ func (m *Model) navigateUp() {
 	}
 	charOffset := m.textareas[m.active].LineInfo().CharOffset
 	m.focusBlock(m.active - 1)
+
+	// Entering a table from below: place cursor at the last data cell.
+	if m.table != nil {
+		lastRow := len(m.table.cells) - 1
+		lastCol := 0
+		if lastRow >= 0 && len(m.table.cells[lastRow]) > 0 {
+			lastCol = len(m.table.cells[lastRow]) - 1
+		}
+		m.table.row = lastRow
+		m.table.col = lastCol
+		cw := m.tableCellTAWidth()
+		m.table.loadCell(&m.textareas[m.active], cw, true)
+		m.cursorCmd = m.textareas[m.active].Focus()
+		return
+	}
+
 	ta := &m.textareas[m.active]
 	ta.MoveToEnd()
 	li := ta.LineInfo()
@@ -909,14 +925,36 @@ func (m *Model) handleEnter() {
 			return
 		}
 
-		// Otherwise insert a newline within the block (term→def, or new def line).
+		// Term line: if a definition line already exists below, just move
+		// the cursor down instead of inserting a duplicate empty line.
+		if cursorLine == 0 && len(lines) > 1 {
+			ta.CursorDown()
+			ta.CursorEnd()
+			m.cursorCmd = ta.Focus()
+			return
+		}
+
+		// Otherwise insert a newline within the block (new def line).
 		m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount() + 1)
 		m.textareas[m.active], _ = m.textareas[m.active].Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 		m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount())
 		return
 	}
 
-	// Code block / Quote: Enter inserts a newline within the block.
+	// Empty multi-line or embed block: convert to paragraph.
+	// For code blocks, content is "\n" when empty (language separator).
+	if bt == block.CodeBlock || bt == block.Quote || bt == block.Callout || bt == block.Embed {
+		if strings.TrimRight(content, "\n") == "" {
+			m.blocks[m.active].Type = block.Paragraph
+			m.blocks[m.active].Content = ""
+			newTA := newTextareaForBlock(m.blocks[m.active], m.width)
+			m.cursorCmd = newTA.Focus()
+			m.textareas[m.active] = newTA
+			return
+		}
+	}
+
+	// Code block / Quote / Callout: Enter inserts a newline within the block.
 	// On an empty last line, exit the block by trimming the empty line
 	// and inserting a new paragraph below.
 	if bt == block.CodeBlock || bt == block.Quote || bt == block.Callout {
@@ -1050,6 +1088,15 @@ func (m *Model) handleEnter() {
 
 // handleBackspace processes Backspace at position 0 for block deletion/merging.
 // Returns true if the backspace was handled (caller should not forward to textarea).
+//
+// Unified behavior:
+//   - Table: no-op (cells handle their own editing).
+//   - Divider: delete block, focus previous.
+//   - List items: outdent if indented, else convert to paragraph.
+//   - Any other non-paragraph type: convert to paragraph (unwrap formatting).
+//     Code blocks keep body only (drop language line). Definition keeps term only.
+//   - Empty paragraph: delete block, focus previous.
+//   - Non-empty paragraph: merge with previous block.
 func (m *Model) handleBackspace() bool {
 	if m.active < 0 || m.active >= len(m.blocks) {
 		return false
@@ -1069,12 +1116,12 @@ func (m *Model) handleBackspace() bool {
 	content := ta.Value()
 	bt := m.blocks[m.active].Type
 
-	// Table cell: never merge/delete — just no-op at position 0.
+	// Table cell: no-op.
 	if bt == block.Table {
 		return true
 	}
 
-	// Divider: backspace always deletes the divider (selected as a unit).
+	// Divider: delete the block.
 	if bt == block.Divider {
 		m.pushUndo()
 		m.deleteBlock(m.active)
@@ -1082,7 +1129,7 @@ func (m *Model) handleBackspace() bool {
 		return true
 	}
 
-	// List item at position 0: outdent if indented, otherwise convert to paragraph.
+	// List items: outdent if indented, else convert to paragraph.
 	if bt.IsListItem() {
 		m.pushUndo()
 		if m.blocks[m.active].Indent > 0 {
@@ -1091,40 +1138,35 @@ func (m *Model) handleBackspace() bool {
 			m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount())
 			return true
 		}
-		m.blocks[m.active].Type = block.Paragraph
-		m.blocks[m.active].Checked = false
-		m.blocks[m.active].Indent = 0
-		newTA := newTextareaForBlock(m.blocks[m.active], m.width)
-		newTA.SetValue(content)
-		m.cursorCmd = newTA.Focus()
-		newTA.SetCursorColumn(0)
-		m.textareas[m.active] = newTA
+		m.convertToParagraph(content)
 		return true
 	}
 
-	// Definition list at position 0: convert to paragraph (keep content).
-	if bt == block.DefinitionList {
+	// Any non-paragraph type: convert to paragraph (unwrap).
+	if bt != block.Paragraph {
 		m.pushUndo()
-		// Take only the term line as paragraph content.
-		term, _ := block.ExtractDefinition(content)
-		m.blocks[m.active].Type = block.Paragraph
-		m.blocks[m.active].Content = term
-		newTA := newTextareaForBlock(m.blocks[m.active], m.width)
-		newTA.SetValue(term)
-		m.cursorCmd = newTA.Focus()
-		newTA.SetCursorColumn(0)
-		m.textareas[m.active] = newTA
+		// Determine what content to keep.
+		keepContent := content
+		switch bt {
+		case block.CodeBlock:
+			// Drop the language line, keep body only.
+			if idx := strings.Index(content, "\n"); idx >= 0 {
+				keepContent = content[idx+1:]
+			}
+		case block.DefinitionList:
+			// Keep only the term line.
+			keepContent, _ = block.ExtractDefinition(content)
+		}
+		m.convertToParagraph(keepContent)
 		return true
 	}
 
+	// --- From here, block is a Paragraph. ---
+
+	// Empty paragraph: delete it, focus previous.
 	if content == "" {
-		// Empty block: delete it, focus previous.
-		if m.active == 0 {
-			if len(m.blocks) <= 1 {
-				if m.blocks[0].Type == block.Paragraph {
-					return true // Already empty paragraph, nothing to do.
-				}
-			}
+		if m.active == 0 && len(m.blocks) <= 1 {
+			return true // Last block, nothing to do.
 		}
 		m.pushUndo()
 		m.deleteBlock(m.active)
@@ -1132,9 +1174,9 @@ func (m *Model) handleBackspace() bool {
 		return true
 	}
 
-	// Non-empty block at position 0: merge with previous block.
+	// Non-empty paragraph at position 0: merge with previous block.
 	if m.active == 0 {
-		return false // No previous block to merge into.
+		return false
 	}
 
 	// If previous block is a divider, just delete the divider.
@@ -1144,14 +1186,30 @@ func (m *Model) handleBackspace() bool {
 		return true
 	}
 
-	// Don't merge content into code blocks, quote blocks, definition lists, callouts, or tables.
-	if m.blocks[m.active-1].Type == block.CodeBlock || m.blocks[m.active-1].Type == block.Quote || m.blocks[m.active-1].Type == block.DefinitionList || m.blocks[m.active-1].Type == block.Callout || m.blocks[m.active-1].Type == block.Table {
+	// Don't merge into multi-line container blocks.
+	prev := m.blocks[m.active-1].Type
+	if prev == block.CodeBlock || prev == block.Quote || prev == block.DefinitionList || prev == block.Callout || prev == block.Table {
 		return false
 	}
 
 	m.pushUndo()
 	m.mergeBlockUp(m.active)
 	return true
+}
+
+// convertToParagraph changes the active block to a paragraph with the given
+// content, rebuilds its textarea, and places the cursor at position 0.
+func (m *Model) convertToParagraph(content string) {
+	m.blocks[m.active].Type = block.Paragraph
+	m.blocks[m.active].Content = content
+	m.blocks[m.active].Checked = false
+	m.blocks[m.active].Indent = 0
+	m.blocks[m.active].Variant = 0
+	newTA := newTextareaForBlock(m.blocks[m.active], m.width)
+	newTA.SetValue(content)
+	m.cursorCmd = newTA.Focus()
+	newTA.SetCursorColumn(0)
+	m.textareas[m.active] = newTA
 }
 
 // cutBlock removes the active block and stores it in the block clipboard.
@@ -1216,6 +1274,7 @@ func (m *Model) applyPaletteSelection(bt block.BlockType) {
 	// from the title into the code area immediately.
 	if bt == block.CodeBlock && !strings.Contains(m.textareas[m.active].Value(), "\n") {
 		m.textareas[m.active].SetValue(m.textareas[m.active].Value() + "\n")
+		m.textareas[m.active].MoveToBegin()
 		m.cursorCmd = m.textareas[m.active].Focus()
 	}
 	// Ensure new definition list blocks have term\ndefinition structure.
@@ -1237,7 +1296,7 @@ func (m *Model) applyPaletteSelection(bt block.BlockType) {
 		content := m.textareas[m.active].Value()
 		if content == "" || !strings.Contains(content, "|") {
 			// Set a default 2x2 table template.
-			content = "| Header 1 | Header 2 |\n| --- | --- |\n|  |  |"
+			content = "|  |  |\n| --- | --- |\n|  |  |"
 		}
 		m.blocks[m.active].Content = content
 		m.textareas[m.active].SetValue(content)

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -1535,8 +1535,10 @@ func TestCutBlockDoesNotDeleteExtra(t *testing.T) {
 	}
 }
 
-func TestMergeHeadingIntoEmptyBlockPreservesType(t *testing.T) {
+func TestBackspaceOnHeadingConvertsToParagraph(t *testing.T) {
 	// Empty paragraph followed by a heading.
+	// Backspace at pos 0 on a heading should convert it to a paragraph
+	// (consistent with list items, code blocks, etc.).
 	content := "\n# Important Title"
 	m := New(Config{Title: "test", Content: content})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
@@ -1561,13 +1563,12 @@ func TestMergeHeadingIntoEmptyBlockPreservesType(t *testing.T) {
 	m.focusBlock(headingIdx)
 	m.textareas[m.active].CursorStart()
 
-	// Press Backspace to merge into the empty block above.
+	// Press Backspace — should convert heading to paragraph, not merge.
 	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
 	m = updated.(Model)
 
-	// The merged block should be a Heading1, not a Paragraph.
-	if m.blocks[m.active].Type != block.Heading1 {
-		t.Fatalf("merged block should be Heading1, got %s", m.blocks[m.active].Type)
+	if m.blocks[m.active].Type != block.Paragraph {
+		t.Fatalf("heading should convert to Paragraph, got %s", m.blocks[m.active].Type)
 	}
 
 	// Content should be preserved.

--- a/internal/editor/render.go
+++ b/internal/editor/render.go
@@ -3,7 +3,6 @@ package editor
 import (
 	"bytes"
 	"fmt"
-	"image/color"
 	"strings"
 
 	"github.com/alecthomas/chroma/v2"
@@ -293,15 +292,10 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 		label := ""
 		cursorOnTitle := ta.Line() == 0
 		if cursorOnTitle {
-			// Cursor is on the title — render with visible cursor.
-			// Use explicit fg+bg so Reverse(true) doesn't leak bare
-			// ANSI escapes ([7m / [40m) on themes with unusual palette.
-			cursorFg := lipgloss.Color(th.Accent)
 			if titleText == "" {
-				cursor := lipgloss.NewStyle().Foreground(cursorFg).Reverse(true)
-				label = cursor.Render(" ") + faintStyle.Render("language")
+				label = renderPlaceholder("language", true)
 			} else {
-				label = renderLabelCursor(titleText, ta.LineInfo().ColumnOffset, faintStyle, cursorFg)
+				label = renderLabelCursor(titleText, ta.LineInfo().ColumnOffset, faintStyle)
 			}
 		} else if titleText != "" {
 			label = faintStyle.Render(titleText)
@@ -335,7 +329,6 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 		markerColor := resolveColor(bs.MarkerColor, th.Muted)
 		marker := lipgloss.NewStyle().Foreground(lipgloss.Color(markerColor)).Render(bs.Marker)
 		markerIndent := strings.Repeat(" ", lipgloss.Width(marker))
-		faint := lipgloss.NewStyle().Faint(true)
 		rawLines := strings.Split(ta.Value(), "\n")
 		lines := strings.Split(taView, "\n")
 
@@ -361,30 +354,19 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 			}
 		}
 
-		cursorFg := lipgloss.Color(th.Accent)
-		cursorStyle := lipgloss.NewStyle().Foreground(cursorFg).Reverse(true)
-
 		for i, l := range lines {
 			vi := visMap[i]
 			if vi.rawIdx == 0 {
 				// Term line: no prefix, just bold + placeholder.
 				if rawLines[0] == "" && vi.isFirst {
-					if cursorVisIdx == i {
-						lines[i] = cursorStyle.Render(" ") + faint.Render("Term")
-					} else {
-						lines[i] = faint.Render("Term")
-					}
+					lines[i] = renderPlaceholder("Term", cursorVisIdx == i)
 				} else if bs.TermBold {
 					lines[i] = styleAroundCursor(l, lipgloss.NewStyle().Bold(true), cursorByteOffset, cursorLen, cursorVisIdx-i)
 				}
 			} else if vi.isFirst {
 				// First visual line of a definition: marker prefix.
 				if rawLines[vi.rawIdx] == "" {
-					if cursorVisIdx == i {
-						lines[i] = marker + cursorStyle.Render(" ") + faint.Render("Definition")
-					} else {
-						lines[i] = marker + faint.Render("Definition")
-					}
+					lines[i] = marker + renderPlaceholder("Definition", cursorVisIdx == i)
 				} else {
 					lines[i] = marker + l
 				}
@@ -403,7 +385,11 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 			icon = "\u2197 "
 		}
 		prefix := lipgloss.NewStyle().Foreground(lipgloss.Color(embedColor)).Render(icon)
-		rendered = prefixFirstLine(prefix, taView)
+		if content == "" {
+			rendered = prefix + renderPlaceholder("Link or note path", true)
+		} else {
+			rendered = prefixFirstLine(prefix, taView)
+		}
 
 	case block.Callout:
 		cs := th.Blocks.Callout
@@ -415,8 +401,12 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 			Render(b.Variant.String())
 		var result []string
 		result = append(result, bar+variantLabel)
-		for _, l := range strings.Split(taView, "\n") {
-			result = append(result, bar+l)
+		if content == "" {
+			result = append(result, bar+renderPlaceholder("Empty callout", true))
+		} else {
+			for _, l := range strings.Split(taView, "\n") {
+				result = append(result, bar+l)
+			}
 		}
 		rendered = strings.Join(result, "\n")
 
@@ -536,11 +526,9 @@ func renderCodeBox(code, label, borderColor, labelAlign string, padWidth int) st
 
 // renderLabelCursor renders a label string with a reverse-video cursor at
 // the given column position. Text outside the cursor is styled with base.
-// cursorFg sets the cursor's foreground color (which becomes the background
-// after Reverse) so bare ANSI escapes don't leak on certain themes.
-func renderLabelCursor(text string, col int, base lipgloss.Style, cursorFg color.Color) string {
+func renderLabelCursor(text string, col int, base lipgloss.Style) string {
 	runes := []rune(text)
-	cursor := lipgloss.NewStyle().Foreground(cursorFg).Reverse(true)
+	cursor := lipgloss.NewStyle().Reverse(true)
 	if col >= len(runes) {
 		return base.Render(text) + cursor.Render(" ")
 	}
@@ -548,6 +536,19 @@ func renderLabelCursor(text string, col int, base lipgloss.Style, cursorFg color
 	ch := string(runes[col : col+1])
 	after := string(runes[col+1:])
 	return base.Render(before) + cursor.Render(ch) + base.Render(after)
+}
+
+// renderPlaceholder renders placeholder text with consistent behavior: the
+// cursor sits on the first letter (plain reverse) and the rest is faint. When
+// the cursor is not on this field, the entire text is faint.
+func renderPlaceholder(text string, hasCursor bool) string {
+	faint := lipgloss.NewStyle().Faint(true)
+	if !hasCursor {
+		return faint.Render(text)
+	}
+	runes := []rune(text)
+	cursor := lipgloss.NewStyle().Reverse(true)
+	return cursor.Render(string(runes[:1])) + faint.Render(string(runes[1:]))
 }
 
 // scrollOrTruncate fits a line within availWidth, adding ← → scroll
@@ -848,10 +849,14 @@ func renderInactiveBlock(b block.Block, content string, width int, wordWrap bool
 		if icon == "" {
 			icon = "\u2197 "
 		}
-		pill := lipgloss.NewStyle().
-			Foreground(lipgloss.Color(embedColor)).
-			Render(icon + wrapped)
-		rendered = pill
+		prefix := lipgloss.NewStyle().Foreground(lipgloss.Color(embedColor)).Render(icon)
+		if wrapped == "" {
+			rendered = prefix + renderPlaceholder("Link or note path", false)
+		} else {
+			rendered = lipgloss.NewStyle().
+				Foreground(lipgloss.Color(embedColor)).
+				Render(icon + wrapped)
+		}
 
 	case block.Table:
 		tableWidth := width - gutterWidth
@@ -1058,11 +1063,16 @@ func renderViewBlock(b block.Block, content string, width int, wordWrap bool, bl
 		if icon == "" {
 			icon = "\u2197 "
 		}
-		style := lipgloss.NewStyle().Foreground(lipgloss.Color(embedColor))
-		if hovered {
-			style = style.Underline(true)
+		if wrapped == "" {
+			prefix := lipgloss.NewStyle().Foreground(lipgloss.Color(embedColor)).Render(icon)
+			rendered = prefix + renderPlaceholder("Link or note path", false)
+		} else {
+			style := lipgloss.NewStyle().Foreground(lipgloss.Color(embedColor))
+			if hovered {
+				style = style.Underline(true)
+			}
+			rendered = style.Render(icon + wrapped)
 		}
-		rendered = style.Render(icon + wrapped)
 
 	case block.Table:
 		rendered = renderTableGrid(content, contentWidth, th.Border, th.Blocks.Table.HeaderBold, true)

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -164,7 +164,7 @@ func DefaultBlockStyles() BlockStyles {
 		Divider:    DividerStyle{Char: "\u2500", MaxWidth: 40},
 		Definition: DefinitionStyle{Marker: "  : ", TermBold: true},
 		Embed:      EmbedStyle{Icon: "\u2197 "},
-		Table:      TableStyle{HeaderBold: true},
+		Table:      TableStyle{HeaderBold: false},
 	}
 }
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -29,6 +29,18 @@ func HandlePickerKey(p *Picker, key string, text string, code rune) (handled, cl
 			return true, true
 		}
 		return true, false
+	case "alt+backspace", "ctrl+w":
+		if !p.DeleteFilterWord() {
+			p.Close()
+			return true, true
+		}
+		return true, false
+	case "ctrl+u":
+		if !p.ClearFilter() {
+			p.Close()
+			return true, true
+		}
+		return true, false
 	default:
 		if len(text) > 0 {
 			for _, r := range text {

--- a/internal/ui/picker.go
+++ b/internal/ui/picker.go
@@ -94,6 +94,39 @@ func (p *Picker) DeleteFilterRune() bool {
 	return true
 }
 
+// DeleteFilterWord removes the last word from the filter. Returns false if the
+// filter was already empty, signalling the caller should close the picker.
+func (p *Picker) DeleteFilterWord() bool {
+	if p.filter == "" {
+		return false
+	}
+	// Trim trailing spaces, then remove back to the next space.
+	s := strings.TrimRight(p.filter, " ")
+	if s == "" {
+		p.filter = ""
+		p.Refilter()
+		return true
+	}
+	if i := strings.LastIndex(s, " "); i >= 0 {
+		p.filter = s[:i+1]
+	} else {
+		p.filter = ""
+	}
+	p.Refilter()
+	return true
+}
+
+// ClearFilter resets the filter text and refilters. Returns false if the
+// filter was already empty.
+func (p *Picker) ClearFilter() bool {
+	if p.filter == "" {
+		return false
+	}
+	p.filter = ""
+	p.Refilter()
+	return true
+}
+
 // MoveUp moves the cursor up in the filtered list.
 func (p *Picker) MoveUp() {
 	if p.cursor > 0 {


### PR DESCRIPTION
## Summary

- **Unified Enter/Backspace**: every block type now behaves predictably — Enter on empty block converts to paragraph, Backspace at pos 0 unwraps formatting before merging
- **Placeholder text**: empty callouts, definitions, code blocks, and embeds show faint placeholder hints with cursor on first letter
- **Input keyboard controls**: word jump, word delete, line start/end, line delete in all browser/picker inputs via shared `lineEdit` function
- **Table defaults**: removed "Header 1"/"Header 2" text and forced bold
- **Sort-checked default**: changed from `true` to `false`
- **Definition Enter**: moves to existing definition line instead of creating duplicate
- **Code block**: cursor starts on language line; navigating up into table lands on last cell
- **Docs**: added CHANGELOG.md, updated README config table, fixed AGENTS.md test count

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./...` — success
- [x] `go test ./...` — 649 passed across 13 packages
- [x] Verified Enter converts empty code/quote/callout/embed to paragraph
- [x] Verified Backspace at pos 0 converts any non-paragraph to paragraph
- [x] Verified placeholder rendering in active, inactive, and view modes
- [x] Verified input keyboard controls (word jump, delete, line ops)

🤖 Generated with [Claude Code](https://claude.com/claude-code)