### PR TITLE
refactor: unify help, settings, and input into footer popup UX

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -608,6 +608,13 @@ func wordRight(s string, cursor int) int {
 
 func (m Model) handleFilterKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	m.inputCur.IsBlinked = false
+	// "/" with empty filter dismisses search (toggle behavior).
+	if msg.Text == "/" && m.filter == "" {
+		m.filtering = false
+		m.resetFilter()
+		m.inputCur.Blur()
+		return m, nil
+	}
 	switch msg.String() {
 	case "esc":
 		m.filtering = false
@@ -709,6 +716,10 @@ func (m Model) handleSettingsInputKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 
 func (m Model) handleSettingsKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	defs := settingDefs()
+	if msg.Text == "," {
+		m.showSettings = false
+		return m, nil
+	}
 	switch msg.String() {
 	case "esc":
 		m.showSettings = false
@@ -1682,7 +1693,13 @@ func (m Model) handleEsc() (tea.Model, tea.Cmd) {
 
 // renderSettingsView builds the full-screen settings view matching the
 // browser's list layout with section header, bullet selection, and status bar.
-func (m Model) renderSettingsView() string {
+// renderSettingsFooter builds the settings panel as a footer popup.
+func (m Model) renderSettingsFooter() string {
+	width := m.width
+	if width <= 0 {
+		width = 80
+	}
+
 	th := theme.Current()
 	accentStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(th.Accent))
 	dim := lipgloss.NewStyle().Faint(true)
@@ -1690,16 +1707,10 @@ func (m Model) renderSettingsView() string {
 	cfg := m.settingsCfg
 	defs := settingDefs()
 
+	border := dim.Render(strings.Repeat("\u2500", width))
+
 	var b strings.Builder
-
-	// Section header — same style as browser's "Notebooks" / "Recent" headers.
-	headerStyle := lipgloss.NewStyle().Bold(true).Padding(0, 1)
-	b.WriteString(" " + headerStyle.Render("Settings") + "\n")
-
-	contentHeight := m.height - 2 - m.statusBarHeight()
-	if contentHeight < 1 {
-		contentHeight = 1
-	}
+	b.WriteString(border + "\n")
 
 	maxLabel := 0
 	for _, d := range defs {
@@ -1708,12 +1719,10 @@ func (m Model) renderSettingsView() string {
 		}
 	}
 
-	lines := 1 // header
 	for i, d := range defs {
 		val, _ := config.Get(cfg, d.key)
 		displayVal := settingDisplayValue(d, val)
 
-		// Cycle settings show arrows.
 		if d.kind == settingCycle && len(d.options) > 1 {
 			displayVal = "◂ " + displayVal + " ▸"
 		}
@@ -1723,66 +1732,33 @@ func (m Model) renderSettingsView() string {
 
 		if i == m.settingsCursor {
 			bullet := accentStyle.Render("\u25CF") + " "
-			line := bullet + accentStyle.Render(label) + pad + accentStyle.Render(displayVal)
-			b.WriteString(line + "\n")
+			b.WriteString(bullet + accentStyle.Render(label) + pad + accentStyle.Render(displayVal) + "\n")
 		} else {
-			line := "  " + label + pad + dim.Render(displayVal)
-			b.WriteString(line + "\n")
-		}
-		lines++
-	}
-
-	// Description for selected setting.
-	if m.settingsCursor < len(defs) {
-		desc := defs[m.settingsCursor].desc
-		if desc != "" {
-			b.WriteString("\n")
-			b.WriteString("  " + dim.Render(desc) + "\n")
-			lines += 2
+			b.WriteString("  " + label + pad + dim.Render(displayVal) + "\n")
 		}
 	}
-
-	// Pad to push status bar to bottom.
-	for lines < contentHeight {
-		b.WriteString("\n")
-		lines++
-	}
-
-	// Status bar.
-	b.WriteString("\n")
-	b.WriteString(m.renderStatusBar())
 
 	return b.String()
 }
 
-// renderHelpOverlay builds the centered help panel.
-func (m Model) renderHelpOverlay() string {
-	sections := []ui.HelpSection{
-		{
-			Title: "Navigation",
-			Bindings: []ui.HelpBinding{
-				{Key: "↑/↓         ", Desc: "Navigate"},
-				{Key: "Enter       ", Desc: "Open / edit"},
-				{Key: "Esc/⌃C      ", Desc: "Back / quit"},
-				{Key: "Tab         ", Desc: "Jump section"},
-				{Key: "/           ", Desc: "Search"},
-			},
-		},
-		{
-			Title: "Actions",
-			Bindings: []ui.HelpBinding{
-				{Key: "n           ", Desc: "New"},
-				{Key: "i           ", Desc: "Open file"},
-				{Key: "d           ", Desc: "Delete / remove"},
-				{Key: "r           ", Desc: "Rename"},
-				{Key: "c           ", Desc: "Copy (notes)"},
-				{Key: "t           ", Desc: "Theme"},
-				{Key: "p           ", Desc: "Preview"},
-				{Key: ",           ", Desc: "Settings"},
-			},
-		},
-	}
-	return ui.RenderHelpOverlay(sections, "Esc/? to close", m.width, m.height)
+// renderHelpFooter builds the help footer panel with keybind reference.
+func (m Model) renderHelpFooter() string {
+	return ui.RenderHelpFooter([]ui.HelpBinding{
+		{Key: "↑/↓", Desc: "Navigate"},
+		{Key: "Enter", Desc: "Open"},
+		{Key: "Esc", Desc: "Back / quit"},
+		{Key: "Tab", Desc: "Jump section"},
+		{Key: "/", Desc: "Search"},
+		{Key: "n", Desc: "New"},
+		{Key: "d", Desc: "Delete"},
+		{Key: "r", Desc: "Rename"},
+		{Key: "c", Desc: "Copy note"},
+		{Key: "i", Desc: "Import file"},
+		{Key: "t", Desc: "Theme"},
+		{Key: "p", Desc: "Preview"},
+		{Key: ",", Desc: "Settings"},
+		{Key: "?", Desc: "Close"},
+	}, m.width)
 }
 
 // currentHintID returns the hint ID relevant to the current browser state,
@@ -1812,12 +1788,8 @@ func (m Model) View() tea.View {
 
 	var content string
 
-	if m.showHelp {
-		content = m.renderHelpOverlay()
-	} else if m.themeMode {
+	if m.themeMode {
 		content = m.renderThemeOverlay()
-	} else if m.showSettings {
-		content = m.renderSettingsView()
 	} else if m.err != nil {
 		content = fmt.Sprintf("\n  Error: %v\n", m.err)
 	} else {
@@ -1830,12 +1802,24 @@ func (m Model) View() tea.View {
 			b.WriteString("\n")
 		}
 
+		// Footer panel (help or settings).
+		var footer string
+		if m.showSettings {
+			footer = m.renderSettingsFooter()
+		} else if m.showHelp {
+			footer = m.renderHelpFooter()
+		}
+
 		// Content area.
 		headerLines := 1 // breadcrumb line
 		if breadcrumb == "" {
 			headerLines = 0
 		}
-		contentHeight := m.height - headerLines - 1 - m.statusBarHeight() // header + status bar + blank line above status
+		footerH := 1 // gap line before status bar
+		if footer != "" {
+			footerH = strings.Count(footer, "\n")
+		}
+		contentHeight := m.height - headerLines - footerH - m.statusBarHeight()
 		if contentHeight < 1 {
 			contentHeight = 1
 		}
@@ -1851,8 +1835,12 @@ func (m Model) View() tea.View {
 			}
 		}
 
-		// Status bar.
-		b.WriteString("\n")
+		// Footer and status bar.
+		if footer != "" {
+			b.WriteString(footer)
+		} else {
+			b.WriteString("\n")
+		}
 		b.WriteString(m.renderStatusBar())
 		content = b.String()
 	}
@@ -2347,6 +2335,10 @@ func (m Model) renderStatusBar() string {
 		width = 80
 	}
 
+	if m.inputMode && m.showSettings {
+		// Settings text edit: use input bar without border (settings footer provides its own).
+		return format.StatusBarInput(m.inputPrompt, m.inputValue, m.inputCursor, "Enter confirm \u00B7 Esc cancel", width, !m.inputCur.IsBlinked)
+	}
 	if m.inputMode {
 		return format.FooterInput(m.inputPrompt, m.inputValue, m.inputCursor, "Enter confirm \u00B7 Esc cancel", width, !m.inputCur.IsBlinked)
 	}
@@ -2359,13 +2351,34 @@ func (m Model) renderStatusBar() string {
 	var hint string
 	var right string
 
-	if m.statusText != "" {
+	if m.showSettings {
+		defs := settingDefs()
+		if m.settingsCursor < len(defs) {
+			if desc := defs[m.settingsCursor].desc; desc != "" {
+				left = "  " + desc
+			}
+			switch defs[m.settingsCursor].kind {
+			case settingBool:
+				right = "Enter toggle \u00B7 Esc close"
+			case settingCycle:
+				right = "←/→ cycle \u00B7 Esc close"
+			case settingText:
+				right = "Enter edit \u00B7 Esc close"
+			}
+		}
+	} else if m.showHelp {
+		right = "? close"
+	} else if m.statusText != "" {
 		left = "  " + m.statusText
 	} else if m.level == 0 {
 		if !m.dismissedHints["browser.theme"] {
 			hint = "press t to change theme!  [h]ide"
 		}
-		right = "Tab jump \u00B7 / search \u00B7 ? help"
+		if len(m.filteredRecent) > 0 && len(m.filtered) > 0 {
+			right = "Tab jump \u00B7 / search \u00B7 ? help"
+		} else {
+			right = "/ search \u00B7 ? help"
+		}
 	} else {
 		right = "/ search \u00B7 Esc back \u00B7 ? help"
 	}

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -390,11 +390,11 @@ func TestBrowserHelpToggle(t *testing.T) {
 	}
 
 	view := m.View().Content
-	if !containsStr(view, "Navigation") {
-		t.Errorf("help overlay should contain 'Keybindings', got:\n%s", view)
-	}
 	if !containsStr(view, "Navigate") {
-		t.Errorf("help overlay should contain 'Navigate', got:\n%s", view)
+		t.Errorf("help footer should contain 'Navigate', got:\n%s", view)
+	}
+	if !containsStr(view, "Search") {
+		t.Errorf("help footer should contain 'Search', got:\n%s", view)
 	}
 
 	// Press '?' again to dismiss.
@@ -405,8 +405,8 @@ func TestBrowserHelpToggle(t *testing.T) {
 	}
 
 	view = m.View().Content
-	if containsStr(view, "Navigation") {
-		t.Error("help overlay should not be visible after dismissing")
+	if containsStr(view, "Navigate") {
+		t.Error("help footer should not be visible after dismissing")
 	}
 }
 

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -608,18 +608,19 @@ func (m *Model) navigateUp() {
 	charOffset := m.textareas[m.active].LineInfo().CharOffset
 	m.focusBlock(m.active - 1)
 
-	// Entering a table from below: place cursor at the last data cell.
+	// Entering a table from below: bottom-left cell, apply charOffset.
 	if m.table != nil {
 		lastRow := len(m.table.cells) - 1
-		lastCol := 0
-		if lastRow >= 0 && len(m.table.cells[lastRow]) > 0 {
-			lastCol = len(m.table.cells[lastRow]) - 1
+		if lastRow < 0 {
+			lastRow = 0
 		}
 		m.table.row = lastRow
-		m.table.col = lastCol
 		cw := m.tableCellTAWidth()
 		m.table.loadCell(&m.textareas[m.active], cw, true)
-		m.cursorCmd = m.textareas[m.active].Focus()
+		ta := &m.textareas[m.active]
+		li := ta.LineInfo()
+		ta.SetCursorColumn(li.StartColumn + charOffset)
+		m.cursorCmd = ta.Focus()
 		return
 	}
 
@@ -636,6 +637,15 @@ func (m *Model) navigateDown() {
 	}
 	charOffset := m.textareas[m.active].LineInfo().CharOffset
 	m.focusBlock(m.active + 1)
+
+	// Entering a table from above: top-left cell, apply charOffset.
+	if m.table != nil {
+		ta := &m.textareas[m.active]
+		ta.SetCursorColumn(charOffset)
+		m.cursorCmd = ta.Focus()
+		return
+	}
+
 	ta := &m.textareas[m.active]
 	ta.MoveToBegin()
 	ta.SetCursorColumn(charOffset)
@@ -1116,8 +1126,16 @@ func (m *Model) handleBackspace() bool {
 	content := ta.Value()
 	bt := m.blocks[m.active].Type
 
-	// Table cell: no-op.
+	// Table: at cell (0,0) convert to paragraph; otherwise no-op.
 	if bt == block.Table {
+		if m.table == nil || m.table.row > 0 || m.table.col > 0 {
+			return true
+		}
+		m.pushUndo()
+		m.table.syncCell(*ta)
+		keepContent := m.table.cells[0][0]
+		m.table = nil
+		m.convertToParagraph(keepContent)
 		return true
 	}
 
@@ -1550,6 +1568,7 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch msg.String() {
 			case "ctrl+g", "esc":
 				m.showHelp = false
+				m.updateViewport()
 			case "ctrl+c":
 				m.showHelp = false
 				if m.modified() {
@@ -1732,6 +1751,7 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			case "ctrl+g":
 				m.showHelp = true
+				m.updateViewport()
 				return m, nil
 			case "up":
 				m.viewport.ScrollUp(1)
@@ -1776,6 +1796,7 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case "ctrl+g":
 			m.showHelp = true
+			m.updateViewport()
 			return m, nil
 
 		case "ctrl+z":
@@ -2660,11 +2681,14 @@ func (m Model) View() tea.View {
 	var content string
 	if m.embedModal.visible {
 		content = m.renderEmbedSheet()
-	} else if m.showHelp {
-		content = m.renderHelpOverlay()
 	} else {
 		statusBar := m.renderStatusBar()
-		footer := m.renderPickerFooter()
+		var footer string
+		if m.showHelp {
+			footer = m.renderHelpFooter()
+		} else {
+			footer = m.renderPickerFooter()
+		}
 		if m.viewMode {
 			if footer != "" {
 				content = m.viewport.View() + "\n" + footer + statusBar
@@ -2691,32 +2715,26 @@ func (m Model) View() tea.View {
 	return v
 }
 
-// renderHelpOverlay builds the full-screen help panel.
-func (m Model) renderHelpOverlay() string {
-	sections := []ui.HelpSection{{
-		Title: "Keybindings",
-		Bindings: []ui.HelpBinding{
-			{},
-			{Key: "Enter        ", Desc: "New block"},
-			{Key: "⇧Enter       ", Desc: "Newline"},
-			{Key: "Backspace    ", Desc: "Merge / delete"},
-			{Key: "⌃K           ", Desc: "Cut block"},
-			{Key: "⌃Z/⌃Y        ", Desc: "Undo / redo"},
-			{Key: "⌥↑/⌥↓        ", Desc: "Move block"},
-			{Key: "/            ", Desc: "Block type"},
-			{},
-			{Key: ":            ", Desc: "Definitions"},
-			{},
-			{Key: "⌃R           ", Desc: "View mode"},
-			{Key: "⌃X           ", Desc: "Checkbox"},
-			{Key: "⌃H           ", Desc: "Sort checked"},
-			{Key: "⌃W           ", Desc: "Word wrap"},
-			{},
-			{Key: "⌃S           ", Desc: "Save"},
-			{Key: "Esc/⌃C       ", Desc: "Quit"},
-		},
-	}}
-	return ui.RenderHelpOverlay(sections, "Esc/⌃G to close", m.width, m.height)
+// renderHelpFooter builds the help footer panel with keybind reference.
+func (m Model) renderHelpFooter() string {
+	return ui.RenderHelpFooter([]ui.HelpBinding{
+		{Key: "Enter", Desc: "New block"},
+		{Key: "⇧Enter", Desc: "Newline"},
+		{Key: "Bksp", Desc: "Delete / merge"},
+		{Key: "⌃K", Desc: "Cut block"},
+		{Key: "⌃Z/⌃Y", Desc: "Undo / redo"},
+		{Key: "⌥↑/⌥↓", Desc: "Move block"},
+		{Key: "/", Desc: "Block type"},
+		{Key: ":", Desc: "Definitions"},
+		{Key: "Tab/⇧Tab", Desc: "Indent"},
+		{Key: "⌃X", Desc: "Interact"},
+		{Key: "⌃R", Desc: "View mode"},
+		{Key: "⌃W", Desc: "Word wrap"},
+		{Key: "⌃H", Desc: "Sort checked"},
+		{Key: "⌃S", Desc: "Save"},
+		{Key: "Esc/⌃C", Desc: "Quit"},
+		{Key: "⌃G", Desc: "Close"},
+	}, m.width)
 }
 
 // renderPickerFooter returns the footer panel for whichever picker is active,
@@ -2736,6 +2754,9 @@ func (m Model) renderPickerFooter() string {
 
 // footerHeight returns the number of lines occupied by the active picker footer.
 func (m Model) footerHeight() int {
+	if m.showHelp {
+		return strings.Count(m.renderHelpFooter(), "\n")
+	}
 	if m.palette.Visible {
 		return m.palette.Height()
 	}
@@ -2801,14 +2822,17 @@ func (m Model) renderStatusBar() string {
 	}
 
 	left := " "
-	if m.modified() {
-		left += " [modified]"
+	if m.viewport.TotalLineCount() > m.viewport.Height() {
+		pct := int(m.viewport.ScrollPercent() * 100)
+		left += fmt.Sprintf(" %d%%", pct)
 	}
 
 	var hint string
 	var right string
 	if m.status != "" {
 		right = m.status
+	} else if m.showHelp {
+		right = "\u2303G close"
 	} else if m.viewMode {
 		if !m.dismissedHints["editor.checkbox"] {
 			hint = "click checkboxes to toggle!  [h]ide"

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -443,7 +443,7 @@ func TestHelpViewContainsKeybindings(t *testing.T) {
 	keybindings := []string{
 		"\u2303S", "Save",
 		"\u2303C", "Quit",
-		"\u2303G", "to close",
+		"\u2303G", "Close",
 		"\u2303K", "Cut block",
 	}
 	for _, kb := range keybindings {
@@ -918,8 +918,8 @@ func TestHelpContainsBlockOperationKeybindings(t *testing.T) {
 
 	keybindings := []string{
 		"Enter", "New block",
-		"Backspace", "Merge",
-		"delete",
+		"Bksp", "Delete",
+		"merge",
 		"Move block",
 	}
 	for _, kb := range keybindings {

--- a/internal/editor/render.go
+++ b/internal/editor/render.go
@@ -64,6 +64,9 @@ func (m Model) renderHeader() string {
 	metaStyle := lipgloss.NewStyle().Faint(true)
 
 	left := " " + titleStyle.Render(m.config.Title)
+	if m.modified() {
+		left += " " + metaStyle.Render("[modified]")
+	}
 
 	var rightParts []string
 	if m.config.FilePath != "" {

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -33,10 +33,6 @@ func StatusBar(left, hint, right string, width int) string {
 // visible cursor, and right-side hints. Returns a fully styled, width-padded
 // string (faint text with a reverse-video cursor).
 func StatusBarInput(prompt, value string, cursorPos int, hints string, width int, cursorVisible bool) string {
-	if width <= 0 {
-		width = 80
-	}
-
 	dim := lipgloss.NewStyle().Faint(true)
 	rev := lipgloss.NewStyle().Reverse(true)
 
@@ -48,21 +44,16 @@ func StatusBarInput(prompt, value string, cursorPos int, hints string, width int
 		after = value[cursorPos+1:]
 	}
 
-	left := dim.Render("  " + prompt + " " + before)
 	var cursor string
 	if cursorVisible {
 		cursor = rev.Render(cursorChar)
 	} else {
 		cursor = dim.Render(cursorChar)
 	}
-	right := dim.Render(after + " \u00B7 " + hints)
 
-	used := lipgloss.Width(left) + 1 + lipgloss.Width(right)
-	pad := width - used
-	if pad < 0 {
-		pad = 0
-	}
-	return left + cursor + right + dim.Render(strings.Repeat(" ", pad))
+	left := dim.Render("  "+prompt+" "+before) + cursor + dim.Render(after)
+	right := dim.Render(hints)
+	return StatusBar(left, "", right, width)
 }
 
 // FooterInput renders an input line with a top border, matching the footer

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -13,61 +13,61 @@ type HelpBinding struct {
 	Desc string
 }
 
-// HelpSection is a titled group of keybindings.
-type HelpSection struct {
-	Title    string
-	Bindings []HelpBinding
-}
-
-// RenderHelpOverlay builds a centered help panel.
-func RenderHelpOverlay(sections []HelpSection, closeHint string, w, h int) string {
-	if w <= 0 {
-		w = 80
+// RenderHelpFooter builds a compact footer panel with bindings in a
+// column-major grid, matching the picker footer style.
+func RenderHelpFooter(bindings []HelpBinding, width int) string {
+	if width <= 0 {
+		width = 80
 	}
-	if h <= 0 {
-		h = 24
+	if len(bindings) == 0 {
+		return ""
 	}
 
 	th := theme.Current()
-	accent := lipgloss.NewStyle().Foreground(lipgloss.Color(th.Accent)).Bold(true)
 	dim := lipgloss.NewStyle().Faint(true)
-	sep := dim.Render("\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500")
-	s := dim.Render("/") // dimmed slash separator
+	accent := lipgloss.NewStyle().Foreground(lipgloss.Color(th.Accent))
 
-	var help strings.Builder
-	for si, section := range sections {
-		if si > 0 {
-			help.WriteString("\n")
-		}
-		help.WriteString("  " + accent.Render(section.Title) + "\n")
-		help.WriteString("  " + sep + "\n")
-
-		for _, b := range section.Bindings {
-			if b.Key == "" {
-				// Blank separator line.
-				help.WriteString("\n")
-				continue
-			}
-			// Replace "/" in desc with dimmed slash for visual consistency.
-			desc := strings.ReplaceAll(b.Desc, " / ", " "+s+" ")
-			key := strings.ReplaceAll(b.Key, "/", s)
-			help.WriteString("  " + key + desc + "\n")
+	// Find max visual width of any single binding entry.
+	maxEntry := 0
+	for _, b := range bindings {
+		w := lipgloss.Width(b.Key) + 1 + lipgloss.Width(b.Desc)
+		if w > maxEntry {
+			maxEntry = w
 		}
 	}
 
-	// Trim trailing newline so the box doesn't have extra space.
-	content := strings.TrimRight(help.String(), "\n")
+	colW := maxEntry + 3
+	cols := (width - 2) / colW // -2 for left margin
+	if cols < 1 {
+		cols = 1
+	}
+	if cols > len(bindings) {
+		cols = len(bindings)
+	}
 
-	box := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color(th.Border)).
-		Padding(1, 2).
-		Width(36).
-		Align(lipgloss.Left)
+	rows := (len(bindings) + cols - 1) / cols
 
-	rendered := box.Render(content)
-	statusHint := dim.Render(closeHint)
-	full := rendered + "\n" + statusHint
+	border := dim.Render(strings.Repeat("\u2500", width))
 
-	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, full)
+	var sb strings.Builder
+	sb.WriteString(border + "\n")
+
+	for r := 0; r < rows; r++ {
+		sb.WriteString("  ")
+		for c := 0; c < cols; c++ {
+			idx := r + c*rows // column-major order
+			if idx < len(bindings) {
+				k := bindings[idx].Key
+				desc := bindings[idx].Desc
+				sb.WriteString(accent.Render(k) + " " + desc)
+				visual := lipgloss.Width(k) + 1 + lipgloss.Width(desc)
+				if pad := colW - visual; pad > 0 {
+					sb.WriteString(strings.Repeat(" ", pad))
+				}
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
 }


### PR DESCRIPTION
## Summary
- Replace full-screen help and settings overlays with footer panels (content stays visible)
- Fix stale/missing keybind hints across browser and editor help
- Make settings status bar context-aware (per setting type: bool/cycle/text)
- DRY up StatusBarInput to delegate layout to StatusBar (right-aligned hints everywhere)
- Add scroll %, toggle-dismiss for , and /, table backspace at (0,0), table entry cursor preservation

## Test plan
- [ ] Press `?` in browser — footer help appears at bottom, content visible above
- [ ] Press `⌃G` in editor (edit + view mode) — footer help appears, viewport resizes
- [ ] Press `,` in browser — settings footer appears; press `,` again to dismiss
- [ ] Press `/` in browser — search opens; press `/` again (empty) to dismiss
- [ ] Edit a text setting (Storage directory) — inline input, no double border
- [ ] Verify scroll % shows in editor status bar when content overflows
- [ ] Navigate into a table from above/below — cursor column preserved
- [ ] Backspace at first cell of a table — converts to paragraph
- [ ] `[modified]` tag appears in header next to title, not in status bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)