### PR TITLE
feat: def preview, shift+enter/backspace fixes, copy-block

### DIFF
--- a/cmd/dispatcher.go
+++ b/cmd/dispatcher.go
@@ -189,13 +189,33 @@ func searchInBook(w io.Writer, book, query string) error {
 // --- Note-scoped operations ---
 
 func editNote(w io.Writer, book, note string) error {
+	for {
+		jumpTo, err := runEditorOnce(w, book, note)
+		if err != nil {
+			return err
+		}
+		if jumpTo == "" {
+			return nil
+		}
+		parts := strings.SplitN(jumpTo, "/", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return nil
+		}
+		book, note = parts[0], parts[1]
+	}
+}
+
+// runEditorOnce runs the block editor on a single note. Returns the
+// "notebook/note" path the editor was asked to jump to on quit (empty when
+// the user quit normally).
+func runEditorOnce(w io.Writer, book, note string) (string, error) {
 	n, err := store.GetNote(book, note)
 	if err != nil {
 		if strings.Contains(err.Error(), "no such file or directory") {
 			printError(w, fmt.Sprintf("Note %q not found in %q. Run notebook %s list to see your notes.", note, book, book))
-			return nil
+			return "", nil
 		}
-		return fmt.Errorf("edit note %q/%q: %w", book, note, err)
+		return "", fmt.Errorf("edit note %q/%q: %w", book, note, err)
 	}
 
 	var fileSize int64
@@ -299,10 +319,14 @@ func editNote(w io.Writer, book, note string) error {
 
 	m := editor.New(editorCfg)
 	p := tea.NewProgram(m)
-	if _, err := p.Run(); err != nil {
-		return fmt.Errorf("run editor: %w", err)
+	final, err := p.Run()
+	if err != nil {
+		return "", fmt.Errorf("run editor: %w", err)
 	}
-	return nil
+	if em, ok := final.(editor.Model); ok {
+		return em.JumpTarget(), nil
+	}
+	return "", nil
 }
 
 func copyNote(w io.Writer, book, note string) error {

--- a/internal/editor/deflookup.go
+++ b/internal/editor/deflookup.go
@@ -1,11 +1,30 @@
 package editor
 
 import (
+	"strings"
+
 	"charm.land/lipgloss/v2"
 	"github.com/oobagi/notebook-cli/internal/block"
 	"github.com/oobagi/notebook-cli/internal/theme"
 	"github.com/oobagi/notebook-cli/internal/ui"
 )
+
+// flattenDef collapses multi-line definition content into a single visual
+// line so picker rows stay a predictable height. Embedded newlines become
+// " \u00B7 " separators so split definitions still read coherently.
+func flattenDef(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	parts := strings.Split(s, "\n")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	return strings.Join(out, " \u00B7 ")
+}
 
 // defLookup is a searchable panel that lists all definition list blocks
 // in the current document, allowing the user to filter by term and jump
@@ -44,7 +63,7 @@ func (d defItem) RenderRow(selected bool, width int) string {
 		location = d.Notebook + "/" + d.Note
 	}
 
-	def := d.Definition
+	def := flattenDef(d.Definition)
 	overhead := len(term) + 8
 	if location != "" {
 		overhead += len(location) + 3

--- a/internal/editor/defpreview.go
+++ b/internal/editor/defpreview.go
@@ -1,0 +1,85 @@
+package editor
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/oobagi/notebook-cli/internal/theme"
+)
+
+// defPreviewPadTop is a single blank line above the preview content.
+const defPreviewPadTop = 1
+
+// wrappedLines returns the preview's wrapped definition body split by line,
+// shared between rendering and height accounting so both agree.
+func (d *defPreviewState) wrappedLines(width int) []string {
+	innerWidth := width - 4 // 2-col left pad + 2-col right breathing room
+	if innerWidth < 20 {
+		innerWidth = 20
+	}
+	// Normalize internal newlines into paragraph breaks.
+	clean := strings.ReplaceAll(d.definition, "\r\n", "\n")
+	paragraphs := strings.Split(clean, "\n")
+	var out []string
+	for i, p := range paragraphs {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			if i > 0 && i < len(paragraphs)-1 {
+				out = append(out, "")
+			}
+			continue
+		}
+		wrapped := ansi.Wordwrap(p, innerWidth, "")
+		for _, line := range strings.Split(wrapped, "\n") {
+			out = append(out, strings.TrimRight(line, " "))
+		}
+	}
+	return out
+}
+
+// Height returns the number of terminal lines the preview occupies. Layout:
+//
+//	1 separator + padTop + 1 term + 1 blank + N body lines + 1 blank
+//
+// This stays bounded by the content so short defs stay short.
+func (d *defPreviewState) Height(width int) int {
+	if !d.visible {
+		return 0
+	}
+	body := d.wrappedLines(width)
+	// 1 border + padTop + 1 term + 1 gap + body + 1 trailing gap
+	return 1 + defPreviewPadTop + 1 + 1 + len(body) + 1
+}
+
+// RenderFooter draws the preview panel as a footer pane above the status
+// bar. It mirrors the picker-footer visual contract (top border + padded
+// content) but with definition-focused styling.
+func (d *defPreviewState) RenderFooter(width int) string {
+	if !d.visible {
+		return ""
+	}
+	th := theme.Current()
+	border := lipgloss.NewStyle().Foreground(lipgloss.Color(th.Muted)).
+		Render(strings.Repeat("\u2500", width))
+	title := lipgloss.NewStyle().Foreground(lipgloss.Color(th.Accent)).Bold(true).
+		Render(d.term)
+	body := d.wrappedLines(width)
+
+	var out strings.Builder
+	out.WriteString(border)
+	out.WriteString("\n")
+	for i := 0; i < defPreviewPadTop; i++ {
+		out.WriteString("\n")
+	}
+	out.WriteString("  ")
+	out.WriteString(title)
+	out.WriteString("\n\n")
+	for _, line := range body {
+		out.WriteString("  ")
+		out.WriteString(line)
+		out.WriteString("\n")
+	}
+	out.WriteString("\n")
+	return out.String()
+}

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -12,6 +12,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/oobagi/notebook-cli/internal/block"
+	"github.com/oobagi/notebook-cli/internal/clipboard"
 	"github.com/oobagi/notebook-cli/internal/config"
 	"github.com/oobagi/notebook-cli/internal/format"
 	"github.com/oobagi/notebook-cli/internal/theme"
@@ -114,6 +115,40 @@ type Model struct {
 	embedModal    embedModalState // overlay for viewing embedded note references
 	embedPicker   embedPicker       // note picker for embed block insertion
 	table         *tableState // active table cell state (non-nil when editing a Table block)
+	defPreview    defPreviewState // focused preview for a single cross-note definition
+	jumpTarget    string      // "notebook/note" to open after editor quits; read via JumpTarget()
+	pendingJump   string      // jump requested but current note is modified — set alongside quitPrompt
+}
+
+// defPreviewState holds a focused preview of one cross-note definition.
+// Renders as a compact auto-height footer pane above the status bar, sized
+// to the wrapped content (not full-screen).
+type defPreviewState struct {
+	visible    bool
+	term       string
+	definition string
+	path       string // "notebook/note" for the Enter-to-open keybind
+}
+
+func (d *defPreviewState) open(term, definition, path string) {
+	d.visible = true
+	d.term = term
+	d.definition = definition
+	d.path = path
+}
+
+func (d *defPreviewState) close() {
+	d.visible = false
+	d.term = ""
+	d.definition = ""
+	d.path = ""
+}
+
+// JumpTarget returns the "notebook/note" path the editor was asked to open
+// before quitting, or "". Non-empty means the host should re-launch the
+// editor on that path instead of exiting normally.
+func (m Model) JumpTarget() string {
+	return m.jumpTarget
 }
 
 type statusKind int
@@ -1288,6 +1323,30 @@ func (m *Model) cutBlock() {
 	m.cursorCmd = m.textareas[m.active].Focus()
 }
 
+// copyActiveBlockContents copies the current block's text to the system
+// clipboard. Table blocks return the serialized markdown grid; all others
+// return the live textarea value so partial edits copy too. Returns a
+// status message describing the result.
+func (m *Model) copyActiveBlockContents() (string, statusKind) {
+	if m.active < 0 || m.active >= len(m.blocks) {
+		return "Nothing to copy", statusWarning
+	}
+	var content string
+	if m.blocks[m.active].Type == block.Table && m.table != nil {
+		m.table.syncCell(m.textareas[m.active])
+		content = m.table.serialize()
+	} else {
+		content = m.textareas[m.active].Value()
+	}
+	if content == "" {
+		return "Block is empty", statusWarning
+	}
+	if err := clipboard.Copy(content); err != nil {
+		return fmt.Sprintf("Could not copy: %s", err), statusError
+	}
+	return "Block copied to clipboard", statusSuccess
+}
+
 // applyPaletteSelection changes the active block's type to the selected
 // palette item type. Special handling is applied for dividers and code blocks.
 func (m *Model) applyPaletteSelection(bt block.BlockType) {
@@ -1374,7 +1433,13 @@ func (m *Model) handlePickerSelect() {
 		m.embedPicker.Close()
 
 	case m.defLookup.Visible:
-		if sel := m.defLookup.selected(); sel != nil && sel.BlockIdx >= 0 {
+		sel := m.defLookup.selected()
+		m.defLookup.close()
+		if sel == nil {
+			return
+		}
+		if sel.BlockIdx >= 0 {
+			// Local definition: focus the block directly.
 			if m.viewMode {
 				m.active = sel.BlockIdx
 				if sel.BlockIdx < len(m.blockLineOffsets) {
@@ -1383,8 +1448,11 @@ func (m *Model) handlePickerSelect() {
 			} else {
 				m.focusBlock(sel.BlockIdx)
 			}
+			return
 		}
-		m.defLookup.close()
+		// Remote definition: show a focused preview of just this
+		// definition. Enter inside the preview jumps to the source note.
+		m.openDefPreview(sel.Notebook, sel.Note, sel.Term, sel.Definition)
 	}
 }
 
@@ -1627,6 +1695,10 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			case "y", "Y", "enter":
 				m.quitPrompt = false
+				if m.pendingJump != "" {
+					m.jumpTarget = m.pendingJump
+					m.pendingJump = ""
+				}
 				if m.config.Save != nil {
 					content := m.Content()
 					return m, func() tea.Msg {
@@ -1639,10 +1711,15 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.quitting = true
 				return m, tea.Quit
 			case "n", "N", "ctrl+c":
+				if m.pendingJump != "" {
+					m.jumpTarget = m.pendingJump
+					m.pendingJump = ""
+				}
 				m.quitting = true
 				return m, tea.Quit
 			case "esc":
 				m.quitPrompt = false
+				m.pendingJump = ""
 				m.status = ""
 				m.statusStyle = statusNone
 				return m, nil
@@ -1688,6 +1765,25 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "esc", "q":
 				m.embedModal.close()
 				m.updateViewport()
+			case "enter":
+				// Jump to the previewed note. If current note has unsaved
+				// changes, trigger the save-prompt flow with pendingJump set
+				// so the "Y" path routes to save-then-jump instead of quit.
+				target := m.embedModal.path
+				if target == "" {
+					return m, nil
+				}
+				m.embedModal.close()
+				if m.modified() {
+					m.pendingJump = target
+					m.quitPrompt = true
+					m.status = "Save before opening? [Y/n/Esc]"
+					m.statusStyle = statusWarning
+					return m, nil
+				}
+				m.jumpTarget = target
+				m.quitting = true
+				return m, tea.Quit
 			case "up", "k":
 				if m.embedModal.scroll > 0 {
 					m.embedModal.scroll--
@@ -1711,6 +1807,34 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.statusStyle = statusWarning
 					return m, nil
 				}
+				m.quitting = true
+				return m, tea.Quit
+			}
+			return m, nil
+		}
+
+		// Definition preview: focused pane for a single remote definition.
+		if m.defPreview.visible {
+			switch msg.String() {
+			case "esc", "q":
+				m.defPreview.close()
+				m.updateViewport()
+				return m, nil
+			case "enter":
+				target := m.defPreview.path
+				m.defPreview.close()
+				if target == "" {
+					m.updateViewport()
+					return m, nil
+				}
+				if m.modified() {
+					m.pendingJump = target
+					m.quitPrompt = true
+					m.status = "Save before opening? [Y/n/Esc]"
+					m.statusStyle = statusWarning
+					return m, nil
+				}
+				m.jumpTarget = target
 				m.quitting = true
 				return m, tea.Quit
 			}
@@ -1847,6 +1971,10 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.cutBlock()
 			m.updateViewport()
 			return m, nil
+
+		case "alt+k":
+			m.status, m.statusStyle = m.copyActiveBlockContents()
+			return m, m.scheduleStatusDismiss()
 
 		case "ctrl+s":
 			if m.config.Save != nil {
@@ -2054,6 +2182,16 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount())
 				m.updateViewport()
 				return m, cmd
+			}
+			// Shift+Enter on single-line blocks (headings, lists) falls
+			// through to regular Enter so users don't have to release Shift.
+			// Ctrl+J stays a no-op here to preserve the "soft newline only"
+			// contract it carries in other text editors.
+			if msg.String() == "shift+enter" && m.active >= 0 && m.active < len(m.blocks) {
+				m.pushUndo()
+				m.handleEnter()
+				m.updateViewport()
+				return m, nil
 			}
 			return m, nil
 		}
@@ -2346,6 +2484,12 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						m.updateViewport()
 						return m, nil
 					}
+				}
+				// The textarea's backspace binding is an exact-match on
+				// "backspace"; "shift+backspace" gets dropped. Rewrite so a
+				// held Shift doesn't swallow the delete.
+				if keyMsg.Mod.Contains(tea.ModShift) {
+					msg = tea.KeyPressMsg{Code: tea.KeyBackspace}
 				}
 			}
 
@@ -2921,6 +3065,7 @@ func (m Model) renderHelpFooter() string {
 		{Key: "⇧Enter", Desc: "Newline"},
 		{Key: "Bksp", Desc: "Delete / merge"},
 		{Key: "⌃K", Desc: "Cut block"},
+		{Key: "⌥K", Desc: "Copy block"},
 		{Key: "⌃Z/⌃Y", Desc: "Undo / redo"},
 		{Key: "⌥↑/⌥↓", Desc: "Move block"},
 		{Key: "/", Desc: "Block type"},
@@ -2948,6 +3093,9 @@ func (m Model) renderPickerFooter() string {
 	if m.defLookup.Visible {
 		return m.defLookup.RenderFooter(m.width)
 	}
+	if m.defPreview.visible {
+		return m.defPreview.RenderFooter(m.width)
+	}
 	return ""
 }
 
@@ -2964,6 +3112,9 @@ func (m Model) footerHeight() int {
 	}
 	if m.defLookup.Visible {
 		return m.defLookup.Height()
+	}
+	if m.defPreview.visible {
+		return m.defPreview.Height(m.width)
 	}
 	return 0
 }
@@ -3037,6 +3188,16 @@ func (m Model) renderStatusBar() string {
 			hint = "click checkboxes to toggle!  [h]ide"
 		}
 		right = ": defs \u00B7 \u2303R edit \u00B7 Esc quit"
+	} else if m.embedModal.visible {
+		right = "\u21B5 open \u00B7 \u2191\u2193 scroll \u00B7 Esc close"
+	} else if m.defPreview.visible {
+		right = "\u21B5 open note \u00B7 Esc close"
+	} else if m.palette.Visible {
+		right = "\u21B5 select \u00B7 \u2191\u2193 move \u00B7 Esc close"
+	} else if m.embedPicker.Visible {
+		right = "\u21B5 insert \u00B7 \u2191\u2193 move \u00B7 Esc close"
+	} else if m.defLookup.Visible {
+		right = "\u21B5 preview \u00B7 \u2191\u2193 move \u00B7 Esc close"
 	} else {
 		// Build right-side hints: block-specific hints + contextual shortcuts.
 		bh := m.blockHint()
@@ -3113,6 +3274,14 @@ func (m *Model) openEmbedModal(idx int) {
 	refBlocks := block.Parse(content)
 	m.embedModal.open(title, path, refBlocks)
 	m.renderEmbedSheetContent()
+}
+
+// openDefPreview shows the focused definition preview for a remote def.
+// The preview is an auto-sized footer, not a fullscreen sheet. Enter inside
+// it jumps to the source note via jumpTarget.
+func (m *Model) openDefPreview(notebook, note, term, definition string) {
+	path := notebook + "/" + note
+	m.defPreview.open(term, definition, path)
 }
 
 // renderEmbedSheetContent pre-renders the embed sheet blocks into lines
@@ -3256,7 +3425,7 @@ func (m Model) renderEmbedSheet() string {
 	}
 
 	// Status bar.
-	statusRight := "Esc close \u00B7 \u2191\u2193 scroll"
+	statusRight := "\u21B5 open \u00B7 \u2191\u2193 scroll \u00B7 Esc close"
 	statusLeft := ""
 	if len(lines) > contentH {
 		pct := 0


### PR DESCRIPTION
## Summary

- **`:` lookup**: remote definitions open a compact auto-height preview pane (term as title + wrapped body), not a fullscreen sheet. Enter opens the source note, with a save prompt if the current note is dirty. Dispatcher loops so the jump re-launches the editor on the target.
- **Picker rows** flatten embedded newlines to ` · ` so multi-line definitions stay single-row and the footer stops overflowing.
- **Status bar** shows picker-specific hints (↵ / ↑↓ / Esc) while palette, embed picker, def lookup, embed sheet, or def preview are open.
- **Shift+Enter** on single-line blocks (lists, headings) falls through to regular Enter instead of silent no-op. Ctrl+J preserved.
- **Shift+Backspace** no longer gets swallowed by the textarea's exact-match binding.
- **Alt+K** copies the current block's contents to the system clipboard.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./...` — 653/653 pass
- [x] `:` lookup with multi-line def renders one row, footer visible
- [x] Enter on remote def → focused preview, Enter → opens source
- [x] Shift+Enter on bullet creates new bullet; on paragraph inserts newline
- [x] Shift+Backspace deletes characters
- [x] Alt+K copies block, pasting elsewhere works

🤖 Generated with [Claude Code](https://claude.com/claude-code)