### PR TITLE
feat: table cell nav, cross-file definitions, recents copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Tables: Home/End now jump between cells when already at the cell's line start/end.
+- Tables: Alt+Left/Right jump to the previous/next cell when the cursor is at the cell's start/end (previously only plain Left/Right did this — Alt variants now skip the walk-to-edge step).
+- Tables: Alt+Up/Down move the focused cell up/down within the table when the cursor is on the first/last line of the cell, falling through to block-swap only on the top/bottom row.
+- Tables: Enter on a fully empty row exits the table and drops the row.
+- Tables: Alt+Shift+Backspace / Alt+Shift+D delete row / column.
+- Definition lookup (`:`) now searches definitions across every note in every notebook, not just the current one. Cross-note matches are read-only and labelled with their `notebook/note` source.
+- Browser: `c` now copies the contents of the highlighted recent entry to the clipboard, matching the existing notebook-level `c` binding.
+
+### Changed
+- Tables: Alt+Backspace / Alt+D now delete word (matching all other blocks); row/column delete moved to the Alt+Shift variants above.
+- View mode (Ctrl+R) trims leading and trailing empty paragraph blocks so accidental top/bottom whitespace doesn't pad the rendered view. The file on disk is untouched.
+- Command palette (/) and other pickers now keep a constant footer height as you filter, so the layout no longer jumps.
+
+### Fixed
+- Inline markdown (**bold**, *italic*, __underline__, ~~strike~~) now renders correctly when a delimiter pair is split across wrapped lines.
+- Alt+Up / Alt+Down on a focused table no longer duplicates the entire table into cell (0,0).
+- Undo no longer needs to be pressed twice in tables. Previously cursor-only key presses inside a cell registered as edits because the dirty-check compared per-cell text against the full serialized table.
+
 ## [1.2.1] - 2026-04-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ notebook path/to/file.md
 ## Features
 
 - **Block editor** — 14 block types: paragraphs, headings (3 levels), bullet lists, numbered lists, checklists, code blocks, tables, quotes, definitions, callouts, dividers, and embeds. Press **/** to switch types.
-- **Tables** — Pipe-delimited GFM tables with per-column widths. Alt+R/C to add rows/columns, Alt+Backspace/D to delete.
+- **Tables** — Pipe-delimited GFM tables with per-column widths. Alt+R/C to add rows/columns, Alt+Shift+Backspace/Alt+Shift+D to delete. Press Enter on an empty row to exit the table and drop the row.
 - **Callouts** — Five admonition variants (Note, Tip, Important, Warning, Caution). Ctrl+T to cycle.
 - **Definitions** — Term/definition pairs. Press **:** to search and jump to definitions.
 - **Embeds** — Reference other notes inline with `![[notebook/note]]`. Click in view mode to expand.

--- a/cmd/dispatcher.go
+++ b/cmd/dispatcher.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/oobagi/notebook-cli/internal/block"
 	"github.com/oobagi/notebook-cli/internal/clipboard"
 	"github.com/oobagi/notebook-cli/internal/config"
 	"github.com/oobagi/notebook-cli/internal/editor"
@@ -257,6 +258,38 @@ func editNote(w io.Writer, book, note string) error {
 				}
 			}
 			return targets
+		},
+		ListAllDefinitions: func() []editor.DefinitionEntry {
+			notebooks, err := store.ListNotebooks()
+			if err != nil {
+				return nil
+			}
+			var defs []editor.DefinitionEntry
+			for _, nb := range notebooks {
+				notes, err := store.ListNotes(nb)
+				if err != nil {
+					continue
+				}
+				for _, n := range notes {
+					if nb == book && n.Name == note {
+						continue // current note's defs come from in-memory blocks
+					}
+					blocks := block.Parse(n.Content)
+					for _, b := range blocks {
+						if b.Type != block.DefinitionList {
+							continue
+						}
+						term, def := block.ExtractDefinition(b.Content)
+						defs = append(defs, editor.DefinitionEntry{
+							Term:       term,
+							Definition: def,
+							Notebook:   nb,
+							Note:       n.Name,
+						})
+					}
+				}
+			}
+			return defs
 		},
 		DismissedHints: config.LoadDismissedHints(),
 		HideChecked: cfg.HideChecked,

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/oobagi/notebook-cli/internal/block"
 	"github.com/oobagi/notebook-cli/internal/editor"
 	"github.com/oobagi/notebook-cli/internal/recents"
 )
@@ -63,6 +64,35 @@ func openFile(path string) error {
 			}
 			recents.RecordExternal(absPath)
 			return nil
+		},
+		ListAllDefinitions: func() []editor.DefinitionEntry {
+			notebooks, err := store.ListNotebooks()
+			if err != nil {
+				return nil
+			}
+			var defs []editor.DefinitionEntry
+			for _, nb := range notebooks {
+				notes, err := store.ListNotes(nb)
+				if err != nil {
+					continue
+				}
+				for _, n := range notes {
+					blocks := block.Parse(n.Content)
+					for _, b := range blocks {
+						if b.Type != block.DefinitionList {
+							continue
+						}
+						term, def := block.ExtractDefinition(b.Content)
+						defs = append(defs, editor.DefinitionEntry{
+							Term:       term,
+							Definition: def,
+							Notebook:   nb,
+							Note:       n.Name,
+						})
+					}
+				}
+			}
+			return defs
 		},
 		HideChecked: cfg.HideChecked,
 		CascadeChecks: cfg.CascadeChecks,

--- a/internal/block/serialize.go
+++ b/internal/block/serialize.go
@@ -112,6 +112,28 @@ func Serialize(blocks []Block) string {
 	return strings.Join(lines, "\n")
 }
 
+// IsEmptyParagraph reports whether a block is a blank paragraph — the
+// shape that Parse produces for a bare newline in the source file.
+func IsEmptyParagraph(b Block) bool {
+	return b.Type == Paragraph && b.Content == ""
+}
+
+// TrimEmptyEdges drops leading and trailing empty-paragraph blocks.
+// Blank lines in the middle of the document are preserved. View-mode
+// rendering uses this to hide accidental top/bottom whitespace without
+// mutating the file on disk.
+func TrimEmptyEdges(blocks []Block) []Block {
+	start := 0
+	for start < len(blocks) && IsEmptyParagraph(blocks[start]) {
+		start++
+	}
+	end := len(blocks)
+	for end > start && IsEmptyParagraph(blocks[end-1]) {
+		end--
+	}
+	return blocks[start:end]
+}
+
 // isSeparatorCell reports whether a trimmed cell is a GFM separator
 // (e.g. "---", ":---", "---:", ":---:").
 func isSeparatorCell(s string) bool {

--- a/internal/block/serialize_test.go
+++ b/internal/block/serialize_test.go
@@ -260,6 +260,37 @@ func TestSerializeTableAlignmentPreserved(t *testing.T) {
 	}
 }
 
+func TestTrimEmptyEdges(t *testing.T) {
+	blocks := []Block{
+		{Type: Paragraph, Content: ""},
+		{Type: Paragraph, Content: ""},
+		{Type: Heading1, Content: "Title"},
+		{Type: Paragraph, Content: "body"},
+		{Type: Paragraph, Content: ""},
+		{Type: Paragraph, Content: ""},
+	}
+	trimmed := TrimEmptyEdges(blocks)
+	if len(trimmed) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(trimmed))
+	}
+	if trimmed[0].Type != Heading1 || trimmed[1].Type != Paragraph {
+		t.Fatalf("wrong block types after trim: %+v", trimmed)
+	}
+}
+
+// Internal blanks must survive — they're how paragraphs get separated.
+func TestTrimEmptyEdgesPreservesInternal(t *testing.T) {
+	blocks := []Block{
+		{Type: Paragraph, Content: "one"},
+		{Type: Paragraph, Content: ""},
+		{Type: Paragraph, Content: "two"},
+	}
+	trimmed := TrimEmptyEdges(blocks)
+	if len(trimmed) != 3 {
+		t.Fatalf("expected 3 blocks, got %d", len(trimmed))
+	}
+}
+
 func TestSerializeNumberedListResets(t *testing.T) {
 	blocks := []Block{
 		{Type: NumberedList, Content: "one"},

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -496,8 +496,13 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if s == "i" && m.level == 0 {
 			return m.startImport()
 		}
-		if s == "c" && m.level == 1 {
-			return m.copyNote()
+		if s == "c" {
+			if m.level == 0 && m.inRecentsSection() {
+				return m.copyRecentEntry()
+			}
+			if m.level == 1 {
+				return m.copyNote()
+			}
 		}
 		if s == "t" {
 			return m.startThemePicker()
@@ -1039,6 +1044,44 @@ func (m Model) copyNote() (tea.Model, tea.Cmd) {
 			return statusMsg{fmt.Sprintf("Could not copy: %s", err)}
 		}
 		return statusMsg{fmt.Sprintf("Copied %q to clipboard", storage.DisplayName(note.Name))}
+	}
+}
+
+func (m Model) copyRecentEntry() (tea.Model, tea.Cmd) {
+	if len(m.filteredRecent) == 0 {
+		return m, nil
+	}
+	_, localIdx := m.cursorSection()
+	if localIdx >= len(m.filteredRecent) {
+		return m, nil
+	}
+	idx := m.filteredRecent[localIdx]
+	entry := m.recentEntries[idx]
+
+	return m, func() tea.Msg {
+		var content, label string
+		switch entry.Type {
+		case recents.TypeStore:
+			n, err := m.store.GetNote(entry.Notebook, entry.Name)
+			if err != nil {
+				return statusMsg{fmt.Sprintf("Could not load: %s", err)}
+			}
+			content = n.Content
+			label = storage.DisplayName(entry.Name)
+		case recents.TypeExternal:
+			data, err := os.ReadFile(entry.Path)
+			if err != nil {
+				return statusMsg{fmt.Sprintf("Could not read: %s", err)}
+			}
+			content = string(data)
+			label = filepath.Base(entry.Path)
+		default:
+			return statusMsg{"Unknown recent entry type"}
+		}
+		if err := clipboard.Copy(content); err != nil {
+			return statusMsg{fmt.Sprintf("Could not copy: %s", err)}
+		}
+		return statusMsg{fmt.Sprintf("Copied %q to clipboard", label)}
 	}
 }
 

--- a/internal/editor/deflookup.go
+++ b/internal/editor/deflookup.go
@@ -15,11 +15,16 @@ type defLookup struct {
 	defItems []defItem // raw items with block indices
 }
 
-// defItem represents one definition list block in the document.
+// defItem represents one definition list block. Local items (from the
+// current document) have BlockIdx >= 0 and Notebook/Note empty; remote
+// items (gathered across notebooks) have BlockIdx == -1 and a populated
+// Notebook/Note pair shown alongside the term.
 type defItem struct {
 	Term       string
 	Definition string
 	BlockIdx   int
+	Notebook   string
+	Note       string
 }
 
 func (d defItem) FilterValue() string { return d.Term }
@@ -33,8 +38,18 @@ func (d defItem) RenderRow(selected bool, width int) string {
 	if term == "" {
 		term = "(empty)"
 	}
+
+	var location string
+	if d.Notebook != "" || d.Note != "" {
+		location = d.Notebook + "/" + d.Note
+	}
+
 	def := d.Definition
-	maxDef := width - len(term) - 8
+	overhead := len(term) + 8
+	if location != "" {
+		overhead += len(location) + 3
+	}
+	maxDef := width - overhead
 	if maxDef < 10 {
 		maxDef = 10
 	}
@@ -46,25 +61,35 @@ func (d defItem) RenderRow(selected bool, width int) string {
 		marker := accent.Render("\u203a")
 		termStr := accent.Render(term)
 		defStr := dim.Render(def)
-		return " " + marker + " " + termStr + "  " + defStr
+		out := " " + marker + " " + termStr + "  " + defStr
+		if location != "" {
+			out += "  " + dim.Render("["+location+"]")
+		}
+		return out
 	}
 	termStr := lipgloss.NewStyle().Bold(true).Render(term)
 	defStr := dim.Render(def)
-	return "   " + termStr + "  " + defStr
+	out := "   " + termStr + "  " + defStr
+	if location != "" {
+		out += "  " + dim.Render("["+location+"]")
+	}
+	return out
 }
 
 // newDefLookup creates a definition lookup ready for use.
 func newDefLookup() defLookup {
 	d := defLookup{}
 	d.Prompt = ": "
-	d.Placeholder = "search definitions..."
+	d.Placeholder = "search definitions across all files..."
 	d.NoMatchText = "No matches"
 	d.MaxVisible = 6
 	return d
 }
 
-// open scans blocks for definition lists and shows the lookup.
-func (d *defLookup) open(blocks []block.Block) {
+// open scans the current document for definition lists, optionally
+// merging in cross-note definitions when remote != nil. Local items
+// always come first so jumping within the current note stays cheap.
+func (d *defLookup) open(blocks []block.Block, remote []DefinitionEntry) {
 	d.defItems = nil
 	for i, b := range blocks {
 		if b.Type == block.DefinitionList {
@@ -75,6 +100,15 @@ func (d *defLookup) open(blocks []block.Block) {
 				BlockIdx:   i,
 			})
 		}
+	}
+	for _, e := range remote {
+		d.defItems = append(d.defItems, defItem{
+			Term:       e.Term,
+			Definition: e.Definition,
+			BlockIdx:   -1,
+			Notebook:   e.Notebook,
+			Note:       e.Note,
+		})
 	}
 	items := make([]ui.PickerItem, len(d.defItems))
 	for i, di := range d.defItems {

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -46,6 +46,20 @@ type Config struct {
 	// ListEmbedTargets returns all available "notebook/note" paths for the
 	// embed picker. Called when the picker opens.
 	ListEmbedTargets func() []string
+	// ListAllDefinitions returns definition list entries gathered from every
+	// note across all notebooks, excluding the note currently being edited
+	// (since its in-memory blocks may differ from disk). When nil, the ":"
+	// lookup is restricted to the current note.
+	ListAllDefinitions func() []DefinitionEntry
+}
+
+// DefinitionEntry is a single definition list block sourced from another
+// note. The Notebook/Note pair locates the source for display in the lookup.
+type DefinitionEntry struct {
+	Term       string
+	Definition string
+	Notebook   string
+	Note       string
 }
 
 // savedMsg is sent after a successful save.
@@ -849,11 +863,13 @@ func (m *Model) swapBlocks(delta int) {
 
 	bStart, bEnd := m.blockBundle(m.active)
 
-	// Sync table cell before swapping.
+	// Sync the active cell into the block's serialized content so the
+	// swap persists user edits. The textarea itself must stay as the
+	// cell view — clobbering it with the full serialized table would
+	// cause the next render to draw the whole table inside one cell.
 	if m.table != nil && m.blocks[m.active].Type == block.Table {
 		m.table.syncCell(m.textareas[m.active])
 		m.blocks[m.active].Content = m.table.serialize()
-		m.textareas[m.active].SetValue(m.blocks[m.active].Content)
 	}
 
 	// Sync textarea content in the active bundle.
@@ -1358,7 +1374,7 @@ func (m *Model) handlePickerSelect() {
 		m.embedPicker.Close()
 
 	case m.defLookup.Visible:
-		if sel := m.defLookup.selected(); sel != nil {
+		if sel := m.defLookup.selected(); sel != nil && sel.BlockIdx >= 0 {
 			if m.viewMode {
 				m.active = sel.BlockIdx
 				if sel.BlockIdx < len(m.blockLineOffsets) {
@@ -1370,6 +1386,15 @@ func (m *Model) handlePickerSelect() {
 		}
 		m.defLookup.close()
 	}
+}
+
+// remoteDefinitions returns definition entries from notes other than the
+// current one, or nil when the host hasn't wired up the lookup.
+func (m Model) remoteDefinitions() []DefinitionEntry {
+	if m.config.ListAllDefinitions == nil {
+		return nil
+	}
+	return m.config.ListAllDefinitions()
 }
 
 // isAtFirstLine returns true if the cursor is on the first visual line
@@ -1767,7 +1792,7 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			default:
 				if msg.Code == ':' {
-					m.defLookup.open(m.blocks)
+					m.defLookup.open(m.blocks, m.remoteDefinitions())
 					m.updateViewport()
 					return m, nil
 				}
@@ -1893,12 +1918,43 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case "alt+up":
+			// Table: at top line of cell, move to cell above
+			// (preserving horizontal position). Falls through to block
+			// swap when already on the top row.
+			if m.isAtFirstLine() && m.table != nil && m.table.row > 0 {
+				ta := &m.textareas[m.active]
+				charOffset := ta.LineInfo().CharOffset
+				cw := m.tableCellTAWidth()
+				m.table.syncCell(*ta)
+				m.table.row--
+				m.table.loadCell(ta, cw, true)
+				li := ta.LineInfo()
+				ta.SetCursorColumn(li.StartColumn + charOffset)
+				m.cursorCmd = ta.Focus()
+				m.updateViewport()
+				return m, nil
+			}
 			m.pushUndo()
 			m.swapBlocks(-1)
 			m.updateViewport()
 			return m, nil
 
 		case "alt+down":
+			// Table: at bottom line of cell, move to cell below
+			// (preserving horizontal position). Falls through to block
+			// swap when already on the last row.
+			if m.isAtLastLine() && m.table != nil && m.table.row < len(m.table.cells)-1 {
+				ta := &m.textareas[m.active]
+				charOffset := ta.LineInfo().CharOffset
+				cw := m.tableCellTAWidth()
+				m.table.syncCell(*ta)
+				m.table.row++
+				m.table.loadCell(ta, cw, false)
+				ta.SetCursorColumn(charOffset)
+				m.cursorCmd = ta.Focus()
+				m.updateViewport()
+				return m, nil
+			}
 			m.pushUndo()
 			m.swapBlocks(1)
 			m.updateViewport()
@@ -1978,7 +2034,7 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.openEmbedModal(m.active)
 					return m, nil
 				case block.DefinitionList:
-					m.defLookup.open(m.blocks)
+					m.defLookup.open(m.blocks, m.remoteDefinitions())
 					m.updateViewport()
 					return m, nil
 				}
@@ -2036,7 +2092,7 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if keyMsg.Code == ':' && len(keyMsg.Text) > 0 {
 				ta := &m.textareas[m.active]
 				if ta.Line() == 0 && ta.LineInfo().ColumnOffset == 0 && ta.Value() == "" {
-					m.defLookup.open(m.blocks)
+					m.defLookup.open(m.blocks, m.remoteDefinitions())
 					m.updateViewport()
 					return m, nil
 				}
@@ -2076,6 +2132,22 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 				if keyMsg.Code == tea.KeyEnter {
 					m.table.syncCell(*ta)
+
+					// Empty row → exit table and drop the row (matches the
+					// "Enter on empty block exits" pattern used elsewhere).
+					if m.table.isRowEmpty(m.table.row) {
+						m.pushUndo()
+						if len(m.table.cells) > 1 {
+							m.table.deleteRow()
+						}
+						m.blocks[m.active].Content = m.table.serialize()
+						m.textareas[m.active].SetValue(m.blocks[m.active].Content)
+						m.table = nil
+						m.insertBlockAfter(m.active, block.Block{Type: block.Paragraph})
+						m.updateViewport()
+						return m, nil
+					}
+
 					m.table.row++
 					if m.table.row >= len(m.table.cells) {
 						newRow := make([]string, m.table.numCols())
@@ -2118,6 +2190,78 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 				}
 
+				// Home (or Cmd+Left on macOS terminals): if cursor is
+				// already at the cell's line-start, jump to prev cell.
+				if keyMsg.Code == tea.KeyHome {
+					li := ta.LineInfo()
+					atLineStart := li.ColumnOffset == 0 && li.RowOffset == 0 && ta.Line() == 0
+					if atLineStart && (m.table.row > 0 || m.table.col > 0) {
+						m.table.syncCell(*ta)
+						m.table.prevCell()
+						m.table.loadCell(ta, cw, true)
+						m.cursorCmd = ta.Focus()
+						m.updateViewport()
+						return m, nil
+					}
+				}
+
+				// End (or Cmd+Right on macOS terminals): if already at
+				// line-end of the last line, jump to next cell.
+				if keyMsg.Code == tea.KeyEnd {
+					li := ta.LineInfo()
+					lines := strings.Split(ta.Value(), "\n")
+					lineRunes := []rune{}
+					if ta.Line() < len(lines) {
+						lineRunes = []rune(lines[ta.Line()])
+					}
+					atLineEnd := m.isAtLastLine() && li.StartColumn+li.ColumnOffset >= len(lineRunes)
+					if atLineEnd && (m.table.row < len(m.table.cells)-1 || m.table.col < m.table.numCols()-1) {
+						m.table.syncCell(*ta)
+						m.table.nextCell()
+						m.table.loadCell(ta, cw, false)
+						m.cursorCmd = ta.Focus()
+						m.updateViewport()
+						return m, nil
+					}
+				}
+
+				// Alt+Left / Ctrl+A at cell start: jump to previous cell.
+				// macOS terminals remap Alt+Left → Ctrl+A, so we accept
+				// all three forms. Same edge-jump as plain Left but
+				// reachable in a single keypress.
+				keyStr := keyMsg.String()
+				if keyStr == "alt+left" || keyStr == "alt+b" || keyStr == "ctrl+a" {
+					li := ta.LineInfo()
+					atStart := ta.Line() == 0 && li.ColumnOffset == 0 && li.RowOffset == 0
+					if atStart && (m.table.row > 0 || m.table.col > 0) {
+						m.table.syncCell(*ta)
+						m.table.prevCell()
+						m.table.loadCell(ta, cw, true)
+						m.cursorCmd = ta.Focus()
+						m.updateViewport()
+						return m, nil
+					}
+				}
+
+				// Alt+Right / Ctrl+E at cell end: jump to next cell.
+				if keyStr == "alt+right" || keyStr == "alt+f" || keyStr == "ctrl+e" {
+					li := ta.LineInfo()
+					lines := strings.Split(ta.Value(), "\n")
+					lineRunes := []rune{}
+					if ta.Line() < len(lines) {
+						lineRunes = []rune(lines[ta.Line()])
+					}
+					atEnd := m.isAtLastLine() && li.StartColumn+li.ColumnOffset >= len(lineRunes)
+					if atEnd && (m.table.row < len(m.table.cells)-1 || m.table.col < m.table.numCols()-1) {
+						m.table.syncCell(*ta)
+						m.table.nextCell()
+						m.table.loadCell(ta, cw, false)
+						m.cursorCmd = ta.Focus()
+						m.updateViewport()
+						return m, nil
+					}
+				}
+
 				// Alt+R: insert row below.
 				if keyMsg.Code == 'r' && keyMsg.Mod.Contains(tea.ModAlt) {
 					m.pushUndo()
@@ -2142,8 +2286,10 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, nil
 				}
 
-				// Alt+Backspace: delete current row (if more than one).
-				if keyMsg.Code == tea.KeyBackspace && keyMsg.Mod.Contains(tea.ModAlt) {
+				// Alt+Shift+Backspace: delete current row. Using a shift
+				// variant keeps plain Alt+Backspace available for
+				// word-delete, matching behavior in other blocks.
+				if keyMsg.Code == tea.KeyBackspace && keyMsg.Mod.Contains(tea.ModAlt) && keyMsg.Mod.Contains(tea.ModShift) {
 					m.pushUndo()
 					m.table.syncCell(*ta)
 					if m.table.deleteRow() {
@@ -2154,8 +2300,9 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, nil
 				}
 
-				// Alt+D: delete current column (if more than one).
-				if keyMsg.Code == 'd' && keyMsg.Mod.Contains(tea.ModAlt) {
+				// Alt+Shift+D: delete current column. Plain Alt+D remains
+				// word-delete-forward to match other blocks.
+				if (keyMsg.Code == 'd' || keyMsg.Code == 'D') && keyMsg.Mod.Contains(tea.ModAlt) && keyMsg.Mod.Contains(tea.ModShift) {
 					m.pushUndo()
 					m.table.syncCell(*ta)
 					if m.table.deleteCol() {
@@ -2291,9 +2438,17 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Capture state before the textarea processes the keystroke so we
 		// can detect whether content actually changed (vs. cursor movement).
+		// Also snapshot the raw textarea value — for tables, captureState
+		// stores the serialized table in blocks[active].Content, which
+		// never equals the per-cell textarea value, so we can't compare
+		// against it to detect real edits.
 		var preState editorState
-		if !m.undoDirty {
+		var preValue string
+		preStateCaptured := false
+		if !m.undoDirty && m.active >= 0 && m.active < len(m.textareas) {
 			preState = m.captureState()
+			preValue = m.textareas[m.active].Value()
+			preStateCaptured = true
 		}
 
 		// Enforce correct width BEFORE the textarea processes the key,
@@ -2309,7 +2464,7 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Only push an undo entry when content actually changed, not on
 		// cursor-only movements (left, right, home, end, etc.).
-		if !m.undoDirty && m.textareas[m.active].Value() != preState.blocks[preState.active].Content {
+		if preStateCaptured && m.textareas[m.active].Value() != preValue {
 			m.undo.push(preState)
 			m.redo.clear()
 			m.undoDirty = true
@@ -2464,8 +2619,25 @@ func (m *Model) updateViewport() {
 		if scrollTarget < yOffset {
 			yOffset = scrollTarget
 		}
-		if cursorLine >= yOffset+m.viewport.Height() {
-			yOffset = cursorLine - m.viewport.Height() + 1
+
+		// In tables, also try to keep the rows + bottom border below the
+		// cursor on screen — without this the last row sits flush against
+		// the viewport bottom and the closing border gets clipped.
+		bottomTarget := cursorLine
+		if m.table != nil && m.blocks[m.active].Type == block.Table {
+			rowsBelow := len(m.table.cells) - 1 - m.table.row
+			if rowsBelow < 0 {
+				rowsBelow = 0
+			}
+			bottomTarget = cursorLine + rowsBelow*2 + 1
+		}
+		if bottomTarget >= yOffset+m.viewport.Height() {
+			candidate := bottomTarget - m.viewport.Height() + 1
+			// Never push the cursor itself off the top of the viewport.
+			if candidate > cursorLine {
+				candidate = cursorLine
+			}
+			yOffset = candidate
 		}
 		if yOffset < 0 {
 			yOffset = 0
@@ -2473,6 +2645,21 @@ func (m *Model) updateViewport() {
 
 		m.viewport.SetYOffset(yOffset)
 	}
+}
+
+// viewRange returns the [start, end) slice of m.blocks that view-mode
+// renders — leading and trailing empty paragraph blocks are skipped so
+// accidental blank space at the edges of the document doesn't bloat
+// the rendered view. Internal blanks (paragraph separators) are kept.
+func (m Model) viewRange() (int, int) {
+	start, end := 0, len(m.blocks)
+	for start < end && block.IsEmptyParagraph(m.blocks[start]) {
+		start++
+	}
+	for end > start && block.IsEmptyParagraph(m.blocks[end-1]) {
+		end--
+	}
+	return start, end
 }
 
 // computeBlockLineOffsets mirrors the spacing logic of renderViewContent to
@@ -2508,9 +2695,15 @@ func (m *Model) computeBlockLineOffsets() {
 		advance("")
 	}
 
+	// Skipped blocks keep offset -1 so blockIndexAtLine ignores them.
 	offsets := make([]int, len(m.blocks))
+	for i := range offsets {
+		offsets[i] = -1
+	}
+	vStart, vEnd := m.viewRange()
 	prevIdx := -1
-	for i, b := range m.blocks {
+	for i := vStart; i < vEnd; i++ {
+		b := m.blocks[i]
 		content := b.Content
 		if i == m.active && i < len(m.textareas) {
 			content = m.textareas[i].Value()
@@ -2553,12 +2746,16 @@ func (m *Model) computeBlockLineOffsets() {
 
 // blockIndexAtLine returns the block index that contains the given absolute
 // line number in view-mode rendered content, or -1 if no block matches.
+// Blocks skipped by viewRange have offset -1 and are ignored.
 func (m Model) blockIndexAtLine(line int) int {
 	if len(m.blockLineOffsets) == 0 {
 		return -1
 	}
 	result := -1
 	for i, offset := range m.blockLineOffsets {
+		if offset < 0 {
+			continue
+		}
 		if offset <= line {
 			result = i
 		} else {
@@ -2622,8 +2819,10 @@ func (m Model) renderViewContent() string {
 		parts = append(parts, "")
 	}
 
+	vStart, vEnd := m.viewRange()
 	prevIdx := -1
-	for i, b := range m.blocks {
+	for i := vStart; i < vEnd; i++ {
+		b := m.blocks[i]
 		content := b.Content
 		if i == m.active && i < len(m.textareas) {
 			content = m.textareas[i].Value()
@@ -2798,7 +2997,7 @@ func (m Model) blockHint() string {
 	}
 	switch m.blocks[m.active].Type {
 	case block.Table:
-		return "\u2325R +row \u00B7 \u2325C +col \u00B7 \u2325\u232B del row \u00B7 \u2325D del col"
+		return "\u2325R +row \u00B7 \u2325C +col \u00B7 \u2325\u21E7\u232B del row \u00B7 \u2325\u21E7D del col"
 	case block.Callout:
 		return "\u2303T variant"
 	case block.CodeBlock:
@@ -2936,10 +3135,24 @@ func (m *Model) renderEmbedSheetContent() {
 
 	var parts []string
 	offsets := make([]int, len(em.blocks))
+	for i := range offsets {
+		offsets[i] = -1
+	}
 	parts = append(parts, "") // top breathing room
 
+	// Trim leading/trailing empty paragraphs so embedded previews don't
+	// lead with a wall of whitespace.
+	vStart, vEnd := 0, len(em.blocks)
+	for vStart < vEnd && block.IsEmptyParagraph(em.blocks[vStart]) {
+		vStart++
+	}
+	for vEnd > vStart && block.IsEmptyParagraph(em.blocks[vEnd-1]) {
+		vEnd--
+	}
+
 	prevIdx := -1
-	for i, b := range em.blocks {
+	for i := vStart; i < vEnd; i++ {
+		b := em.blocks[i]
 		if prevIdx >= 0 {
 			prev := em.blocks[prevIdx]
 			switch {

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -826,6 +826,36 @@ func TestAltDownMovesBlockDown(t *testing.T) {
 	}
 }
 
+// Regression: swapBlocks on an active Table block used to clobber the
+// cell textarea with the full serialized table, which rendered as a
+// nested "double table" inside cell (0,0).
+func TestAltDownOnActiveTableKeepsCellTextarea(t *testing.T) {
+	content := "| a | b |\n| --- | --- |\n| c | d |\n\nParagraph"
+	m := New(Config{Title: "test", Content: content})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(Model)
+
+	m.focusBlock(0)
+	if m.blocks[0].Type != block.Table {
+		t.Fatalf("expected first block to be a table, got %d", m.blocks[0].Type)
+	}
+	if m.table == nil {
+		t.Fatal("expected table state to be initialised on focus")
+	}
+
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown, Mod: tea.ModAlt})
+	m = updated.(Model)
+
+	if m.blocks[m.active].Type != block.Table {
+		t.Fatalf("table should have moved and stayed focused, got type %d", m.blocks[m.active].Type)
+	}
+	// Active cell is (0,0); textarea must hold only that cell's value.
+	got := m.textareas[m.active].Value()
+	if strings.Contains(got, "|") || strings.Contains(got, "---") {
+		t.Fatalf("cell textarea should hold cell value, not serialized table: %q", got)
+	}
+}
+
 func TestAltUpNoOpAtTop(t *testing.T) {
 	content := "# Title\n\nParagraph"
 	m := New(Config{Title: "test", Content: content})

--- a/internal/editor/table.go
+++ b/internal/editor/table.go
@@ -71,6 +71,19 @@ func (ts *tableState) numCols() int {
 	return len(ts.cells[0])
 }
 
+// isRowEmpty reports whether every cell in the given row is empty.
+func (ts *tableState) isRowEmpty(row int) bool {
+	if row < 0 || row >= len(ts.cells) {
+		return false
+	}
+	for _, cell := range ts.cells[row] {
+		if cell != "" {
+			return false
+		}
+	}
+	return true
+}
+
 // nextCell advances to the next cell. Returns true if a new row was added.
 func (ts *tableState) nextCell() bool {
 	nc := ts.numCols()

--- a/internal/format/inline.go
+++ b/internal/format/inline.go
@@ -20,51 +20,21 @@ const (
 // RenderInlineMarkdown applies inline markdown formatting to plain text.
 // Supports **bold**, *italic*, ~~strikethrough~~, and __underline__ with
 // correct nesting. Uses targeted ANSI SGR codes (not full resets) so that
-// outer block-level styles (e.g. heading bold) are preserved.
+// outer block-level styles (e.g. heading bold) are preserved. Delimiter
+// pairs may span newlines — useful when the caller has already
+// word-wrapped text, which can split a **foo bar** marker across lines.
 func RenderInlineMarkdown(text string) string {
-	lines := strings.Split(text, "\n")
-	for i, line := range lines {
-		lines[i] = renderInlineLine(line)
-	}
-	return strings.Join(lines, "\n")
-}
-
-type delimKind int
-
-const (
-	delimBold          delimKind = iota
-	delimItalic
-	delimStrikethrough
-	delimUnderline
-)
-
-// delimPair records a matched open/close delimiter and the rune ranges it covers.
-type delimPair struct {
-	kind       delimKind
-	openStart  int // first rune of opening delimiter
-	openEnd    int // rune after opening delimiter (content starts here)
-	closeStart int // first rune of closing delimiter
-	closeEnd   int // rune after closing delimiter
-}
-
-type styleFlags struct {
-	bold, italic, strikethrough, underline bool
-}
-
-func renderInlineLine(line string) string {
-	runes := []rune(line)
+	runes := []rune(text)
 	n := len(runes)
 	if n == 0 {
 		return ""
 	}
 
-	// Pass 1: find all matched delimiter pairs.
 	pairs := findDelimiterPairs(runes)
 	if len(pairs) == 0 {
-		return line
+		return text
 	}
 
-	// Mark delimiter runes for removal.
 	skip := make([]bool, n)
 	for _, p := range pairs {
 		for j := p.openStart; j < p.openEnd; j++ {
@@ -75,7 +45,6 @@ func renderInlineLine(line string) string {
 		}
 	}
 
-	// Pass 2: emit text with targeted ANSI style transitions.
 	var buf strings.Builder
 	buf.Grow(n * 2)
 	var active styleFlags
@@ -85,7 +54,23 @@ func renderInlineLine(line string) string {
 			continue
 		}
 
-		// Determine which styles are active at this rune.
+		// Close active styles around newlines so styles don't bleed
+		// into prefixes/indents added by the caller on the next line.
+		// Reopen after the newline to continue the style visually.
+		if runes[i] == '\n' {
+			if active != (styleFlags{}) {
+				saved := active
+				emitTransition(&buf, active, styleFlags{})
+				active = styleFlags{}
+				buf.WriteRune('\n')
+				emitTransition(&buf, active, saved)
+				active = saved
+			} else {
+				buf.WriteRune('\n')
+			}
+			continue
+		}
+
 		var flags styleFlags
 		for _, p := range pairs {
 			if i >= p.openEnd && i < p.closeStart {
@@ -109,9 +94,30 @@ func renderInlineLine(line string) string {
 		buf.WriteRune(runes[i])
 	}
 
-	// Disable any styles still open.
 	emitTransition(&buf, active, styleFlags{})
 	return buf.String()
+}
+
+type delimKind int
+
+const (
+	delimBold          delimKind = iota
+	delimItalic
+	delimStrikethrough
+	delimUnderline
+)
+
+// delimPair records a matched open/close delimiter and the rune ranges it covers.
+type delimPair struct {
+	kind       delimKind
+	openStart  int // first rune of opening delimiter
+	openEnd    int // rune after opening delimiter (content starts here)
+	closeStart int // first rune of closing delimiter
+	closeEnd   int // rune after closing delimiter
+}
+
+type styleFlags struct {
+	bold, italic, strikethrough, underline bool
 }
 
 // emitTransition writes only the ANSI codes needed to move from one style set to another.

--- a/internal/format/inline_test.go
+++ b/internal/format/inline_test.go
@@ -125,6 +125,16 @@ func TestRenderInlineMarkdown_MultiLine(t *testing.T) {
 	}
 }
 
+// When the caller has already word-wrapped the text, a **bold** pair can
+// span across a newline. The renderer should still style both lines.
+func TestRenderInlineMarkdown_DelimiterSpansWrappedLines(t *testing.T) {
+	result := RenderInlineMarkdown("**add the correct version\nto the settings.**")
+	expected := boldOn + "add the correct version" + boldOff + "\n" + boldOn + "to the settings." + boldOff
+	if result != expected {
+		t.Errorf("wrapped bold:\n got: %q\nwant: %q", result, expected)
+	}
+}
+
 func TestRenderInlineMarkdown_PlainText(t *testing.T) {
 	input := "no formatting here"
 	result := RenderInlineMarkdown(input)

--- a/internal/storage/welcome.go
+++ b/internal/storage/welcome.go
@@ -47,7 +47,12 @@ const showcaseContent = "" +
 	"## Code Blocks\n\n" +
 	"```go\nfunc main() {\n    fmt.Println(\"Hello from notebook!\")\n}\n```\n\n" +
 	"## Tables\n\n" +
-	"| Shortcut | Action |\n| --- | --- |\n| Alt+R | Add row |\n| Alt+C | Add column |\n\n" +
+	"| Shortcut                | Action              |\n" +
+	"| ---                     | ---                 |\n" +
+	"| Alt+R / Alt+C           | Add row / column    |\n" +
+	"| Alt+Shift+Bksp / Alt+⇧D | Delete row / column |\n" +
+	"| Home / End              | Jump between cells  |\n" +
+	"| Enter on empty row      | Exit table          |\n\n" +
 	"## Quotes\n\n" +
 	"> The best way to predict the future is to invent it.\n> \u2014 Alan Kay\n\n" +
 	"## Definitions\n\n" +

--- a/internal/ui/picker.go
+++ b/internal/ui/picker.go
@@ -21,6 +21,7 @@ type Picker struct {
 	filtered    []int
 	filter      string
 	cursor      int
+	reserved    int    // row slots kept constant across filter changes
 	Prompt      string // displayed before the filter text, e.g. "/", "↗ ", ": "
 	Placeholder string // shown when filter is empty, e.g. "type to filter..."
 	NoMatchText string // shown when filter yields no results
@@ -35,11 +36,17 @@ type Picker struct {
 }
 
 // Open populates the picker with items, resets state, and makes it visible.
+// The reserved row count is pinned at open time so subsequent filter changes
+// don't resize the footer and shift surrounding layout.
 func (p *Picker) Open(items []PickerItem) {
 	p.Visible = true
 	p.items = items
 	p.filter = ""
 	p.cursor = 0
+	p.reserved = len(items)
+	if p.MaxVisible > 0 && p.reserved > p.MaxVisible {
+		p.reserved = p.MaxVisible
+	}
 	p.Refilter()
 }
 
@@ -48,6 +55,7 @@ func (p *Picker) Close() {
 	p.Visible = false
 	p.filter = ""
 	p.cursor = 0
+	p.reserved = 0
 	p.items = nil
 	p.FilterFunc = nil
 }
@@ -167,14 +175,15 @@ func (p *Picker) FilteredIndices() []int {
 func (p *Picker) Items() []PickerItem { return p.items }
 
 // Height returns the number of terminal lines the footer panel occupies.
+// Once opened, the height stays pinned to the reserved row count so
+// filter-driven list shrinkage can't reshape the surrounding layout.
 func (p *Picker) Height() int {
 	if !p.Visible {
 		return 0
 	}
-	// border + filter line = 2
-	n := p.visibleCount()
-	if n == 0 && p.filter != "" {
-		n = 1 // "No matches" line
+	n := p.reserved
+	if n < 1 && p.filter != "" {
+		n = 1 // room for "No matches"
 	}
 	return n + 2
 }
@@ -232,38 +241,50 @@ func (p *Picker) RenderFooter(width int) string {
 		// Show the list even when filter is empty.
 	}
 
-	if len(p.filtered) == 0 && p.filter != "" {
-		noMatch := dim.Render(p.NoMatchText)
-		return border + "\n" + filterLine + "\n" + " " + noMatch + "\n"
-	}
-
-	if len(p.filtered) == 0 {
-		return border + "\n" + filterLine + "\n"
-	}
-
-	// Build rows.
-	start, end := p.visibleWindow()
+	// Build rows. The list is padded to `reserved` rows so the footer
+	// height stays constant even as filter narrows results.
 	var rows []string
 
-	// Scroll-up indicator.
-	if start > 0 {
-		rows = append(rows, dim.Render("  \u2191 more"))
+	if len(p.filtered) == 0 {
+		if p.filter != "" {
+			rows = append(rows, " "+dim.Render(p.NoMatchText))
+		}
+	} else {
+		start, end := p.visibleWindow()
+
+		// Scroll-up indicator.
+		if start > 0 {
+			rows = append(rows, dim.Render("  \u2191 more"))
+		}
+
+		rowWidth := width - 4 // margin for borders/padding
+		if rowWidth < 20 {
+			rowWidth = 20
+		}
+
+		for i := start; i < end; i++ {
+			item := p.items[p.filtered[i]]
+			rows = append(rows, item.RenderRow(i == p.cursor, rowWidth))
+		}
+
+		// Scroll-down indicator.
+		if end < len(p.filtered) {
+			rows = append(rows, dim.Render("  \u2193 more"))
+		}
 	}
 
-	rowWidth := width - 4 // margin for borders/padding
-	if rowWidth < 20 {
-		rowWidth = 20
+	// Pad to the reserved row count so layout doesn't shift as the
+	// filter narrows results.
+	target := p.reserved
+	if target < 1 && p.filter != "" {
+		target = 1
+	}
+	for len(rows) < target {
+		rows = append(rows, "")
 	}
 
-	for i := start; i < end; i++ {
-		item := p.items[p.filtered[i]]
-		rows = append(rows, item.RenderRow(i == p.cursor, rowWidth))
+	if len(rows) == 0 {
+		return border + "\n" + filterLine + "\n"
 	}
-
-	// Scroll-down indicator.
-	if end < len(p.filtered) {
-		rows = append(rows, dim.Render("  \u2193 more"))
-	}
-
 	return border + "\n" + filterLine + "\n" + strings.Join(rows, "\n") + "\n"
 }


### PR DESCRIPTION
## Summary
- **Table cell navigation**: Alt+arrow keys (Ctrl+A/E on macOS terminals) jump between cells at content boundaries. Alt+Up/Down move vertically within the table, falling through to block-swap only on the top/bottom row.
- **Cross-file definition lookup**: The `:` palette now searches definitions across all notebooks/notes, not just the current document. Remote matches show `[notebook/note]` source and are read-only.
- **Recents copy**: `c` in the browser's recents section copies the highlighted entry's content to clipboard (store notes and external files).
- **Assorted fixes**: inline markdown across wrapped lines, picker footer height stability, table undo double-press, Alt+Up/Down table duplication bug.

## Test plan
- [ ] Open a table, navigate cursor to cell start, press Alt+Left (Ctrl+A on macOS) — should jump to previous cell
- [ ] Navigate cursor to cell end, press Alt+Right (Ctrl+E on macOS) — should jump to next cell
- [ ] Alt+Up/Down in table mid-rows — should move between rows, not swap blocks
- [ ] Type `:` in an empty block — picker should show definitions from all notebooks with `[source]` labels
- [ ] Select a cross-note definition — should dismiss without crash
- [ ] In browser recents section, press `c` — should copy note content to clipboard
- [ ] All 653 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)