### PR TITLE
feat: kanban block type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Kanban block**: new visual board block type. Adds via `/` command palette, ships with four default columns (Backlog / Todo / In Progress / Done) and a starter card in Backlog. Arrow keys navigate cards, Shift+arrows move them between/within columns, Enter edits the selected card (or inserts a paragraph below the board when no card is selected), `n` creates a new card, `p` cycles priority, `s` toggles auto-sort by priority, Backspace deletes the selected card (and deletes the whole board when pressed on an empty column). Done state derives from the column titled "Done". Round-trips as a `\`\`\`kanban` fenced block in the markdown file so notes stay portable.
 - Tables: Home/End now jump between cells when already at the cell's line start/end.
 - Tables: Alt+Left/Right jump to the previous/next cell when the cursor is at the cell's start/end (previously only plain Left/Right did this — Alt variants now skip the walk-to-edge step).
 - Tables: Alt+Up/Down move the focused cell up/down within the table when the cursor is on the first/last line of the cell, falling through to block-swap only on the top/bottom row.

--- a/cmd/dispatcher.go
+++ b/cmd/dispatcher.go
@@ -312,9 +312,10 @@ func runEditorOnce(w io.Writer, book, note string) (string, error) {
 			return defs
 		},
 		DismissedHints: config.LoadDismissedHints(),
-		HideChecked: cfg.HideChecked,
-		CascadeChecks: cfg.CascadeChecks,
-		WordWrap:       cfg.WordWrap,
+		HideChecked:      cfg.HideChecked,
+		CascadeChecks:    cfg.CascadeChecks,
+		WordWrap:         cfg.WordWrap,
+		KanbanSortByPrio: cfg.KanbanSortByPrio,
 	}
 
 	m := editor.New(editorCfg)

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -94,9 +94,10 @@ func openFile(path string) error {
 			}
 			return defs
 		},
-		HideChecked: cfg.HideChecked,
-		CascadeChecks: cfg.CascadeChecks,
-		WordWrap:       cfg.WordWrap,
+		HideChecked:      cfg.HideChecked,
+		CascadeChecks:    cfg.CascadeChecks,
+		WordWrap:         cfg.WordWrap,
+		KanbanSortByPrio: cfg.KanbanSortByPrio,
 	}
 
 	m := editor.New(editorCfg)

--- a/internal/block/block.go
+++ b/internal/block/block.go
@@ -26,6 +26,7 @@ const (
 	Embed                         // ![[path]] embedded note reference
 	Callout                       // > [!NOTE] callout/admonition
 	Table                         // GFM pipe table
+	Kanban                        // ```kanban``` fenced kanban board
 )
 
 // String returns the human-readable name of a BlockType.
@@ -59,6 +60,8 @@ func (bt BlockType) String() string {
 		return "Callout"
 	case Table:
 		return "Table"
+	case Kanban:
+		return "Kanban"
 	default:
 		return "Unknown"
 	}
@@ -105,6 +108,8 @@ func (bt BlockType) Short() string {
 		return "co"
 	case Table:
 		return "tb"
+	case Kanban:
+		return "kb"
 	default:
 		return "?"
 	}
@@ -165,11 +170,76 @@ func ParseCalloutVariant(s string) (CalloutVariant, bool) {
 
 // Block holds a single parsed content block.
 type Block struct {
-	Type    BlockType      // kind of block
-	Content string         // text content without markdown prefix
-	Checked bool           // whether checklist item is checked (Checklist only)
-	Indent  int            // nesting level for list items (0 = top level)
-	Variant CalloutVariant // admonition variant (Callout only)
+	Type     BlockType      // kind of block
+	Content  string         // text content without markdown prefix
+	Checked  bool           // whether checklist item is checked (Checklist only)
+	Indent   int            // nesting level for list items (0 = top level)
+	Variant  CalloutVariant // admonition variant (Callout only)
+	Priority Priority       // priority label (Checklist only)
+}
+
+// Priority enumerates the priority labels available to checklist items.
+// These let checklists serve as kanban-style cards: items can be tagged
+// with a priority and moved between heading-defined "sections".
+type Priority int
+
+const (
+	PriorityNone Priority = iota // no priority label
+	PriorityLow                  // ! marker
+	PriorityMed                  // !! marker
+	PriorityHigh                 // !!! marker
+)
+
+// String returns the uppercase short label of a Priority.
+func (p Priority) String() string {
+	switch p {
+	case PriorityLow:
+		return "LOW"
+	case PriorityMed:
+		return "MED"
+	case PriorityHigh:
+		return "HIGH"
+	default:
+		return ""
+	}
+}
+
+// Marker returns the inline markdown marker for a Priority (e.g. "!!").
+// Returns "" for PriorityNone.
+func (p Priority) Marker() string {
+	switch p {
+	case PriorityLow:
+		return "!"
+	case PriorityMed:
+		return "!!"
+	case PriorityHigh:
+		return "!!!"
+	default:
+		return ""
+	}
+}
+
+// Next cycles to the next priority: None → Low → Med → High → None.
+func (p Priority) Next() Priority {
+	return (p + 1) % (PriorityHigh + 1)
+}
+
+// ParsePriorityMarker reads an optional leading "!", "!!", or "!!!" marker
+// (followed by a space) from content and returns the priority and the
+// remaining text. If no marker is present, returns PriorityNone and the
+// original string. The marker is recognized only when followed by a space
+// so plain "!" exclamations don't accidentally tag items.
+func ParsePriorityMarker(content string) (Priority, string) {
+	if strings.HasPrefix(content, "!!! ") {
+		return PriorityHigh, content[4:]
+	}
+	if strings.HasPrefix(content, "!! ") {
+		return PriorityMed, content[3:]
+	}
+	if strings.HasPrefix(content, "! ") {
+		return PriorityLow, content[2:]
+	}
+	return PriorityNone, content
 }
 
 // CountNumberedPosition returns the 1-based position of a numbered list block

--- a/internal/block/kanban.go
+++ b/internal/block/kanban.go
@@ -1,0 +1,159 @@
+package block
+
+import "strings"
+
+// KanbanCard is a single card on a kanban board.
+type KanbanCard struct {
+	Text     string
+	Priority Priority
+	Done     bool
+}
+
+// KanbanColumn is a single column on a kanban board.
+type KanbanColumn struct {
+	Title string
+	Cards []KanbanCard
+}
+
+// DefaultKanbanContent is the markdown body inserted when a fresh Kanban
+// block is created from the command palette. Four columns starting at
+// Backlog so users can park ideas before promoting them to Todo.
+const DefaultKanbanContent = "## Backlog\n" +
+	"- New card\n" +
+	"\n" +
+	"## Todo\n" +
+	"\n" +
+	"## In Progress\n" +
+	"\n" +
+	"## Done\n"
+
+// ParseKanban interprets the inner body of a kanban fence into columns
+// and cards. The body uses lightweight markdown:
+//
+//	## Column Title
+//	- Card text             (open card)
+//	- [x] Card text         (done card)
+//	- !! Card text          (priority marker before text)
+//	- [ ] !!! Card text     (combined: open + high priority)
+//	  continuation line     (indented continuation of previous card)
+//
+// Lines that do not match a column header or card are treated as
+// continuation lines for the most recent card if any, otherwise ignored.
+// An empty body produces an empty slice.
+func ParseKanban(body string) []KanbanColumn {
+	var cols []KanbanColumn
+	if strings.TrimSpace(body) == "" {
+		return cols
+	}
+
+	var current *KanbanColumn
+	var lastCard *KanbanCard
+	for _, raw := range strings.Split(body, "\n") {
+		line := strings.TrimRight(raw, " \t")
+		if line == "" {
+			lastCard = nil // blank line breaks card continuation
+			continue
+		}
+
+		// Column header: ## Title (also accept # and ###).
+		if strings.HasPrefix(line, "### ") {
+			cols = append(cols, KanbanColumn{Title: strings.TrimSpace(line[4:])})
+			current = &cols[len(cols)-1]
+			lastCard = nil
+			continue
+		}
+		if strings.HasPrefix(line, "## ") {
+			cols = append(cols, KanbanColumn{Title: strings.TrimSpace(line[3:])})
+			current = &cols[len(cols)-1]
+			lastCard = nil
+			continue
+		}
+		if strings.HasPrefix(line, "# ") {
+			cols = append(cols, KanbanColumn{Title: strings.TrimSpace(line[2:])})
+			current = &cols[len(cols)-1]
+			lastCard = nil
+			continue
+		}
+
+		// Card: - text, - [ ] text, - [x] text, optionally with priority.
+		if strings.HasPrefix(line, "- ") || strings.HasPrefix(line, "* ") {
+			body := line[2:]
+			done := false
+			if strings.HasPrefix(body, "[x] ") || strings.HasPrefix(body, "[X] ") {
+				done = true
+				body = body[4:]
+			} else if strings.HasPrefix(body, "[ ] ") {
+				body = body[4:]
+			}
+			prio, text := ParsePriorityMarker(body)
+			if current == nil {
+				cols = append(cols, KanbanColumn{Title: "Untitled"})
+				current = &cols[len(cols)-1]
+			}
+			current.Cards = append(current.Cards, KanbanCard{
+				Text:     text,
+				Priority: prio,
+				Done:     done,
+			})
+			lastCard = &current.Cards[len(current.Cards)-1]
+			continue
+		}
+
+		// Otherwise: treat as a continuation of the previous card. We strip
+		// up to two leading spaces (the indent SerializeKanban emits) so
+		// the user-visible text doesn't accumulate whitespace on round-trip.
+		if lastCard != nil {
+			cont := strings.TrimPrefix(line, "  ")
+			if lastCard.Text == "" {
+				lastCard.Text = cont
+			} else {
+				lastCard.Text += "\n" + cont
+			}
+		}
+	}
+	return cols
+}
+
+// SerializeKanban renders columns and cards back to the lightweight
+// markdown format consumed by ParseKanban. It is the inverse of
+// ParseKanban for the canonical form.
+//
+// "Done" is column-derived: cards in any column whose title is "Done"
+// (case-insensitive) are emitted as `- [x] ...` so the markdown stays
+// readable outside the app. Cards spanning multiple lines have their
+// continuation lines indented two spaces, matching list-continuation
+// conventions and ensuring round-trip via ParseKanban.
+func SerializeKanban(cols []KanbanColumn) string {
+	var lines []string
+	for i, col := range cols {
+		if i > 0 {
+			lines = append(lines, "")
+		}
+		lines = append(lines, "## "+col.Title)
+		done := strings.EqualFold(strings.TrimSpace(col.Title), "Done")
+		for _, c := range col.Cards {
+			textLines := strings.Split(c.Text, "\n")
+			first := textLines[0]
+			// Drop fully-empty cards on save: no text and no
+			// continuation lines means there's nothing to round-trip
+			// (and serializing `- ` would round-trip to "no card"
+			// anyway since the parser strips trailing whitespace).
+			if first == "" && len(textLines) == 1 {
+				continue
+			}
+			marker := ""
+			if m := c.Priority.Marker(); m != "" {
+				marker = m + " "
+			}
+			if done {
+				lines = append(lines, "- [x] "+marker+first)
+			} else {
+				lines = append(lines, "- "+marker+first)
+			}
+			for _, cont := range textLines[1:] {
+				lines = append(lines, "  "+cont)
+			}
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/block/kanban_test.go
+++ b/internal/block/kanban_test.go
@@ -1,0 +1,188 @@
+package block
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseKanbanBasic(t *testing.T) {
+	body := "## Todo\n- A\n- B\n\n## Done\n- [x] C"
+	cols := ParseKanban(body)
+	if len(cols) != 2 {
+		t.Fatalf("got %d columns, want 2", len(cols))
+	}
+	if cols[0].Title != "Todo" || cols[1].Title != "Done" {
+		t.Errorf("titles = %q / %q", cols[0].Title, cols[1].Title)
+	}
+	if len(cols[0].Cards) != 2 || cols[0].Cards[0].Text != "A" || cols[0].Cards[1].Text != "B" {
+		t.Errorf("Todo cards = %+v", cols[0].Cards)
+	}
+	if len(cols[1].Cards) != 1 || !cols[1].Cards[0].Done || cols[1].Cards[0].Text != "C" {
+		t.Errorf("Done cards = %+v", cols[1].Cards)
+	}
+}
+
+func TestParseKanbanPriority(t *testing.T) {
+	body := "## Todo\n- !!! urgent\n- !! medium\n- ! low\n- plain"
+	cols := ParseKanban(body)
+	if len(cols) != 1 || len(cols[0].Cards) != 4 {
+		t.Fatalf("unexpected: %+v", cols)
+	}
+	want := []Priority{PriorityHigh, PriorityMed, PriorityLow, PriorityNone}
+	for i, p := range want {
+		if cols[0].Cards[i].Priority != p {
+			t.Errorf("card %d priority = %v, want %v", i, cols[0].Cards[i].Priority, p)
+		}
+	}
+}
+
+func TestParseKanbanCheckedAndPriority(t *testing.T) {
+	body := "## Done\n- [x] !!! shipped"
+	cols := ParseKanban(body)
+	if len(cols) != 1 || len(cols[0].Cards) != 1 {
+		t.Fatalf("unexpected shape")
+	}
+	c := cols[0].Cards[0]
+	if !c.Done || c.Priority != PriorityHigh || c.Text != "shipped" {
+		t.Errorf("card = %+v", c)
+	}
+}
+
+func TestSerializeKanbanRoundTrip(t *testing.T) {
+	cols := []KanbanColumn{
+		{Title: "Todo", Cards: []KanbanCard{
+			{Text: "Buy groceries", Priority: PriorityHigh},
+			{Text: "Read book"},
+		}},
+		{Title: "In Progress", Cards: []KanbanCard{
+			{Text: "Email", Priority: PriorityMed},
+		}},
+		{Title: "Done", Cards: []KanbanCard{
+			{Text: "Shipped", Done: true},
+		}},
+	}
+	md := SerializeKanban(cols)
+	got := ParseKanban(md)
+	if len(got) != len(cols) {
+		t.Fatalf("col count = %d, want %d", len(got), len(cols))
+	}
+	for i := range cols {
+		if got[i].Title != cols[i].Title {
+			t.Errorf("col %d title = %q, want %q", i, got[i].Title, cols[i].Title)
+		}
+		if len(got[i].Cards) != len(cols[i].Cards) {
+			t.Fatalf("col %d card count = %d, want %d", i, len(got[i].Cards), len(cols[i].Cards))
+		}
+		for j := range cols[i].Cards {
+			if got[i].Cards[j] != cols[i].Cards[j] {
+				t.Errorf("col %d card %d = %+v, want %+v", i, j, got[i].Cards[j], cols[i].Cards[j])
+			}
+		}
+	}
+}
+
+func TestSerializeEmptyCardIsDropped(t *testing.T) {
+	// Fully-empty cards have no value — and serializing one as "- "
+	// would round-trip to "no card" anyway (the parser strips trailing
+	// whitespace). Make this explicit: empty cards drop on save.
+	// Real cards alongside an empty one survive.
+	cols := []KanbanColumn{{
+		Title: "Todo",
+		Cards: []KanbanCard{
+			{Text: "", Priority: PriorityMed}, // empty + priority
+			{Text: "real"},                    // real
+			{Text: ""},                        // empty no priority
+		},
+	}}
+	out := SerializeKanban(cols)
+	round := ParseKanban(out)
+	if len(round) != 1 {
+		t.Fatalf("round-trip cols: got %d, want 1", len(round))
+	}
+	if len(round[0].Cards) != 1 {
+		t.Fatalf("round-trip cards: got %d, want 1 (empty cards dropped)", len(round[0].Cards))
+	}
+	if round[0].Cards[0].Text != "real" {
+		t.Errorf("kept card text = %q, want \"real\"", round[0].Cards[0].Text)
+	}
+}
+
+func TestParseKanbanEmpty(t *testing.T) {
+	if cols := ParseKanban(""); len(cols) != 0 {
+		t.Errorf("empty body: got %d cols", len(cols))
+	}
+	if cols := ParseKanban("   \n\n  "); len(cols) != 0 {
+		t.Errorf("whitespace body: got %d cols", len(cols))
+	}
+}
+
+func TestKanbanFenceParse(t *testing.T) {
+	input := "```kanban\n## Todo\n- task one\n## Done\n- [x] task two\n```"
+	blocks := Parse(input)
+	if len(blocks) != 1 {
+		t.Fatalf("got %d blocks, want 1", len(blocks))
+	}
+	if blocks[0].Type != Kanban {
+		t.Errorf("type = %v, want Kanban", blocks[0].Type)
+	}
+	if !strings.Contains(blocks[0].Content, "## Todo") {
+		t.Errorf("content missing Todo: %q", blocks[0].Content)
+	}
+}
+
+func TestKanbanFenceRoundTrip(t *testing.T) {
+	original := "```kanban\n## Todo\n- A\n- B\n\n## Done\n- [x] C\n```"
+	blocks := Parse(original)
+	if blocks[0].Type != Kanban {
+		t.Fatalf("type = %v", blocks[0].Type)
+	}
+	got := Serialize(blocks)
+	if got != original {
+		t.Errorf("round trip:\nwant: %q\ngot:  %q", original, got)
+	}
+}
+
+func TestKanbanMultilineCardRoundTrip(t *testing.T) {
+	cols := []KanbanColumn{{Title: "Todo", Cards: []KanbanCard{
+		{Text: "First line\nSecond line\nThird line"},
+		{Text: "single line", Priority: PriorityHigh},
+	}}}
+	md := SerializeKanban(cols)
+	got := ParseKanban(md)
+	if len(got) != 1 || len(got[0].Cards) != 2 {
+		t.Fatalf("shape lost: %+v", got)
+	}
+	if got[0].Cards[0].Text != "First line\nSecond line\nThird line" {
+		t.Errorf("multi-line text lost: %q", got[0].Cards[0].Text)
+	}
+	if got[0].Cards[1].Text != "single line" || got[0].Cards[1].Priority != PriorityHigh {
+		t.Errorf("second card = %+v", got[0].Cards[1])
+	}
+}
+
+func TestKanbanDoneColumnAutoMarks(t *testing.T) {
+	cols := []KanbanColumn{
+		{Title: "Done", Cards: []KanbanCard{{Text: "shipped"}}},
+		{Title: "Todo", Cards: []KanbanCard{{Text: "next"}}},
+	}
+	md := SerializeKanban(cols)
+	if !strings.Contains(md, "## Done\n- [x] shipped") {
+		t.Errorf("Done column should auto-mark cards: %q", md)
+	}
+	if !strings.Contains(md, "## Todo\n- next") {
+		t.Errorf("non-Done column should not mark: %q", md)
+	}
+}
+
+func TestKanbanDefaultContent(t *testing.T) {
+	cols := ParseKanban(DefaultKanbanContent)
+	if len(cols) != 4 {
+		t.Errorf("default has %d cols, want 4", len(cols))
+	}
+	titles := []string{"Backlog", "Todo", "In Progress", "Done"}
+	for i, want := range titles {
+		if cols[i].Title != want {
+			t.Errorf("col %d title = %q, want %q", i, cols[i].Title, want)
+		}
+	}
+}

--- a/internal/block/parse.go
+++ b/internal/block/parse.go
@@ -47,6 +47,16 @@ func Parse(markdown string) []Block {
 				i++
 			}
 			content := strings.Join(contentLines, "\n")
+
+			// Special-case kanban fence: own block type, content stored verbatim.
+			if strings.EqualFold(lang, "kanban") {
+				blocks = append(blocks, Block{
+					Type:    Kanban,
+					Content: content,
+				})
+				continue
+			}
+
 			if lang != "" {
 				if content == "" {
 					content = lang
@@ -123,12 +133,14 @@ func Parse(markdown string) []Block {
 		indent, stripped := stripListIndent(line)
 
 		if strings.HasPrefix(stripped, "- [x] ") || strings.HasPrefix(stripped, "- [X] ") {
-			blocks = append(blocks, Block{Type: Checklist, Content: stripped[6:], Checked: true, Indent: indent})
+			prio, body := ParsePriorityMarker(stripped[6:])
+			blocks = append(blocks, Block{Type: Checklist, Content: body, Checked: true, Indent: indent, Priority: prio})
 			i++
 			continue
 		}
 		if strings.HasPrefix(stripped, "- [ ] ") {
-			blocks = append(blocks, Block{Type: Checklist, Content: stripped[6:], Checked: false, Indent: indent})
+			prio, body := ParsePriorityMarker(stripped[6:])
+			blocks = append(blocks, Block{Type: Checklist, Content: body, Checked: false, Indent: indent, Priority: prio})
 			i++
 			continue
 		}

--- a/internal/block/priority_test.go
+++ b/internal/block/priority_test.go
@@ -1,0 +1,151 @@
+package block
+
+import "testing"
+
+func TestPriorityString(t *testing.T) {
+	tests := []struct {
+		p    Priority
+		want string
+	}{
+		{PriorityNone, ""},
+		{PriorityLow, "LOW"},
+		{PriorityMed, "MED"},
+		{PriorityHigh, "HIGH"},
+	}
+	for _, tt := range tests {
+		if got := tt.p.String(); got != tt.want {
+			t.Errorf("Priority(%d).String() = %q, want %q", tt.p, got, tt.want)
+		}
+	}
+}
+
+func TestPriorityMarker(t *testing.T) {
+	tests := []struct {
+		p    Priority
+		want string
+	}{
+		{PriorityNone, ""},
+		{PriorityLow, "!"},
+		{PriorityMed, "!!"},
+		{PriorityHigh, "!!!"},
+	}
+	for _, tt := range tests {
+		if got := tt.p.Marker(); got != tt.want {
+			t.Errorf("Priority(%d).Marker() = %q, want %q", tt.p, got, tt.want)
+		}
+	}
+}
+
+func TestPriorityNext(t *testing.T) {
+	got := PriorityNone
+	want := []Priority{PriorityLow, PriorityMed, PriorityHigh, PriorityNone}
+	for i, w := range want {
+		got = got.Next()
+		if got != w {
+			t.Errorf("step %d: got %v, want %v", i, got, w)
+		}
+	}
+}
+
+func TestParsePriorityMarker(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantPrio Priority
+		wantBody string
+	}{
+		{"plain task", PriorityNone, "plain task"},
+		{"! low task", PriorityLow, "low task"},
+		{"!! medium", PriorityMed, "medium"},
+		{"!!! high stakes", PriorityHigh, "high stakes"},
+		{"!!!! too many bangs", PriorityNone, "!!!! too many bangs"},
+		{"!no space", PriorityNone, "!no space"},
+		{"! ", PriorityLow, ""},
+		{"", PriorityNone, ""},
+		{"hello! world", PriorityNone, "hello! world"},
+	}
+	for _, tt := range tests {
+		gotP, gotBody := ParsePriorityMarker(tt.input)
+		if gotP != tt.wantPrio || gotBody != tt.wantBody {
+			t.Errorf("ParsePriorityMarker(%q) = (%v, %q), want (%v, %q)",
+				tt.input, gotP, gotBody, tt.wantPrio, tt.wantBody)
+		}
+	}
+}
+
+func TestParseChecklistPriority(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantPrio Priority
+		wantBody string
+		wantDone bool
+	}{
+		{"unchecked no priority", "- [ ] task", PriorityNone, "task", false},
+		{"unchecked low", "- [ ] ! low task", PriorityLow, "low task", false},
+		{"unchecked med", "- [ ] !! mid task", PriorityMed, "mid task", false},
+		{"unchecked high", "- [ ] !!! urgent", PriorityHigh, "urgent", false},
+		{"checked high", "- [x] !!! shipped", PriorityHigh, "shipped", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blocks := Parse(tt.input)
+			if len(blocks) != 1 {
+				t.Fatalf("got %d blocks, want 1", len(blocks))
+			}
+			b := blocks[0]
+			if b.Type != Checklist {
+				t.Errorf("type = %v, want Checklist", b.Type)
+			}
+			if b.Priority != tt.wantPrio {
+				t.Errorf("priority = %v, want %v", b.Priority, tt.wantPrio)
+			}
+			if b.Content != tt.wantBody {
+				t.Errorf("content = %q, want %q", b.Content, tt.wantBody)
+			}
+			if b.Checked != tt.wantDone {
+				t.Errorf("checked = %v, want %v", b.Checked, tt.wantDone)
+			}
+		})
+	}
+}
+
+func TestSerializeChecklistPriority(t *testing.T) {
+	tests := []struct {
+		name string
+		b    Block
+		want string
+	}{
+		{"none", Block{Type: Checklist, Content: "task"}, "- [ ] task"},
+		{"low", Block{Type: Checklist, Content: "low", Priority: PriorityLow}, "- [ ] ! low"},
+		{"med", Block{Type: Checklist, Content: "mid", Priority: PriorityMed}, "- [ ] !! mid"},
+		{"high checked", Block{Type: Checklist, Content: "done", Checked: true, Priority: PriorityHigh}, "- [x] !!! done"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Serialize([]Block{tt.b})
+			if got != tt.want {
+				t.Errorf("Serialize = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestChecklistPriorityRoundTrip(t *testing.T) {
+	priorities := []Priority{PriorityNone, PriorityLow, PriorityMed, PriorityHigh}
+	for _, p := range priorities {
+		t.Run(p.String(), func(t *testing.T) {
+			original := Block{Type: Checklist, Content: "round trip", Priority: p}
+			md := Serialize([]Block{original})
+			parsed := Parse(md)
+			if len(parsed) != 1 {
+				t.Fatalf("parse produced %d blocks, want 1", len(parsed))
+			}
+			if parsed[0].Priority != p {
+				t.Errorf("priority round trip lost: got %v, want %v", parsed[0].Priority, p)
+			}
+			if parsed[0].Content != "round trip" {
+				t.Errorf("content round trip lost: got %q", parsed[0].Content)
+			}
+		})
+	}
+}

--- a/internal/block/serialize.go
+++ b/internal/block/serialize.go
@@ -47,10 +47,14 @@ func Serialize(blocks []Block) string {
 			lines = append(lines, pad+fmt.Sprintf("%d. %s", seq, b.Content))
 
 		case Checklist:
+			marker := ""
+			if m := b.Priority.Marker(); m != "" {
+				marker = m + " "
+			}
 			if b.Checked {
-				lines = append(lines, pad+"- [x] "+b.Content)
+				lines = append(lines, pad+"- [x] "+marker+b.Content)
 			} else {
-				lines = append(lines, pad+"- [ ] "+b.Content)
+				lines = append(lines, pad+"- [ ] "+marker+b.Content)
 			}
 
 		case CodeBlock:
@@ -101,6 +105,13 @@ func Serialize(blocks []Block) string {
 
 		case Table:
 			lines = append(lines, serializeTable(b.Content)...)
+
+		case Kanban:
+			lines = append(lines, "```kanban")
+			if b.Content != "" {
+				lines = append(lines, strings.Split(b.Content, "\n")...)
+			}
+			lines = append(lines, "```")
 
 		default:
 			if b.Content != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,27 +11,29 @@ import (
 
 // Config holds all user-configurable settings.
 type Config struct {
-	StorageDir    string `toml:"storage_dir"`
-	Editor        string `toml:"editor"`
-	Theme         string `toml:"theme"`                          // any preset name
-	DateFormat    string `toml:"date_format"`                    // "relative" or Go time format
-	HideChecked   *bool  `toml:"hide_checked,omitempty"`         // sort checked to bottom
-	CascadeChecks *bool  `toml:"cascade_checks,omitempty"`       // check parent → check children
-	ShowPreview   *bool  `toml:"show_preview,omitempty"`         // browser preview pane
-	WordWrap      *bool  `toml:"word_wrap,omitempty"`            // editor word wrap
+	StorageDir       string `toml:"storage_dir"`
+	Editor           string `toml:"editor"`
+	Theme            string `toml:"theme"`                             // any preset name
+	DateFormat       string `toml:"date_format"`                       // "relative" or Go time format
+	HideChecked      *bool  `toml:"hide_checked,omitempty"`            // sort checked to bottom
+	CascadeChecks    *bool  `toml:"cascade_checks,omitempty"`          // check parent → check children
+	ShowPreview      *bool  `toml:"show_preview,omitempty"`            // browser preview pane
+	WordWrap         *bool  `toml:"word_wrap,omitempty"`               // editor word wrap
+	KanbanSortByPrio *bool  `toml:"kanban_sort_by_priority,omitempty"` // sort kanban cards by priority desc
 }
 
 // rawConfig mirrors Config but uses any for hide_checked to handle
 // legacy string values ("on"/"off") during migration.
 type rawConfig struct {
-	StorageDir    string `toml:"storage_dir"`
-	Editor        string `toml:"editor"`
-	Theme         string `toml:"theme"`
-	DateFormat    string `toml:"date_format"`
-	HideChecked   any    `toml:"hide_checked,omitempty"`
-	CascadeChecks *bool  `toml:"cascade_checks,omitempty"`
-	ShowPreview   *bool  `toml:"show_preview,omitempty"`
-	WordWrap      *bool  `toml:"word_wrap,omitempty"`
+	StorageDir       string `toml:"storage_dir"`
+	Editor           string `toml:"editor"`
+	Theme            string `toml:"theme"`
+	DateFormat       string `toml:"date_format"`
+	HideChecked      any    `toml:"hide_checked,omitempty"`
+	CascadeChecks    *bool  `toml:"cascade_checks,omitempty"`
+	ShowPreview      *bool  `toml:"show_preview,omitempty"`
+	WordWrap         *bool  `toml:"word_wrap,omitempty"`
+	KanbanSortByPrio *bool  `toml:"kanban_sort_by_priority,omitempty"`
 }
 
 // DefaultConfig returns the default configuration.
@@ -62,9 +64,9 @@ var ValidKeys = map[string]bool{
 	"theme":          true,
 	"date_format":    true,
 	"show_hints":     true,
-	"hide_checked":    true,
-	"cascade_checks":  true,
-	"show_preview":    true,
+	"hide_checked":   true,
+	"cascade_checks": true,
+	"show_preview":   true,
 	"word_wrap":      true,
 }
 
@@ -118,6 +120,7 @@ func LoadFrom(path string) (Config, error) {
 	cfg.CascadeChecks = raw.CascadeChecks
 	cfg.ShowPreview = raw.ShowPreview
 	cfg.WordWrap = raw.WordWrap
+	cfg.KanbanSortByPrio = raw.KanbanSortByPrio
 
 	// Convert hide_checked: legacy "on"/"off" strings → bool.
 	switch v := raw.HideChecked.(type) {

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -39,6 +39,8 @@ type Config struct {
 	CascadeChecks *bool
 	// WordWrap from config; nil = default (true).
 	WordWrap *bool
+	// KanbanSortByPrio sorts kanban cards by priority desc within each column.
+	KanbanSortByPrio *bool
 	// ResolveEmbed resolves an embed path (e.g. "notebook/note") to its title
 	// and content. Returns an error if the note doesn't exist.
 	ResolveEmbed func(path string) (title, content string, err error)
@@ -87,19 +89,19 @@ type Model struct {
 	active    int              // index of focused block
 	viewport  viewport.Model   // scrollable container
 
-	config      Config
-	initial     string
-	width       int
-	height      int
-	status      string
-	statusStyle statusKind
-	quitPrompt  bool
-	quitting    bool
-	showHelp    bool
-	blockClip   *block.Block // block-level clipboard for Ctrl+K block cut
-	statusGen   int    // generation counter for status auto-dismiss
-	palette     palette      // "/" command palette for block type insertion
-	defLookup   defLookup    // ":" definition lookup palette
+	config           Config
+	initial          string
+	width            int
+	height           int
+	status           string
+	statusStyle      statusKind
+	quitPrompt       bool
+	quitting         bool
+	showHelp         bool
+	blockClip        *block.Block    // block-level clipboard for Ctrl+K block cut
+	statusGen        int             // generation counter for status auto-dismiss
+	palette          palette         // "/" command palette for block type insertion
+	defLookup        defLookup       // ":" definition lookup palette
 	wordWrap         bool            // when true, text wraps at terminal width
 	viewMode         bool            // when true, read-only rendering with no cursor
 	hoverBlock       int             // view mode: block index under mouse cursor (-1 = none)
@@ -107,17 +109,22 @@ type Model struct {
 	blockLineOffsets []int           // view mode: starting Y line of each block in rendered output
 	blockLineCounts  []int           // per-block rendered line counts from renderAllBlocks
 	dismissedHints   map[string]bool // tracks which onboarding hints the user has dismissed
-	undo        undoStack       // undo history
-	redo        undoStack       // redo history
-	undoDirty   bool            // true when textarea content changed since last snapshot
-	sortChecked   bool // sort checked checklist items to bottom of each group
-	cascadeChecks bool // checking parent also checks/unchecks children
-	embedModal    embedModalState // overlay for viewing embedded note references
-	embedPicker   embedPicker       // note picker for embed block insertion
-	table         *tableState // active table cell state (non-nil when editing a Table block)
-	defPreview    defPreviewState // focused preview for a single cross-note definition
-	jumpTarget    string      // "notebook/note" to open after editor quits; read via JumpTarget()
-	pendingJump   string      // jump requested but current note is modified — set alongside quitPrompt
+	undo             undoStack       // undo history
+	redo             undoStack       // redo history
+	undoDirty        bool            // true when textarea content changed since last snapshot
+	sortChecked      bool            // sort checked checklist items to bottom of each group
+	cascadeChecks    bool            // checking parent also checks/unchecks children
+	kanbanSortByPrio bool            // sort kanban cards by priority desc within each column
+	embedModal       embedModalState // overlay for viewing embedded note references
+	embedPicker      embedPicker     // note picker for embed block insertion
+	table            *tableState     // active table cell state (non-nil when editing a Table block)
+	kanban           *kanbanState    // active kanban board state (non-nil when editing a Kanban block)
+	viewKanbanOffset int             // horizontal scroll for kanban blocks in view mode
+	kanbanOffsets    map[int]int     // saved colOffset per block index, restored when refocusing
+	kanbanAnchorTop  bool            // one-shot: next viewport update anchors to kanban title row
+	defPreview       defPreviewState // focused preview for a single cross-note definition
+	jumpTarget       string          // "notebook/note" to open after editor quits; read via JumpTarget()
+	pendingJump      string          // jump requested but current note is modified — set alongside quitPrompt
 }
 
 // defPreviewState holds a focused preview of one cross-note definition.
@@ -163,14 +170,14 @@ const (
 // embedModalState holds the state for the embedded note bottom sheet.
 type embedModalState struct {
 	visible          bool
-	title            string         // display title for the sheet header
-	path             string         // original embed path for save-back
-	blocks           []block.Block  // parsed blocks of the referenced note
-	scroll           int            // scroll offset (line index)
-	lines            []string       // pre-split rendered lines
-	blockLineOffsets []int          // starting line of each block within lines
-	hoverBlock       int            // block under mouse cursor (-1 = none)
-	sheetStartY      int            // Y line where the sheet content begins
+	title            string        // display title for the sheet header
+	path             string        // original embed path for save-back
+	blocks           []block.Block // parsed blocks of the referenced note
+	scroll           int           // scroll offset (line index)
+	lines            []string      // pre-split rendered lines
+	blockLineOffsets []int         // starting line of each block within lines
+	hoverBlock       int           // block under mouse cursor (-1 = none)
+	sheetStartY      int           // Y line where the sheet content begins
 }
 
 // open prepares the sheet with parsed blocks and resets state.
@@ -233,16 +240,19 @@ const noWrapWidth = 1000
 // (e.g. bullet markers, numbered list prefixes, checkbox markers).
 const gutterWidth = 5
 
-func blockPrefixWidth(bt block.BlockType, indent int) int {
+func blockPrefixWidth(b block.Block) int {
 	th := theme.Current()
 	base := 0
-	switch bt {
+	switch b.Type {
 	case block.BulletList:
 		base = lipgloss.Width(th.Blocks.Bullet.Marker)
 	case block.NumberedList:
 		base = lipgloss.Width(fmt.Sprintf(th.Blocks.Numbered.Format, 1))
 	case block.Checklist:
 		base = lipgloss.Width(th.Blocks.Checklist.Unchecked)
+		if m := b.Priority.Marker(); m != "" {
+			base += len(m) + 1 // marker + trailing space
+		}
 	case block.Quote, block.Callout:
 		base = lipgloss.Width(th.Blocks.Quote.Bar)
 	case block.CodeBlock:
@@ -258,7 +268,7 @@ func blockPrefixWidth(bt block.BlockType, indent int) int {
 	case block.Table:
 		base = 0
 	}
-	return indent*4 + base
+	return b.Indent*4 + base
 }
 
 // contentWidth returns the effective textarea width for a block, accounting
@@ -268,7 +278,7 @@ func (m Model) contentWidth(b block.Block) int {
 	if mw <= 0 {
 		mw = defaultWidth
 	}
-	w := mw - gutterWidth - blockPrefixWidth(b.Type, b.Indent)
+	w := mw - gutterWidth - blockPrefixWidth(b)
 	if w < 1 {
 		w = 1
 	}
@@ -331,22 +341,24 @@ func New(cfg Config) Model {
 	}
 
 	m := Model{
-		blocks:         blocks,
-		textareas:      textareas,
-		active:         0,
-		viewport:       vp,
-		config:         cfg,
-		initial:        cfg.Content,
-		width:          defaultWidth,
-		height:         defaultHeight,
-		palette:        newPalette(),
-		defLookup:      newDefLookup(),
-		embedPicker:    newEmbedPicker(),
-		wordWrap:       config.BoolVal(cfg.WordWrap, true),
-		dismissedHints: dismissed,
-		hoverBlock:     -1,
-		sortChecked:   config.BoolVal(cfg.HideChecked, false),
-		cascadeChecks: config.BoolVal(cfg.CascadeChecks, true),
+		blocks:           blocks,
+		textareas:        textareas,
+		active:           0,
+		viewport:         vp,
+		config:           cfg,
+		initial:          cfg.Content,
+		width:            defaultWidth,
+		height:           defaultHeight,
+		palette:          newPalette(),
+		defLookup:        newDefLookup(),
+		embedPicker:      newEmbedPicker(),
+		wordWrap:         config.BoolVal(cfg.WordWrap, true),
+		dismissedHints:   dismissed,
+		hoverBlock:       -1,
+		sortChecked:      config.BoolVal(cfg.HideChecked, false),
+		cascadeChecks:    config.BoolVal(cfg.CascadeChecks, true),
+		kanbanSortByPrio: config.BoolVal(cfg.KanbanSortByPrio, false),
+		kanbanOffsets:    map[int]int{},
 	}
 
 	// If first block is a Table, init table state.
@@ -355,6 +367,16 @@ func New(cfg Config) Model {
 		cw := m.tableCellTAWidth()
 		m.table.loadCell(&m.textareas[0], cw, false)
 		m.cursorCmd = m.textareas[0].Focus()
+	}
+	// If first block is a Kanban, init kanban state. Offset starts at 0
+	// for fresh editor sessions; the offset map persists across focus
+	// changes within the same session.
+	if len(m.blocks) > 0 && m.blocks[0].Type == block.Kanban {
+		m.kanban = newKanbanState(m.blocks[0].Content)
+		if m.kanbanSortByPrio {
+			m.kanban.sortByPriority()
+		}
+		m.textareas[0].Blur()
 	}
 
 	return m
@@ -367,7 +389,7 @@ func newTextareaForBlock(b block.Block, width int) textarea.Model {
 	ta.ShowLineNumbers = false
 	// Set width BEFORE value so the textarea's internal state (viewport
 	// scroll, wrap cache) is initialized with the correct dimensions.
-	taWidth := width - gutterWidth - blockPrefixWidth(b.Type, b.Indent)
+	taWidth := width - gutterWidth - blockPrefixWidth(b)
 	if taWidth < 1 {
 		taWidth = 1
 	}
@@ -411,6 +433,18 @@ func (m Model) syncBlocks() []block.Block {
 				ts := *m.table // copy to avoid mutating receiver
 				ts.syncCell(m.textareas[i])
 				result[i].Content = ts.serialize()
+			} else if m.kanban != nil && i == m.active && m.blocks[i].Type == block.Kanban {
+				// For the active kanban, serialize state. If mid-edit, fold
+				// the textarea value into the selected card's text in a
+				// deep copy so the live state isn't mutated by a save.
+				cols := cloneKanbanCols(m.kanban.cols)
+				if m.kanban.edit && m.kanban.col >= 0 && m.kanban.col < len(cols) {
+					col := &cols[m.kanban.col]
+					if m.kanban.card >= 0 && m.kanban.card < len(col.Cards) {
+						col.Cards[m.kanban.card].Text = strings.TrimRight(m.kanban.editTA.Value(), "\n")
+					}
+				}
+				result[i].Content = block.SerializeKanban(cols)
 			} else {
 				result[i].Content = m.textareas[i].Value()
 			}
@@ -539,6 +573,13 @@ func (m *Model) persistSortChecked() {
 	}
 }
 
+// persistKanbanSort saves the kanban sort-by-priority toggle to global config.
+func (m *Model) persistKanbanSort() {
+	if globalCfg, err := config.Load(); err == nil {
+		globalCfg.KanbanSortByPrio = config.BoolPtr(m.kanbanSortByPrio)
+		_ = config.Save(globalCfg)
+	}
+}
 
 // toggleChecklist toggles the checked state of the block at idx. When
 // cascadeChecks is enabled, indented checklist children are also toggled.
@@ -632,6 +673,21 @@ func (m *Model) focusBlock(idx int) {
 		m.textareas[m.active].SetValue(serialized)
 		m.table = nil
 	}
+	// Leaving a kanban: serialize state back to block content and remember
+	// the horizontal scroll offset for when we focus this block again.
+	if m.kanban != nil && m.active >= 0 && m.active < len(m.textareas) {
+		if m.kanban.edit {
+			m.kanban.commitEdit()
+		}
+		if m.kanbanOffsets == nil {
+			m.kanbanOffsets = map[int]int{}
+		}
+		m.kanbanOffsets[m.active] = m.kanban.colOffset
+		serialized := m.kanban.serialize()
+		m.blocks[m.active].Content = serialized
+		m.textareas[m.active].SetValue(serialized)
+		m.kanban = nil
+	}
 
 	if m.active >= 0 && m.active < len(m.textareas) {
 		m.blocks[m.active].Content = m.textareas[m.active].Value()
@@ -646,6 +702,18 @@ func (m *Model) focusBlock(idx int) {
 		cw := m.tableCellTAWidth()
 		m.table.loadCell(&m.textareas[idx], cw, false)
 		m.cursorCmd = m.textareas[idx].Focus()
+	}
+	// Entering a kanban: init kanban state from block content and restore
+	// the saved horizontal scroll offset (if any).
+	if m.blocks[idx].Type == block.Kanban {
+		m.kanban = newKanbanState(m.blocks[idx].Content)
+		if m.kanbanOffsets != nil {
+			m.kanban.colOffset = m.kanbanOffsets[idx]
+		}
+		if m.kanbanSortByPrio {
+			m.kanban.sortByPriority()
+		}
+		m.textareas[idx].Blur()
 	}
 }
 
@@ -672,6 +740,13 @@ func (m *Model) navigateUp() {
 		m.cursorCmd = ta.Focus()
 		return
 	}
+	// Entering a kanban from below: land on the last card of the
+	// leftmost non-empty column. Mirrors table behavior, which always
+	// enters at column 0 regardless of direction.
+	if m.kanban != nil {
+		m.kanban.enterFromBelow()
+		return
+	}
 
 	ta := &m.textareas[m.active]
 	ta.MoveToEnd()
@@ -692,6 +767,12 @@ func (m *Model) navigateDown() {
 		ta := &m.textareas[m.active]
 		ta.SetCursorColumn(charOffset)
 		m.cursorCmd = ta.Focus()
+		return
+	}
+	// Entering a kanban from above: land on the first card of the
+	// leftmost non-empty column. Symmetric with navigateUp's entry.
+	if m.kanban != nil {
+		m.kanban.enterFromAbove()
 		return
 	}
 
@@ -725,6 +806,19 @@ func (m *Model) insertBlockBefore(idx int, b block.Block) {
 	newTAs = append(newTAs, m.textareas[idx:]...)
 	m.textareas = newTAs
 
+	// Shift m.active forward so focusBlock's "leaving the previously-active
+	// block" logic (e.g. serializing kanban/table state back into the block
+	// it came from) writes to the correct, post-shift index. Without this,
+	// the leaving kanban's serialized content gets written into the new
+	// paragraph at idx.
+	if m.active >= idx {
+		m.active++
+	}
+
+	// Shift kanbanOffsets keys >= idx forward by one so saved horizontal
+	// scroll positions stay attached to the right Kanban block.
+	m.shiftKanbanOffsets(idx, +1)
+
 	m.focusBlock(idx)
 }
 
@@ -750,6 +844,10 @@ func (m *Model) insertBlockAfter(idx int, b block.Block) {
 	newTAs = append(newTAs, m.textareas[insertAt+1:]...)
 	m.textareas = newTAs
 
+	// Shift kanbanOffsets keys > insertAt forward by one so saved
+	// horizontal scroll positions stay attached to the right Kanban.
+	m.shiftKanbanOffsets(insertAt+1, +1)
+
 	m.focusBlock(insertAt + 1)
 }
 
@@ -768,6 +866,13 @@ func (m *Model) deleteBlock(idx int) {
 	m.blocks = append(m.blocks[:idx], m.blocks[idx+1:]...)
 	m.textareas = append(m.textareas[:idx], m.textareas[idx+1:]...)
 
+	// Drop the deleted block's saved kanban offset (if any) and shift
+	// later keys back by one to keep them aligned.
+	if m.kanbanOffsets != nil {
+		delete(m.kanbanOffsets, idx)
+	}
+	m.shiftKanbanOffsets(idx+1, -1)
+
 	// Adjust active index.
 	if idx >= len(m.blocks) {
 		m.active = len(m.blocks) - 1
@@ -778,6 +883,56 @@ func (m *Model) deleteBlock(idx int) {
 	}
 
 	m.cursorCmd = m.textareas[m.active].Focus()
+
+	// If the new active block is a Table or Kanban, init its state so the
+	// renderer doesn't fall back to a collapsed single-line view.
+	m.initActiveContainerState()
+}
+
+// shiftKanbanOffsets remaps kanbanOffsets keys at or above `from` by `delta`.
+// Used by insertBlockBefore/After (delta=+1) and deleteBlock (delta=-1) so
+// that per-block horizontal scroll positions stay attached to the right
+// Kanban as block indexes shift around them.
+func (m *Model) shiftKanbanOffsets(from, delta int) {
+	if len(m.kanbanOffsets) == 0 || delta == 0 {
+		return
+	}
+	next := make(map[int]int, len(m.kanbanOffsets))
+	for k, v := range m.kanbanOffsets {
+		if k >= from {
+			next[k+delta] = v
+		} else {
+			next[k] = v
+		}
+	}
+	m.kanbanOffsets = next
+}
+
+// initActiveContainerState initializes table/kanban state when the active
+// block is one of those types and the corresponding state is nil. Used by
+// deleteBlock and other paths that change m.active without going through
+// focusBlock (which has its own init logic).
+func (m *Model) initActiveContainerState() {
+	if m.active < 0 || m.active >= len(m.blocks) {
+		return
+	}
+	bt := m.blocks[m.active].Type
+	if bt == block.Table && m.table == nil {
+		m.table = initTable(m.blocks[m.active].Content)
+		cw := m.tableCellTAWidth()
+		m.table.loadCell(&m.textareas[m.active], cw, false)
+		m.cursorCmd = m.textareas[m.active].Focus()
+	}
+	if bt == block.Kanban && m.kanban == nil {
+		m.kanban = newKanbanState(m.blocks[m.active].Content)
+		if m.kanbanOffsets != nil {
+			m.kanban.colOffset = m.kanbanOffsets[m.active]
+		}
+		if m.kanbanSortByPrio {
+			m.kanban.sortByPriority()
+		}
+		m.textareas[m.active].Blur()
+	}
 }
 
 // mergeBlockUp merges block at idx into block at idx-1. The merged block
@@ -827,7 +982,6 @@ func (m *Model) mergeBlockUp(idx int) {
 	}
 	m.textareas[m.active].SetCursorColumn(len([]rune(prevLines[mergeRow])))
 }
-
 
 // blockBundle returns the range [start, end) of the bundle rooted at idx.
 // For list items, this includes all consecutive deeper-indented children.
@@ -1257,7 +1411,7 @@ func (m *Model) handleBackspace() bool {
 
 	// Don't merge into multi-line container blocks.
 	prev := m.blocks[m.active-1].Type
-	if prev == block.CodeBlock || prev == block.Quote || prev == block.DefinitionList || prev == block.Callout || prev == block.Table {
+	if prev == block.CodeBlock || prev == block.Quote || prev == block.DefinitionList || prev == block.Callout || prev == block.Table || prev == block.Kanban {
 		return false
 	}
 
@@ -1397,6 +1551,13 @@ func (m *Model) applyPaletteSelection(bt block.BlockType) {
 		cw := m.tableCellTAWidth()
 		m.table.loadCell(&m.textareas[m.active], cw, false)
 		m.cursorCmd = m.textareas[m.active].Focus()
+	}
+	// Kanban: insert default board and enter card-selection mode.
+	if bt == block.Kanban {
+		m.blocks[m.active].Content = block.DefaultKanbanContent
+		m.textareas[m.active].SetValue(block.DefaultKanbanContent)
+		m.textareas[m.active].Blur()
+		m.kanban = newKanbanState(m.blocks[m.active].Content)
 	}
 	m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount())
 }
@@ -1914,6 +2075,19 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "pgdown":
 				m.viewport.HalfPageDown()
 				return m, nil
+			case "left":
+				if m.viewKanbanOffset > 0 {
+					m.viewKanbanOffset--
+					m.updateViewport()
+				}
+				return m, nil
+			case "right":
+				maxOff := m.maxViewKanbanOffset()
+				if m.viewKanbanOffset < maxOff {
+					m.viewKanbanOffset++
+					m.updateViewport()
+				}
+				return m, nil
 			default:
 				if msg.Code == ':' {
 					m.defLookup.open(m.blocks, m.remoteDefinitions())
@@ -1925,6 +2099,16 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
+		// Kanban-block intercept: consumes most keys when a kanban is active.
+		// Save/quit/help/view-mode still work via the main switch below.
+		if m.kanban != nil && m.active >= 0 && m.active < len(m.blocks) && m.blocks[m.active].Type == block.Kanban {
+			handled, kanbanCmd := m.handleKanbanKey(msg)
+			if handled {
+				m.updateViewport()
+				return m, kanbanCmd
+			}
+		}
+
 		switch msg.String() {
 		case "ctrl+r":
 			m.viewMode = true
@@ -1934,6 +2118,12 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.table != nil && m.blocks[m.active].Type == block.Table {
 					m.table.syncCell(m.textareas[m.active])
 					m.blocks[m.active].Content = m.table.serialize()
+					m.textareas[m.active].SetValue(m.blocks[m.active].Content)
+				} else if m.kanban != nil && m.blocks[m.active].Type == block.Kanban {
+					if m.kanban.edit {
+						m.kanban.commitEdit()
+					}
+					m.blocks[m.active].Content = m.kanban.serialize()
 					m.textareas[m.active].SetValue(m.blocks[m.active].Content)
 				} else {
 					m.blocks[m.active].Content = m.textareas[m.active].Value()
@@ -2720,13 +2910,19 @@ func (m *Model) updateViewport() {
 		cursorRawLine := ta.Line()
 		visualLine := cursorRawLine
 
-		if m.table != nil && m.blocks[m.active].Type == block.Table {
+		if m.kanban != nil && m.blocks[m.active].Type == block.Kanban {
+			// For kanban, the textarea cursor doesn't move — track the
+			// selected card's row range instead so vertical navigation
+			// keeps the focused card in view.
+			top, _ := m.selectedCardLineRange()
+			visualLine = top
+		} else if m.table != nil && m.blocks[m.active].Type == block.Table {
 			// For tables, compute cursor line within the grid.
 			// Each row before the active row contributes: 1 content line + 1 separator.
 			// (Simplified: assume 1 visual line per cell for scroll purposes.)
 			visualLine = m.table.row*2 + cursorRawLine
 		} else if m.wordWrap {
-			contentWidth := m.width - gutterWidth - blockPrefixWidth(m.blocks[m.active].Type, m.blocks[m.active].Indent)
+			contentWidth := m.width - gutterWidth - blockPrefixWidth(m.blocks[m.active])
 			if contentWidth < 1 {
 				contentWidth = 1
 			}
@@ -2751,22 +2947,8 @@ func (m *Model) updateViewport() {
 
 		cursorLine := lineOffset + chromeLines + visualLine
 
-		// Always ensure the cursor line is visible. Prefer keeping the
-		// current scroll position when the cursor is already on screen.
-		// When cursor is on the first content line, also show the block's
-		// chrome (borders, labels) above it.
-		yOffset := m.viewport.YOffset()
-		scrollTarget := cursorLine
-		if cursorRawLine == 0 && chromeLines > 0 {
-			scrollTarget = lineOffset // show from block start
-		}
-		if scrollTarget < yOffset {
-			yOffset = scrollTarget
-		}
-
-		// In tables, also try to keep the rows + bottom border below the
-		// cursor on screen — without this the last row sits flush against
-		// the viewport bottom and the closing border gets clipped.
+		// Resolve cursorLine / bottomTarget overrides before computing the
+		// scroll target so block-specific anchoring (kanban, table) wins.
 		bottomTarget := cursorLine
 		if m.table != nil && m.blocks[m.active].Type == block.Table {
 			rowsBelow := len(m.table.cells) - 1 - m.table.row
@@ -2774,6 +2956,34 @@ func (m *Model) updateViewport() {
 				rowsBelow = 0
 			}
 			bottomTarget = cursorLine + rowsBelow*2 + 1
+		}
+		// Pre-compute scrollTarget after any block-specific cursorLine override.
+		yOffset := m.viewport.YOffset()
+		scrollTarget := cursorLine
+		if cursorRawLine == 0 && chromeLines > 0 {
+			scrollTarget = lineOffset // show from block start
+		}
+
+		if m.kanban != nil && m.blocks[m.active].Type == block.Kanban {
+			top, bot := m.selectedCardLineRange()
+			bottomTarget = lineOffset + chromeLines + bot
+			cursorLine = lineOffset + chromeLines + top
+			kanbanTop := lineOffset + chromeLines
+			// Anchor to the title row only when the user just changed
+			// columns — otherwise navigating into the kanban from below
+			// would snap to top instead of landing near the entry point.
+			if m.kanbanAnchorTop && bottomTarget-kanbanTop+1 <= m.viewport.Height() {
+				scrollTarget = kanbanTop
+			} else {
+				scrollTarget = cursorLine
+			}
+			m.kanbanAnchorTop = false
+		}
+
+		// Always ensure the cursor line is visible. Prefer keeping the
+		// current scroll position when the cursor is already on screen.
+		if scrollTarget < yOffset {
+			yOffset = scrollTarget
 		}
 		if bottomTarget >= yOffset+m.viewport.Height() {
 			candidate := bottomTarget - m.viewport.Height() + 1
@@ -2880,7 +3090,7 @@ func (m *Model) computeBlockLineOffsets() {
 		}
 
 		offsets[i] = nextLine
-		rendered := renderViewBlock(b, content, contentWidth, m.wordWrap, m.blocks, i, false)
+		rendered := renderViewBlock(b, content, contentWidth, m.wordWrap, m.blocks, i, false, m.viewKanbanOffset)
 		advance(rendered)
 		prevIdx = i
 	}
@@ -2973,7 +3183,7 @@ func (m Model) renderViewContent() string {
 		}
 
 		hovered := i == m.hoverBlock
-		rendered := renderViewBlock(b, content, contentWidth, m.wordWrap, m.blocks, i, hovered)
+		rendered := renderViewBlock(b, content, contentWidth, m.wordWrap, m.blocks, i, hovered, m.viewKanbanOffset)
 
 		// Add vertical spacing before certain block types.
 		if prevIdx >= 0 {
@@ -3155,6 +3365,11 @@ func (m Model) blockHint() string {
 		return "line 1 sets language"
 	case block.Checklist:
 		return "\u2303X toggle"
+	case block.Kanban:
+		if m.kanban != nil && m.kanban.edit {
+			return "\u23ce save \u00b7 \u21e7\u23ce newline \u00b7 esc cancel"
+		}
+		return "\u2190\u2192 col \u00b7 \u2191\u2193 card \u00b7 \u21e7+arrows move \u00b7 n new \u00b7 \u23ce edit \u00b7 p prio \u00b7 s sort \u00b7 bksp del (board if col empty)"
 	case block.Embed:
 		return "\u2303X open \u00B7 Tab pick"
 	case block.DefinitionList:
@@ -3348,7 +3563,7 @@ func (m *Model) renderEmbedSheetContent() {
 
 		offsets[i] = len(parts)
 		hovered := i == em.hoverBlock
-		rendered := renderViewBlock(b, b.Content, contentWidth, true, em.blocks, i, hovered)
+		rendered := renderViewBlock(b, b.Content, contentWidth, true, em.blocks, i, hovered, 0)
 		for _, l := range strings.Split(rendered, "\n") {
 			parts = append(parts, padStr+l)
 		}

--- a/internal/editor/kanban.go
+++ b/internal/editor/kanban.go
@@ -1,0 +1,1108 @@
+package editor
+
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/oobagi/notebook-cli/internal/block"
+	"github.com/oobagi/notebook-cli/internal/format"
+	"github.com/oobagi/notebook-cli/internal/theme"
+)
+
+// renderEditingCardText renders the textarea content with a manually
+// drawn cursor, bypassing the textarea's internal viewport. The textarea's
+// own View() can clip top lines once it has scrolled internally; rendering
+// from Value() + cursor position avoids that and matches the rest of the
+// block editor's pattern.
+func renderEditingCardText(ta *textarea.Model, contentWidth int) string {
+	li := ta.LineInfo()
+	cursorRawRow := ta.Line()
+	cursorColInWrap := li.ColumnOffset
+	cursorWrapRow := li.RowOffset
+
+	content := ta.Value()
+	if content == "" {
+		// Show a single cursor on an otherwise empty card.
+		ta.CursorSetChar(" ")
+		return ta.CursorView()
+	}
+
+	rawLines := strings.Split(content, "\n")
+	var visualLines []string
+	for rawIdx, raw := range rawLines {
+		segs := textarea.Wrap([]rune(raw), contentWidth)
+		if len(segs) == 0 {
+			segs = [][]rune{{}}
+		}
+		for wIdx, seg := range segs {
+			line := strings.TrimSuffix(string(seg), " ")
+			if rawIdx == cursorRawRow && wIdx == cursorWrapRow {
+				runes := []rune(line)
+				col := cursorColInWrap
+				if col > len(runes) {
+					col = len(runes)
+				}
+				before := string(runes[:col])
+				curChar := " "
+				after := ""
+				if col < len(runes) {
+					curChar = string(runes[col : col+1])
+					after = string(runes[col+1:])
+				}
+				ta.CursorSetChar(curChar)
+				line = before + ta.CursorView() + after
+			}
+			visualLines = append(visualLines, line)
+		}
+	}
+	return strings.Join(visualLines, "\n")
+}
+
+// kanbanState holds the in-memory representation of a focused Kanban block.
+// Mirrors the role of tableState for tables — non-nil only while a Kanban
+// block is the active block in the editor.
+type kanbanState struct {
+	cols      []block.KanbanColumn
+	col       int  // selected column index
+	card      int  // selected card index within selected column (-1 = column header)
+	colOffset int  // index of the leftmost visible column (horizontal scroll)
+	edit      bool // true when the inline text editor is active
+	editTA    textarea.Model
+	// addedCardIdx tracks a card index inserted by addCard; if the user
+	// cancels editing it before typing anything, cancelEdit drops it and
+	// restores the prior selection. -1 when not in an addCard flow.
+	addedCardIdx int
+}
+
+// kanbanTargetColWidth is the preferred visible width of a single column
+// (including borders/padding of its cards). The renderer uses this to
+// decide how many columns fit on screen at once; the rest stay off-screen
+// and are reached by scrolling horizontally as the focus moves.
+const kanbanTargetColWidth = 32
+
+// kanbanIndicatorWidth reserves space for the ◀ / ▶ off-screen-column
+// indicators on the left/right edges of the board (one cell each).
+const kanbanIndicatorWidth = 1
+
+// newKanbanState parses a kanban body into editable state, defaulting the
+// selection to the first card (or first column if there are no cards).
+func newKanbanState(body string) *kanbanState {
+	ks := &kanbanState{cols: block.ParseKanban(body), addedCardIdx: -1}
+	if len(ks.cols) == 0 {
+		ks.cols = block.ParseKanban(block.DefaultKanbanContent)
+	}
+	ks.col = 0
+	if len(ks.cols[0].Cards) > 0 {
+		ks.card = 0
+	} else {
+		ks.card = -1
+	}
+	return ks
+}
+
+// serialize emits the current board to kanban-fence body markdown.
+func (ks *kanbanState) serialize() string {
+	return block.SerializeKanban(ks.cols)
+}
+
+// enterFromAbove positions the selection for entering the kanban from a
+// block above (e.g. via Down arrow). Lands on the leftmost column that
+// has cards, first card. If all columns are empty, col=0 with no card.
+func (ks *kanbanState) enterFromAbove() {
+	for ci := range ks.cols {
+		if len(ks.cols[ci].Cards) > 0 {
+			ks.col = ci
+			ks.card = 0
+			return
+		}
+	}
+	ks.col = 0
+	ks.card = -1
+}
+
+// enterFromBelow positions the selection for entering the kanban from a
+// block below (e.g. via Up arrow). Lands on the leftmost column that has
+// cards, last card. Mirrors enterFromAbove for symmetric navigation.
+func (ks *kanbanState) enterFromBelow() {
+	for ci := range ks.cols {
+		if len(ks.cols[ci].Cards) > 0 {
+			ks.col = ci
+			ks.card = len(ks.cols[ci].Cards) - 1
+			return
+		}
+	}
+	ks.col = 0
+	ks.card = -1
+}
+
+// selectedCard returns a pointer to the selected card, or nil.
+func (ks *kanbanState) selectedCard() *block.KanbanCard {
+	if ks.col < 0 || ks.col >= len(ks.cols) {
+		return nil
+	}
+	if ks.card < 0 || ks.card >= len(ks.cols[ks.col].Cards) {
+		return nil
+	}
+	return &ks.cols[ks.col].Cards[ks.card]
+}
+
+// clamp keeps col/card in valid bounds. Called after every mutation.
+func (ks *kanbanState) clamp() {
+	if len(ks.cols) == 0 {
+		ks.col, ks.card = 0, -1
+		return
+	}
+	if ks.col < 0 {
+		ks.col = 0
+	}
+	if ks.col >= len(ks.cols) {
+		ks.col = len(ks.cols) - 1
+	}
+	n := len(ks.cols[ks.col].Cards)
+	if n == 0 {
+		ks.card = -1
+		return
+	}
+	if ks.card < 0 {
+		ks.card = 0
+	}
+	if ks.card >= n {
+		ks.card = n - 1
+	}
+}
+
+// clampColOffset shifts the horizontal viewport so the selected column is
+// visible within a window of `visible` columns. When the selected column
+// is already in view, colOffset is unchanged (no jitter).
+func (ks *kanbanState) clampColOffset(visible int) {
+	if visible <= 0 || len(ks.cols) == 0 {
+		ks.colOffset = 0
+		return
+	}
+	if visible >= len(ks.cols) {
+		ks.colOffset = 0
+		return
+	}
+	if ks.col < ks.colOffset {
+		ks.colOffset = ks.col
+	} else if ks.col >= ks.colOffset+visible {
+		ks.colOffset = ks.col - visible + 1
+	}
+	if ks.colOffset < 0 {
+		ks.colOffset = 0
+	}
+	if ks.colOffset > len(ks.cols)-visible {
+		ks.colOffset = len(ks.cols) - visible
+	}
+}
+
+// moveSelection nudges the selection in a direction. Falls through to
+// adjacent columns at the edges, so navigation feels continuous.
+func (ks *kanbanState) moveSelection(dCol, dCard int) {
+	if len(ks.cols) == 0 {
+		return
+	}
+	if dCol != 0 {
+		ks.col += dCol
+		if ks.col < 0 {
+			ks.col = 0
+		}
+		if ks.col >= len(ks.cols) {
+			ks.col = len(ks.cols) - 1
+		}
+		// Try to keep the same card index when switching columns; clamp.
+		ks.clamp()
+		return
+	}
+	if dCard != 0 {
+		n := len(ks.cols[ks.col].Cards)
+		if n == 0 {
+			return
+		}
+		ks.card += dCard
+		if ks.card < 0 {
+			ks.card = 0
+		}
+		if ks.card >= n {
+			ks.card = n - 1
+		}
+	}
+}
+
+// moveCard moves the selected card within its column or across columns,
+// preserving selection (selection follows the moved card).
+func (ks *kanbanState) moveCard(dCol, dCard int) {
+	c := ks.selectedCard()
+	if c == nil {
+		return
+	}
+	src := *c
+	col := &ks.cols[ks.col]
+
+	if dCard != 0 && dCol == 0 {
+		// Reorder within column.
+		newIdx := ks.card + dCard
+		if newIdx < 0 || newIdx >= len(col.Cards) {
+			return
+		}
+		col.Cards[ks.card], col.Cards[newIdx] = col.Cards[newIdx], col.Cards[ks.card]
+		ks.card = newIdx
+		return
+	}
+	if dCol != 0 {
+		newCol := ks.col + dCol
+		if newCol < 0 || newCol >= len(ks.cols) {
+			return
+		}
+		// Remove from current.
+		col.Cards = append(col.Cards[:ks.card], col.Cards[ks.card+1:]...)
+		// Append to bottom of destination column (most natural for kanban).
+		ks.cols[newCol].Cards = append(ks.cols[newCol].Cards, src)
+		ks.col = newCol
+		ks.card = len(ks.cols[newCol].Cards) - 1
+	}
+}
+
+// addCard inserts a new empty card after the current selection (or at top
+// when the column is empty), then enters edit mode on it.
+func (ks *kanbanState) addCard(width int) {
+	if len(ks.cols) == 0 {
+		return
+	}
+	col := &ks.cols[ks.col]
+	newIdx := ks.card + 1
+	if newIdx < 0 {
+		newIdx = 0
+	}
+	if newIdx > len(col.Cards) {
+		newIdx = len(col.Cards)
+	}
+	card := block.KanbanCard{}
+	col.Cards = append(col.Cards[:newIdx], append([]block.KanbanCard{card}, col.Cards[newIdx:]...)...)
+	ks.card = newIdx
+	ks.addedCardIdx = newIdx
+	ks.startEdit(width)
+}
+
+// deleteCard removes the selected card.
+func (ks *kanbanState) deleteCard() {
+	c := ks.selectedCard()
+	if c == nil {
+		return
+	}
+	col := &ks.cols[ks.col]
+	col.Cards = append(col.Cards[:ks.card], col.Cards[ks.card+1:]...)
+	ks.clamp()
+}
+
+// isEmpty reports whether the board has zero cards across all columns.
+func (ks *kanbanState) isEmpty() bool {
+	for _, c := range ks.cols {
+		if len(c.Cards) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// togglePriority cycles the priority of the selected card.
+func (ks *kanbanState) togglePriority() {
+	c := ks.selectedCard()
+	if c == nil {
+		return
+	}
+	c.Priority = c.Priority.Next()
+}
+
+// sortByPriority sorts cards within each column by priority descending
+// (HIGH → MED → LOW → none) using a stable sort, so cards of the same
+// priority keep their relative order. Selection follows the focused card
+// to its new position.
+func (ks *kanbanState) sortByPriority() {
+	// Tag the selected card so we can find it after sort.
+	type marker struct{}
+	var sel *marker
+	if c := ks.selectedCard(); c != nil {
+		sel = &marker{}
+	}
+	for ci, col := range ks.cols {
+		// Pair (originalIdx, card) for stable sort.
+		idxs := make([]int, len(col.Cards))
+		for i := range idxs {
+			idxs[i] = i
+		}
+		// Stable sort: higher priority first; ties preserve original order.
+		for i := 1; i < len(idxs); i++ {
+			for j := i; j > 0; j-- {
+				a := col.Cards[idxs[j-1]].Priority
+				b := col.Cards[idxs[j]].Priority
+				if a >= b {
+					break
+				}
+				idxs[j-1], idxs[j] = idxs[j], idxs[j-1]
+			}
+		}
+		// Apply.
+		newCards := make([]block.KanbanCard, len(col.Cards))
+		for i, oi := range idxs {
+			newCards[i] = col.Cards[oi]
+		}
+		ks.cols[ci].Cards = newCards
+		// Update selection if this is the selected column.
+		if ci == ks.col && sel != nil {
+			for newIdx, oi := range idxs {
+				if oi == ks.card {
+					ks.card = newIdx
+					break
+				}
+			}
+		}
+	}
+}
+
+// startEdit opens an inline textarea seeded with the selected card's text.
+// The textarea wraps at the card's inner width and grows in height as the
+// user types or inserts newlines (Shift+Enter).
+func (ks *kanbanState) startEdit(width int) {
+	c := ks.selectedCard()
+	if c == nil {
+		return
+	}
+	ta := textarea.New()
+	ta.ShowLineNumbers = false
+	ta.Prompt = ""
+	ta.CharLimit = 0
+	ta.SetWidth(width)
+	ta.SetValue(c.Text)
+	ta.MoveToEnd()
+	ta.SetHeight(ta.VisualLineCount())
+	ta.Focus()
+	ks.editTA = ta
+	ks.edit = true
+}
+
+// commitEdit writes the textarea contents back to the selected card and
+// exits edit mode. Empty card text is left empty (the card stays).
+func (ks *kanbanState) commitEdit() {
+	c := ks.selectedCard()
+	if c == nil {
+		ks.edit = false
+		ks.addedCardIdx = -1
+		return
+	}
+	c.Text = strings.TrimRight(ks.editTA.Value(), "\n")
+	ks.edit = false
+	ks.addedCardIdx = -1
+}
+
+// cancelEdit discards textarea changes and exits edit mode. If the card
+// was just created via addCard and never typed into, drop it AND restore
+// the selection to the card the user was on before pressing `n` so Esc
+// doesn't shift their focus to a different card.
+func (ks *kanbanState) cancelEdit() {
+	if c := ks.selectedCard(); c != nil && c.Text == "" && ks.editTA.Value() == "" {
+		justAdded := ks.addedCardIdx == ks.card
+		ks.deleteCard()
+		if justAdded {
+			// addCard set ks.card = prev+1; restore by stepping back.
+			if ks.card > 0 {
+				ks.card--
+			}
+			ks.clamp()
+		}
+	}
+	ks.edit = false
+	ks.addedCardIdx = -1
+}
+
+// selectedCardLineRange returns the inclusive [top, bottom] line offsets
+// of the selected card within the rendered kanban board, relative to the
+// board's first line. Returns (0, 0) when there is no selection (e.g.
+// empty column). Used to drive viewport auto-scroll so the selected card
+// stays visible when the board is taller than the viewport.
+func (m Model) selectedCardLineRange() (top, bottom int) {
+	if m.kanban == nil || len(m.kanban.cols) == 0 {
+		return 0, 0
+	}
+	col := m.kanban.col
+	if col < 0 || col >= len(m.kanban.cols) {
+		return 0, 0
+	}
+	cards := m.kanban.cols[col].Cards
+	if m.kanban.card < 0 || m.kanban.card >= len(cards) {
+		// Empty / no card selected: return header line range.
+		return 0, 1 // title + underline
+	}
+
+	// Header (title + underline) is 2 lines.
+	line := 2
+	cardOuterWidth := m.kanbanCardOuterWidth()
+	contentWidth := cardOuterWidth - kanbanCardChromeWidth
+	if contentWidth < 1 {
+		contentWidth = 1
+	}
+	for i := 0; i < m.kanban.card; i++ {
+		line += cardRenderHeight(cards[i], contentWidth)
+	}
+	height := cardRenderHeight(cards[m.kanban.card], contentWidth)
+	if m.kanban.edit {
+		// Editing: textarea visual line count drives the height.
+		taLines := m.kanban.editTA.VisualLineCount()
+		if taLines < 1 {
+			taLines = 1
+		}
+		// 2 border + priority badge (1 if present).
+		extra := 2
+		if cards[m.kanban.card].Priority != block.PriorityNone {
+			extra++
+		}
+		height = taLines + extra
+	}
+	return line, line + height - 1
+}
+
+// maxViewKanbanOffset returns the largest valid offset for the view-mode
+// horizontal scroll, based on the widest kanban block in the document at
+// the current terminal width. Zero when no kanban exists or the board
+// already fits.
+func (m Model) maxViewKanbanOffset() int {
+	maxOff := 0
+	width := m.width - 4
+	if width < 30 {
+		width = 30
+	}
+	for _, b := range m.blocks {
+		if b.Type != block.Kanban {
+			continue
+		}
+		cols := block.ParseKanban(b.Content)
+		visible, _ := kanbanVisibleCols(len(cols), width)
+		off := len(cols) - visible
+		if off > maxOff {
+			maxOff = off
+		}
+	}
+	return maxOff
+}
+
+// kanbanCardOuterWidth returns the visible width of a card box, computed
+// the same way as renderKanbanBoard so callers stay in sync.
+func (m Model) kanbanCardOuterWidth() int {
+	if m.kanban == nil || len(m.kanban.cols) == 0 {
+		return 20
+	}
+	width := m.width - gutterWidth
+	if width < 30 {
+		width = 30
+	}
+	_, colWidth := kanbanVisibleCols(len(m.kanban.cols), width)
+	return colWidth
+}
+
+// cardRenderHeight predicts the rendered line count of a single card box
+// given its content width. Mirrors the math in renderKanbanCard.
+func cardRenderHeight(card block.KanbanCard, contentWidth int) int {
+	textLines := 1
+	if card.Text != "" {
+		// Account for explicit newlines in card text and word-wrapping at
+		// contentWidth (matches wrapPlain).
+		wrapped := wrapPlain(card.Text, contentWidth)
+		textLines = strings.Count(wrapped, "\n") + 1
+	}
+	extra := 2 // top + bottom border
+	if card.Priority != block.PriorityNone {
+		extra++ // priority header line
+	}
+	return textLines + extra
+}
+
+// kanbanCardChromeWidth is the visual width consumed by a card's border
+// (left + right) plus its horizontal padding (1 + 1).
+const kanbanCardChromeWidth = 4
+
+// renderKanbanCard renders one card box. outerWidth is the total visible
+// width of the card box (including border and padding); the actual text
+// content area is outerWidth - kanbanCardChromeWidth wide.
+func renderKanbanCard(card block.KanbanCard, outerWidth int, selected, editing bool, editView string, th theme.Theme) string {
+	border := lipgloss.RoundedBorder()
+	borderColor := th.Border
+	if selected {
+		borderColor = th.Accent
+	}
+
+	style := lipgloss.NewStyle().
+		Border(border).
+		BorderForeground(lipgloss.Color(borderColor)).
+		Padding(0, 1).
+		Width(outerWidth)
+
+	contentWidth := outerWidth - kanbanCardChromeWidth
+	if contentWidth < 1 {
+		contentWidth = 1
+	}
+
+	var text string
+	switch {
+	case editing:
+		text = editView
+		if text == "" {
+			text = " "
+		}
+	case card.Text == "":
+		text = lipgloss.NewStyle().Faint(true).Render("(empty)")
+	default:
+		// Wrap the plain text first (wrap uses visual width and would
+		// miscount ANSI escapes), then apply inline markdown formatting.
+		text = format.RenderInlineMarkdown(wrapPlain(card.Text, contentWidth))
+	}
+
+	// Priority badge on its own short header line.
+	header := ""
+	if m := card.Priority.Marker(); m != "" {
+		color := priorityColor(card.Priority, th)
+		bs := lipgloss.NewStyle().Foreground(lipgloss.Color(color))
+		if card.Priority == block.PriorityHigh {
+			bs = bs.Bold(true)
+		}
+		header = bs.Render(m)
+	}
+
+	body := text
+	if header != "" {
+		body = header + "\n" + text
+	}
+	return style.Render(body)
+}
+
+// wrapPlain word-wraps text to the given visual width. Empty preserves
+// existing line breaks so multi-line card bodies render naturally.
+func wrapPlain(text string, width int) string {
+	if width <= 0 {
+		return text
+	}
+	out := make([]string, 0)
+	for _, line := range strings.Split(text, "\n") {
+		if line == "" {
+			out = append(out, "")
+			continue
+		}
+		words := strings.Fields(line)
+		if len(words) == 0 {
+			out = append(out, line)
+			continue
+		}
+		cur := words[0]
+		for _, w := range words[1:] {
+			if lipgloss.Width(cur)+1+lipgloss.Width(w) <= width {
+				cur += " " + w
+			} else {
+				out = append(out, cur)
+				cur = w
+			}
+		}
+		out = append(out, cur)
+	}
+	return strings.Join(out, "\n")
+}
+
+// kanbanVisibleCols returns the number of columns that fit in width and
+// the chosen per-column width. Always at least 1; capped at the total
+// column count.
+func kanbanVisibleCols(totalCols, width int) (visible, colWidth int) {
+	if totalCols <= 0 {
+		return 0, 0
+	}
+	gap := 1
+	// Reserve indicator strips on both edges when not all columns fit.
+	usable := width
+	// Account for inter-column gaps when fitting N columns: gap*(N-1).
+	// Greedy: try N from totalCols down to 1.
+	for n := totalCols; n >= 1; n-- {
+		gaps := gap * (n - 1)
+		// If we'd be hiding columns, reserve 2*indicator for ◀ / ▶.
+		reserved := 0
+		if n < totalCols {
+			reserved = kanbanIndicatorWidth * 2
+		}
+		w := (usable - gaps - reserved) / n
+		if w >= kanbanTargetColWidth || n == 1 {
+			if w < 14 {
+				w = 14
+			}
+			return n, w
+		}
+	}
+	return 1, max(usable, 14)
+}
+
+// renderKanbanBoard renders the full board. Width is the available width
+// for the kanban (including borders). Columns slide horizontally so the
+// selected column is always in view.
+func (m Model) renderKanbanBoard(blockIdx, width int) string {
+	if m.kanban == nil {
+		return ""
+	}
+	th := theme.Current()
+	cols := m.kanban.cols
+	if len(cols) == 0 {
+		return ""
+	}
+
+	visible, colWidth := kanbanVisibleCols(len(cols), width)
+	m.kanban.clampColOffset(visible)
+	startCol := m.kanban.colOffset
+	endCol := startCol + visible
+	if endCol > len(cols) {
+		endCol = len(cols)
+	}
+	// Cards span the full column width. Title/underline use the same width
+	// so everything aligns visually.
+	cardOuterWidth := colWidth
+	gap := 1
+
+	colStyle := lipgloss.NewStyle().Width(colWidth)
+
+	rendered := make([]string, 0, endCol-startCol)
+	for ci := startCol; ci < endCol; ci++ {
+		col := cols[ci]
+		colSelected := m.kanban.col == ci
+		titleColor := th.Accent
+		if !colSelected {
+			titleColor = th.Muted
+		}
+		titleStyle := lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color(titleColor)).
+			Width(colWidth).
+			Padding(0, 1)
+		count := lipgloss.NewStyle().
+			Faint(true).
+			Render(formatCount(len(col.Cards)))
+		title := titleStyle.Render(format.StripControlChars(col.Title) + "  " + count)
+
+		// Underline: solid accent rule when this column is selected,
+		// otherwise a faint border-color rule.
+		underColor := th.Border
+		if colSelected {
+			underColor = th.Accent
+		}
+		under := lipgloss.NewStyle().
+			Foreground(lipgloss.Color(underColor)).
+			Render(strings.Repeat("─", colWidth))
+
+		var cardLines []string
+		cardLines = append(cardLines, title)
+		cardLines = append(cardLines, under)
+
+		if len(col.Cards) == 0 {
+			// Empty placeholder. When this column is the focus, draw it
+			// in accent so the user can see where they are.
+			placeholderColor := th.Muted
+			placeholderText := "no cards · n to add"
+			if colSelected {
+				placeholderColor = th.Accent
+			}
+			placeholder := lipgloss.NewStyle().
+				Foreground(lipgloss.Color(placeholderColor)).
+				Italic(true).
+				Padding(0, 2).
+				Render(placeholderText)
+			cardLines = append(cardLines, placeholder)
+		}
+
+		for cardI, card := range col.Cards {
+			isSel := m.kanban.col == ci && m.kanban.card == cardI
+			editing := isSel && m.kanban.edit
+			editView := ""
+			if editing {
+				editView = renderEditingCardText(&m.kanban.editTA, cardOuterWidth-kanbanCardChromeWidth)
+			}
+			cardLines = append(cardLines, renderKanbanCard(card, cardOuterWidth, isSel, editing, editView, th))
+		}
+
+		rendered = append(rendered, colStyle.Render(strings.Join(cardLines, "\n")))
+	}
+
+	gapStr := strings.Repeat(" ", gap)
+	board := lipgloss.JoinHorizontal(lipgloss.Top, joinWithGap(rendered, gapStr)...)
+
+	// Sandwich with off-screen-column indicators when more cols exist.
+	leftHidden := startCol
+	rightHidden := len(cols) - endCol
+	if leftHidden > 0 || rightHidden > 0 {
+		left := renderColIndicator(leftHidden, true, th)
+		right := renderColIndicator(rightHidden, false, th)
+		board = lipgloss.JoinHorizontal(lipgloss.Top, left, board, right)
+	}
+	return board
+}
+
+// renderColIndicator renders a single-cell arrow showing whether columns
+// are hidden on the left or right edge of the board. Returns a single
+// space when count is 0 so the layout stays stable.
+func renderColIndicator(count int, left bool, th theme.Theme) string {
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color(th.Muted))
+	if count <= 0 {
+		return " "
+	}
+	if left {
+		return style.Render("◀")
+	}
+	return style.Render("▶")
+}
+
+// joinWithGap interleaves a gap string between rendered columns.
+func joinWithGap(parts []string, gap string) []string {
+	if len(parts) == 0 {
+		return parts
+	}
+	out := make([]string, 0, len(parts)*2-1)
+	for i, p := range parts {
+		if i > 0 {
+			out = append(out, gap)
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// cloneKanbanCols deep-copies a column slice (and its card slices) so the
+// caller can mutate the result without aliasing live editor state.
+func cloneKanbanCols(in []block.KanbanColumn) []block.KanbanColumn {
+	out := make([]block.KanbanColumn, len(in))
+	for i, col := range in {
+		copyCards := make([]block.KanbanCard, len(col.Cards))
+		copy(copyCards, col.Cards)
+		out[i] = block.KanbanColumn{Title: col.Title, Cards: copyCards}
+	}
+	return out
+}
+
+// kanbanCardEditWidth returns the available textarea width for the inline
+// edit textarea: matches the card's inner content width so the textarea
+// wraps at exactly the same column the rendered box does.
+func (m Model) kanbanCardEditWidth() int {
+	return m.kanbanCardOuterWidth() - kanbanCardChromeWidth
+}
+
+// handleKanbanKey routes a key press to the kanban state machine while a
+// Kanban block is active. Returns (handled, cmd). When handled is true,
+// the caller must not process the key further; when false, the global
+// editor handler runs (e.g. for Ctrl+S, Ctrl+R, Esc).
+func (m *Model) handleKanbanKey(msg tea.KeyPressMsg) (handled bool, cmd tea.Cmd) {
+	if m.kanban == nil {
+		return false, nil
+	}
+
+	// Edit mode: most keys go to the textarea. Enter commits, Shift+Enter
+	// inserts a newline (matches the rest of the editor's "soft newline"
+	// convention). Esc cancels.
+	if m.kanban.edit {
+		switch msg.String() {
+		case "esc":
+			m.kanban.cancelEdit()
+			return true, nil
+		case "enter":
+			m.kanban.commitEdit()
+			return true, nil
+		case "shift+enter", "ctrl+j":
+			// Insert a literal newline by forwarding a plain Enter to the
+			// textarea (which interprets it as a newline since CharLimit=0
+			// and we don't intercept it).
+			m.kanban.editTA.SetHeight(m.kanban.editTA.VisualLineCount() + 1)
+			var c tea.Cmd
+			m.kanban.editTA, c = m.kanban.editTA.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+			m.kanban.editTA.SetHeight(m.kanban.editTA.VisualLineCount())
+			return true, c
+		case "ctrl+s":
+			// Let main handler save; first commit edit so latest text is in state.
+			m.kanban.commitEdit()
+			return false, nil
+		}
+		var c tea.Cmd
+		m.kanban.editTA, c = m.kanban.editTA.Update(msg)
+		// Reflow height so the box grows with wrapped/multi-line content.
+		m.kanban.editTA.SetHeight(m.kanban.editTA.VisualLineCount())
+		return true, c
+	}
+
+	// Selection mode keys.
+	switch msg.String() {
+	case "left":
+		m.kanban.moveSelection(-1, 0)
+		m.kanbanAnchorTop = true
+		return true, nil
+	case "right":
+		m.kanban.moveSelection(1, 0)
+		m.kanbanAnchorTop = true
+		return true, nil
+	case "up":
+		// At top of column (or empty column), navigate out to the previous
+		// block so the page can scroll past the board.
+		col := m.kanban.cols[m.kanban.col]
+		if m.kanban.card <= 0 || len(col.Cards) == 0 {
+			if m.active > 0 {
+				m.navigateUp()
+			} else if m.blocks[0].Type != block.Paragraph {
+				m.pushUndo()
+				m.insertBlockBefore(0, block.Block{Type: block.Paragraph})
+			}
+			return true, nil
+		}
+		m.kanban.moveSelection(0, -1)
+		m.kanbanAnchorTop = true
+		return true, nil
+	case "down":
+		col := m.kanban.cols[m.kanban.col]
+		if len(col.Cards) == 0 || m.kanban.card >= len(col.Cards)-1 {
+			if m.active < len(m.textareas)-1 {
+				m.navigateDown()
+			} else {
+				// At last card of last block — insert a paragraph
+				// below so the user can escape downward.
+				m.pushUndo()
+				m.insertBlockAfter(m.active, block.Block{Type: block.Paragraph})
+			}
+			return true, nil
+		}
+		m.kanban.moveSelection(0, 1)
+		m.kanbanAnchorTop = true
+		return true, nil
+	case "pgup":
+		// Always page-scroll past the board.
+		m.viewport.HalfPageUp()
+		return true, nil
+	case "pgdown":
+		m.viewport.HalfPageDown()
+		return true, nil
+	case "shift+left":
+		m.pushUndo()
+		m.kanban.moveCard(-1, 0)
+		m.kanbanAnchorTop = true
+		return true, nil
+	case "shift+right":
+		m.pushUndo()
+		m.kanban.moveCard(1, 0)
+		m.kanbanAnchorTop = true
+		return true, nil
+	case "shift+up":
+		m.pushUndo()
+		m.kanban.moveCard(0, -1)
+		m.kanbanAnchorTop = true
+		return true, nil
+	case "shift+down":
+		m.pushUndo()
+		m.kanban.moveCard(0, 1)
+		m.kanbanAnchorTop = true
+		return true, nil
+	case "enter":
+		if m.kanban.selectedCard() != nil {
+			m.pushUndo()
+			m.kanban.startEdit(m.kanbanCardEditWidth())
+			return true, nil
+		}
+		// No card to edit — escape downward by inserting a paragraph
+		// below the kanban so the user can keep writing.
+		m.pushUndo()
+		m.insertBlockAfter(m.active, block.Block{Type: block.Paragraph})
+		return true, nil
+	case "n", "ctrl+n":
+		m.pushUndo()
+		m.kanban.addCard(m.kanbanCardEditWidth())
+		// New card has no priority, so sorting puts it after prioritized
+		// cards. Apply sort so it lands in the right slot immediately.
+		if m.kanbanSortByPrio {
+			m.kanban.sortByPriority()
+		}
+		return true, nil
+	case "backspace", "delete":
+		if m.kanban.selectedCard() != nil {
+			m.pushUndo()
+			m.kanban.deleteCard()
+			return true, nil
+		}
+		// On an empty column (no card selected) → delete the whole
+		// kanban block. Undo restores it.
+		m.pushUndo()
+		m.kanban = nil
+		m.deleteBlock(m.active)
+		m.textareas[m.active].MoveToEnd()
+		return true, nil
+	case "p":
+		if m.kanban.selectedCard() != nil {
+			m.pushUndo()
+			m.kanban.togglePriority()
+			if m.kanbanSortByPrio {
+				m.kanban.sortByPriority()
+			}
+		}
+		return true, nil
+	case "s":
+		// Toggle priority sort for the whole document and persist.
+		m.pushUndo()
+		m.kanbanSortByPrio = !m.kanbanSortByPrio
+		if m.kanbanSortByPrio {
+			m.kanban.sortByPriority()
+			m.status = "Sort by priority: on"
+		} else {
+			m.status = "Sort by priority: off"
+		}
+		m.statusStyle = statusSuccess
+		m.persistKanbanSort()
+		return true, m.scheduleStatusDismiss()
+	case "tab":
+		// Tab cycles to the next column.
+		m.kanban.moveSelection(1, 0)
+		m.kanbanAnchorTop = true
+		return true, nil
+	case "shift+tab":
+		m.kanban.moveSelection(-1, 0)
+		m.kanbanAnchorTop = true
+		return true, nil
+	}
+
+	// Swallow plain printable keystrokes so the underlying textarea
+	// (which holds serialized kanban markdown) isn't mutated. A direct
+	// mutation would push a phantom undo entry whose state is the
+	// serialized board, and the next focusBlock would silently overwrite
+	// the typed characters via m.kanban.serialize(). Modifier-bearing
+	// keys (Ctrl+S, Ctrl+R, Ctrl+G, Ctrl+Z, etc.) and special keys
+	// (Esc, function keys) still fall through to the global handler.
+	if msg.Text != "" && msg.Mod == 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
+// renderActiveKanban renders the focused Kanban block including the gutter
+// label, mirroring the structure used by other active block render branches.
+func (m Model) renderActiveKanban(idx int, b block.Block) string {
+	width := m.width - gutterWidth
+	if width < 30 {
+		width = 30
+	}
+	board := m.renderKanbanBoard(idx, width)
+	return prefixGutter(board, b, true)
+}
+
+// renderInactiveKanbanBoard renders a kanban board read-only (used for
+// inactive editor blocks and view mode). Uses the same horizontal
+// sliding-window layout as the active board so the look matches; the
+// only difference is no card is highlighted as selected. The window
+// offset is taken from `colOffset` — callers can drive scroll in view
+// mode by adjusting it.
+func renderInactiveKanbanBoard(content string, width, colOffset int, th theme.Theme) string {
+	cols := block.ParseKanban(content)
+	if len(cols) == 0 {
+		return lipgloss.NewStyle().Faint(true).Render("(empty kanban — focus and press n to add a card)")
+	}
+
+	visible, colWidth := kanbanVisibleCols(len(cols), width)
+	startCol := colOffset
+	if startCol < 0 {
+		startCol = 0
+	}
+	if startCol > len(cols)-visible {
+		startCol = len(cols) - visible
+	}
+	endCol := startCol + visible
+	if endCol > len(cols) {
+		endCol = len(cols)
+	}
+
+	colStyle := lipgloss.NewStyle().Width(colWidth)
+
+	rendered := make([]string, 0, endCol-startCol)
+	for ci := startCol; ci < endCol; ci++ {
+		col := cols[ci]
+		titleStyle := lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color(th.Accent)).
+			Width(colWidth).
+			Padding(0, 1)
+		count := lipgloss.NewStyle().
+			Faint(true).
+			Render(formatCount(len(col.Cards)))
+		title := titleStyle.Render(format.StripControlChars(col.Title) + "  " + count)
+		under := lipgloss.NewStyle().
+			Foreground(lipgloss.Color(th.Border)).
+			Render(strings.Repeat("─", colWidth))
+
+		var cardLines []string
+		cardLines = append(cardLines, title)
+		cardLines = append(cardLines, under)
+
+		if len(col.Cards) == 0 {
+			placeholder := lipgloss.NewStyle().Faint(true).Italic(true).Padding(0, 2).Render("no cards")
+			cardLines = append(cardLines, placeholder)
+		}
+
+		for _, card := range col.Cards {
+			cardLines = append(cardLines, renderKanbanCard(card, colWidth, false, false, "", th))
+		}
+
+		rendered = append(rendered, colStyle.Render(strings.Join(cardLines, "\n")))
+	}
+
+	gapStr := " "
+	board := lipgloss.JoinHorizontal(lipgloss.Top, joinWithGap(rendered, gapStr)...)
+
+	leftHidden := startCol
+	rightHidden := len(cols) - endCol
+	if leftHidden > 0 || rightHidden > 0 {
+		left := renderColIndicator(leftHidden, true, th)
+		right := renderColIndicator(rightHidden, false, th)
+		board = lipgloss.JoinHorizontal(lipgloss.Top, left, board, right)
+	}
+	return board
+}
+
+// prefixGutter mirrors the gutter+separator decoration applied to all
+// other active block renders so kanban aligns with surrounding blocks.
+func prefixGutter(body string, b block.Block, active bool) string {
+	th := theme.Current()
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color(th.Accent))
+	if !active {
+		style = lipgloss.NewStyle().Faint(true)
+	}
+	label := style.Render(formatBlockLabel(b.Type))
+	sep := style.Render("│")
+	blank := style.Render("  ")
+	lines := strings.Split(body, "\n")
+	for i, l := range lines {
+		if i == 0 {
+			lines[i] = label + " " + sep + " " + l
+		} else {
+			lines[i] = blank + " " + sep + " " + l
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// formatBlockLabel returns the 2-char gutter label for a block type.
+func formatBlockLabel(bt block.BlockType) string {
+	s := bt.Short()
+	if len(s) >= 2 {
+		return s[:2]
+	}
+	return s + " "
+}
+
+// formatCount returns "(n)" for a card count.
+func formatCount(n int) string {
+	if n == 0 {
+		return "(0)"
+	}
+	if n == 1 {
+		return "(1)"
+	}
+	// Avoid pulling fmt for one tiny use.
+	digits := ""
+	for n > 0 {
+		digits = string(rune('0'+(n%10))) + digits
+		n /= 10
+	}
+	return "(" + digits + ")"
+}

--- a/internal/editor/kanban_test.go
+++ b/internal/editor/kanban_test.go
@@ -1,0 +1,662 @@
+package editor
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/oobagi/notebook-cli/internal/block"
+)
+
+const sampleKanbanMD = "```kanban\n" +
+	"## Todo\n" +
+	"- A\n" +
+	"- B\n" +
+	"\n" +
+	"## Doing\n" +
+	"- C\n" +
+	"\n" +
+	"## Done\n" +
+	"- [x] D\n" +
+	"```"
+
+// firstKanban returns the index of the first Kanban block in m, or -1.
+func firstKanban(m Model) int {
+	for i, b := range m.blocks {
+		if b.Type == block.Kanban {
+			return i
+		}
+	}
+	return -1
+}
+
+// pressKey synthesizes a KeyPressMsg for tests via the model's Update path.
+func pressKey(m Model, key string) Model {
+	msg := keyMsgFromString(key)
+	out, _ := m.Update(msg)
+	return out.(Model)
+}
+
+// keyMsgFromString builds a tea.KeyPressMsg whose String() matches `key`.
+// We map common test keys directly to KeyCode + ModMask so the resulting
+// msg.String() matches the strings the editor's switch statements compare.
+func keyMsgFromString(key string) tea.KeyPressMsg {
+	switch key {
+	case "left":
+		return tea.KeyPressMsg{Code: tea.KeyLeft}
+	case "right":
+		return tea.KeyPressMsg{Code: tea.KeyRight}
+	case "up":
+		return tea.KeyPressMsg{Code: tea.KeyUp}
+	case "down":
+		return tea.KeyPressMsg{Code: tea.KeyDown}
+	case "shift+left":
+		return tea.KeyPressMsg{Code: tea.KeyLeft, Mod: tea.ModShift}
+	case "shift+right":
+		return tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift}
+	case "shift+up":
+		return tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift}
+	case "shift+down":
+		return tea.KeyPressMsg{Code: tea.KeyDown, Mod: tea.ModShift}
+	case "enter":
+		return tea.KeyPressMsg{Code: tea.KeyEnter}
+	case "esc":
+		return tea.KeyPressMsg{Code: tea.KeyEsc}
+	case "backspace":
+		return tea.KeyPressMsg{Code: tea.KeyBackspace}
+	case "n":
+		return tea.KeyPressMsg{Code: 'n', Text: "n"}
+	case "p":
+		return tea.KeyPressMsg{Code: 'p', Text: "p"}
+	case "s":
+		return tea.KeyPressMsg{Code: 's', Text: "s"}
+	case "space":
+		return tea.KeyPressMsg{Code: tea.KeySpace, Text: " "}
+	case "x":
+		return tea.KeyPressMsg{Code: 'x', Text: "x"}
+	case "z":
+		return tea.KeyPressMsg{Code: 'z', Text: "z"}
+	case "?":
+		return tea.KeyPressMsg{Code: '?', Text: "?"}
+	}
+	// Generic single-char fallback.
+	if len(key) == 1 {
+		return tea.KeyPressMsg{Code: rune(key[0]), Text: key}
+	}
+	return tea.KeyPressMsg{}
+}
+
+func newKanbanEditor(t *testing.T) Model {
+	t.Helper()
+	m := New(Config{Title: "test", Content: sampleKanbanMD, Save: func(string) error { return nil }})
+	// Window-size message wires up widths; tests exercise model methods that
+	// don't require a real terminal, but column width math needs >0.
+	out, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = out.(Model)
+	idx := firstKanban(m)
+	if idx < 0 {
+		t.Fatalf("no Kanban block parsed from sample")
+	}
+	if m.kanban == nil {
+		t.Fatalf("kanban state not initialized")
+	}
+	return m
+}
+
+func TestKanbanInitialSelection(t *testing.T) {
+	m := newKanbanEditor(t)
+	if m.kanban.col != 0 {
+		t.Errorf("initial col = %d, want 0", m.kanban.col)
+	}
+	if m.kanban.card != 0 {
+		t.Errorf("initial card = %d, want 0", m.kanban.card)
+	}
+	if c := m.kanban.selectedCard(); c == nil || c.Text != "A" {
+		t.Errorf("selected card = %+v, want A", c)
+	}
+}
+
+func TestKanbanRightArrowMovesColumn(t *testing.T) {
+	m := newKanbanEditor(t)
+	m = pressKey(m, "right")
+	if m.kanban.col != 1 {
+		t.Errorf("col after right = %d, want 1", m.kanban.col)
+	}
+	if c := m.kanban.selectedCard(); c == nil || c.Text != "C" {
+		t.Errorf("selected = %+v, want C", c)
+	}
+}
+
+func TestKanbanShiftRightMovesCard(t *testing.T) {
+	m := newKanbanEditor(t)
+	// Move A to "Doing" column.
+	m = pressKey(m, "shift+right")
+	if m.kanban.col != 1 {
+		t.Errorf("col after shift+right = %d, want 1", m.kanban.col)
+	}
+	doing := m.kanban.cols[1]
+	if len(doing.Cards) != 2 {
+		t.Errorf("Doing cards count = %d, want 2", len(doing.Cards))
+	}
+	if doing.Cards[len(doing.Cards)-1].Text != "A" {
+		t.Errorf("last Doing card = %q, want A", doing.Cards[len(doing.Cards)-1].Text)
+	}
+	// Source column should now be missing A.
+	for _, c := range m.kanban.cols[0].Cards {
+		if c.Text == "A" {
+			t.Errorf("A still in Todo column")
+		}
+	}
+}
+
+func TestKanbanShiftDownReorders(t *testing.T) {
+	m := newKanbanEditor(t)
+	m = pressKey(m, "shift+down")
+	if m.kanban.col != 0 || m.kanban.card != 1 {
+		t.Errorf("after shift+down: col=%d card=%d, want 0/1", m.kanban.col, m.kanban.card)
+	}
+	if m.kanban.cols[0].Cards[0].Text != "B" || m.kanban.cols[0].Cards[1].Text != "A" {
+		t.Errorf("reordered = %+v, want [B, A]", m.kanban.cols[0].Cards)
+	}
+}
+
+func TestKanbanPriorityCycle(t *testing.T) {
+	m := newKanbanEditor(t)
+	m = pressKey(m, "p")
+	if c := m.kanban.selectedCard(); c == nil || c.Priority != block.PriorityLow {
+		t.Errorf("after one p: priority = %v, want Low", c.Priority)
+	}
+	m = pressKey(m, "p")
+	m = pressKey(m, "p")
+	if c := m.kanban.selectedCard(); c == nil || c.Priority != block.PriorityHigh {
+		t.Errorf("after three p: priority = %v, want High", c.Priority)
+	}
+	m = pressKey(m, "p")
+	if c := m.kanban.selectedCard(); c == nil || c.Priority != block.PriorityNone {
+		t.Errorf("after four p: priority = %v, want None", c.Priority)
+	}
+}
+
+func TestKanbanAddCard(t *testing.T) {
+	m := newKanbanEditor(t)
+	before := len(m.kanban.cols[0].Cards)
+	m = pressKey(m, "n")
+	after := len(m.kanban.cols[0].Cards)
+	if after != before+1 {
+		t.Errorf("card count: %d → %d, want +1", before, after)
+	}
+	if !m.kanban.edit {
+		t.Errorf("addCard should enter edit mode")
+	}
+}
+
+func TestKanbanDeleteCard(t *testing.T) {
+	m := newKanbanEditor(t)
+	before := len(m.kanban.cols[0].Cards)
+	m = pressKey(m, "backspace")
+	after := len(m.kanban.cols[0].Cards)
+	if after != before-1 {
+		t.Errorf("card count: %d → %d, want -1", before, after)
+	}
+	// Selection should still be valid.
+	if c := m.kanban.selectedCard(); c == nil {
+		t.Errorf("selection invalid after delete")
+	}
+}
+
+func TestKanbanBackspaceOnEmptyColumnDeletesBoard(t *testing.T) {
+	// Non-empty kanban (Doing has only "C"). Navigate selection to the
+	// "Doing" column, delete C, leaving Doing empty. Pressing backspace
+	// again on the now-empty column should delete the whole kanban.
+	md := "para\n\n" + sampleKanbanMD
+	m := New(Config{Title: "k", Content: md, Save: func(string) error { return nil }})
+	out, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = out.(Model)
+	idx := firstKanban(m)
+	if idx < 0 {
+		t.Fatalf("no kanban parsed")
+	}
+	m.focusBlock(idx)
+	if m.kanban == nil {
+		t.Fatalf("kanban not initialized")
+	}
+	// Move to "Doing" column (col index 1) and delete its only card.
+	m = pressKey(m, "right")
+	if m.kanban.col != 1 {
+		t.Fatalf("expected col 1 after right, got %d", m.kanban.col)
+	}
+	m = pressKey(m, "backspace")
+	if c := m.kanban.selectedCard(); c != nil {
+		t.Fatalf("col should now be empty, got selection %+v", c)
+	}
+	beforeBlocks := len(m.blocks)
+	// Backspace on an empty column → delete the whole kanban.
+	m = pressKey(m, "backspace")
+	if len(m.blocks) != beforeBlocks-1 {
+		t.Errorf("blocks count: %d → %d, want -1", beforeBlocks, len(m.blocks))
+	}
+	if m.kanban != nil {
+		t.Errorf("kanban state should be cleared after empty-col backspace")
+	}
+	for _, b := range m.blocks {
+		if b.Type == block.Kanban {
+			t.Errorf("kanban block still present after empty-col backspace")
+		}
+	}
+}
+
+func TestKanbanEnterOnEmptyColumnInsertsParagraphBelow(t *testing.T) {
+	md := "para\n\n```kanban\n## Todo\n## Doing\n## Done\n```"
+	m := New(Config{Title: "k", Content: md, Save: func(string) error { return nil }})
+	out, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = out.(Model)
+	idx := firstKanban(m)
+	if idx < 0 {
+		t.Fatalf("no kanban parsed")
+	}
+	m.active = idx
+	if m.kanban == nil {
+		m.kanban = newKanbanState(m.blocks[idx].Content)
+	}
+	beforeBlocks := len(m.blocks)
+	m = pressKey(m, "enter")
+	if len(m.blocks) != beforeBlocks+1 {
+		t.Errorf("blocks count: %d → %d, want +1", beforeBlocks, len(m.blocks))
+	}
+	if m.active != idx+1 {
+		t.Errorf("active block = %d, want %d", m.active, idx+1)
+	}
+	if m.blocks[idx+1].Type != block.Paragraph {
+		t.Errorf("inserted block type = %v, want Paragraph", m.blocks[idx+1].Type)
+	}
+}
+
+func TestKanbanDownAtLastCardInsertsParagraphBelow(t *testing.T) {
+	// Single kanban block, navigate to last card, then down should insert a
+	// paragraph after.
+	md := "```kanban\n## Todo\n- only\n```"
+	m := New(Config{Title: "k", Content: md, Save: func(string) error { return nil }})
+	out, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = out.(Model)
+	idx := firstKanban(m)
+	if idx < 0 || m.kanban == nil {
+		t.Fatalf("kanban not initialized")
+	}
+	beforeBlocks := len(m.blocks)
+	m = pressKey(m, "down")
+	if len(m.blocks) != beforeBlocks+1 {
+		t.Errorf("blocks count: %d → %d, want +1", beforeBlocks, len(m.blocks))
+	}
+	if m.blocks[idx+1].Type != block.Paragraph {
+		t.Errorf("inserted block type = %v, want Paragraph", m.blocks[idx+1].Type)
+	}
+}
+
+func TestKanbanOffsetsShiftOnInsertAndDelete(t *testing.T) {
+	// Two paragraphs sandwiching a kanban; verify the kanban's saved
+	// horizontal scroll offset stays attached to the kanban after we
+	// insert a block before it (shifting indexes) and after we delete
+	// a block before it (shifting back).
+	md := "first\n\n" + sampleKanbanMD + "\n\nlast"
+	m := New(Config{Title: "k", Content: md, Save: func(string) error { return nil }})
+	out, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = out.(Model)
+	idx := firstKanban(m)
+	if idx < 1 {
+		t.Fatalf("expected paragraph before kanban")
+	}
+	m.focusBlock(idx)
+	m.kanban.colOffset = 2
+	m.kanbanOffsets = map[int]int{idx: 2}
+
+	// Insert a paragraph before the kanban; the kanban moves to idx+1
+	// and the offset map key should shift with it.
+	m.insertBlockBefore(idx, block.Block{Type: block.Paragraph})
+	if got, ok := m.kanbanOffsets[idx+1]; !ok || got != 2 {
+		t.Errorf("after insert: kanbanOffsets[%d] = (%d, %v), want (2, true). Map: %+v",
+			idx+1, got, ok, m.kanbanOffsets)
+	}
+
+	// Delete the paragraph we just inserted; offset should shift back.
+	m.deleteBlock(idx)
+	if got, ok := m.kanbanOffsets[idx]; !ok || got != 2 {
+		t.Errorf("after delete: kanbanOffsets[%d] = (%d, %v), want (2, true). Map: %+v",
+			idx, got, ok, m.kanbanOffsets)
+	}
+}
+
+func TestKanbanCancelEditAfterAddRestoresSelection(t *testing.T) {
+	// Backlog has "A" and "B". Select "A", press n (adds new card after
+	// A, enters edit), press Esc with no input. Selection should land
+	// back on A, not on B.
+	md := "```kanban\n## Todo\n- A\n- B\n```"
+	m := New(Config{Title: "k", Content: md, Save: func(string) error { return nil }})
+	out, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = out.(Model)
+	if m.kanban == nil {
+		t.Fatalf("kanban not initialized")
+	}
+	m.kanban.col = 0
+	m.kanban.card = 0 // on "A"
+	m = pressKey(m, "n")
+	if !m.kanban.edit {
+		t.Fatalf("n should enter edit mode")
+	}
+	if len(m.kanban.cols[0].Cards) != 3 {
+		t.Fatalf("addCard should add a card, got %d", len(m.kanban.cols[0].Cards))
+	}
+	m = pressKey(m, "esc")
+	if m.kanban.edit {
+		t.Errorf("esc should exit edit mode")
+	}
+	if len(m.kanban.cols[0].Cards) != 2 {
+		t.Errorf("esc on empty new card should drop it; got %d cards", len(m.kanban.cols[0].Cards))
+	}
+	// Selection should be back on "A" (index 0), not "B" (index 1).
+	if c := m.kanban.selectedCard(); c == nil || c.Text != "A" {
+		t.Errorf("selection after cancel = %+v, want A", c)
+	}
+}
+
+func TestKanbanSwallowsPlainPrintableKeys(t *testing.T) {
+	// In selection mode, typing a plain printable character (one with no
+	// modifier) must NOT mutate the underlying textarea — that would
+	// corrupt the kanban's serialized content via undo and silently
+	// discard the keystroke on next focusBlock.
+	m := newKanbanEditor(t)
+	idx := firstKanban(m)
+	beforeContent := m.blocks[idx].Content
+	beforeTAValue := m.textareas[idx].Value()
+	// Press a key that has no kanban handler (e.g. 'z' or '?').
+	m = pressKey(m, "z")
+	m = pressKey(m, "?")
+	if m.blocks[idx].Content != beforeContent {
+		t.Errorf("kanban block content changed: %q → %q", beforeContent, m.blocks[idx].Content)
+	}
+	if m.textareas[idx].Value() != beforeTAValue {
+		t.Errorf("kanban textarea was mutated by stray keys")
+	}
+}
+
+func TestKanbanUpAtTopFirstBlockInsertsCleanParagraph(t *testing.T) {
+	// Repro: kanban is the first (and only) block, user presses up.
+	// A paragraph should be inserted before, but the paragraph must be
+	// EMPTY — not contain the kanban's serialized content.
+	m := New(Config{Title: "k", Content: sampleKanbanMD, Save: func(string) error { return nil }})
+	out, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = out.(Model)
+	idx := firstKanban(m)
+	if idx != 0 {
+		t.Fatalf("expected kanban at index 0, got %d", idx)
+	}
+	// Move selection to the top-left card so up triggers exit-up.
+	if m.kanban == nil {
+		t.Fatalf("kanban not initialized")
+	}
+	m.kanban.col = 0
+	m.kanban.card = 0
+
+	beforeBlocks := len(m.blocks)
+	m = pressKey(m, "up")
+	if len(m.blocks) != beforeBlocks+1 {
+		t.Fatalf("blocks count: %d → %d, want +1", beforeBlocks, len(m.blocks))
+	}
+	if m.blocks[0].Type != block.Paragraph {
+		t.Errorf("inserted block type = %v, want Paragraph", m.blocks[0].Type)
+	}
+	if m.blocks[0].Content != "" {
+		t.Errorf("inserted paragraph should be empty, got %q", m.blocks[0].Content)
+	}
+	if m.blocks[1].Type != block.Kanban {
+		t.Errorf("kanban should now be at index 1, got %v", m.blocks[1].Type)
+	}
+	if !strings.Contains(m.blocks[1].Content, "## Todo") {
+		t.Errorf("kanban content corrupted: %q", m.blocks[1].Content)
+	}
+}
+
+func TestKanbanEntrySymmetric(t *testing.T) {
+	// Both entries should land in the leftmost non-empty column,
+	// only the card position differs (top → first, bottom → last).
+	md := "para above\n\n" + sampleKanbanMD + "\n\npara below"
+	m := New(Config{Title: "k", Content: md, Save: func(string) error { return nil }})
+	out, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = out.(Model)
+	idx := firstKanban(m)
+	if idx < 0 || idx == 0 || idx == len(m.blocks)-1 {
+		t.Fatalf("expected paragraphs on both sides of kanban, got idx=%d blocks=%d", idx, len(m.blocks))
+	}
+
+	// Enter from above: focus paragraph above, navigateDown.
+	m.focusBlock(idx - 1)
+	m.navigateDown()
+	if m.active != idx {
+		t.Fatalf("navigateDown active = %d, want %d", m.active, idx)
+	}
+	colTop, cardTop := m.kanban.col, m.kanban.card
+	if cardTop != 0 {
+		t.Errorf("entry from above card = %d, want 0", cardTop)
+	}
+
+	// Enter from below: focus paragraph below, navigateUp.
+	m.focusBlock(idx + 1)
+	m.navigateUp()
+	if m.active != idx {
+		t.Fatalf("navigateUp active = %d, want %d", m.active, idx)
+	}
+	colBot, cardBot := m.kanban.col, m.kanban.card
+	if colBot != colTop {
+		t.Errorf("inconsistent column on entry: top=%d bot=%d", colTop, colBot)
+	}
+	wantLast := len(m.kanban.cols[colBot].Cards) - 1
+	if cardBot != wantLast {
+		t.Errorf("entry from below card = %d, want %d (last)", cardBot, wantLast)
+	}
+}
+
+func TestKanbanDeletingBlockBelowKeepsBoardRendered(t *testing.T) {
+	// Repro: kanban followed by an empty paragraph. Focus paragraph,
+	// press backspace to delete it. After deletion, active is the kanban
+	// and m.kanban must be initialized so the board renders as a board,
+	// not collapsed to a single raw line.
+	md := sampleKanbanMD + "\n\n"
+	m := New(Config{Title: "k", Content: md, Save: func(string) error { return nil }})
+	out, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = out.(Model)
+	idx := firstKanban(m)
+	if idx < 0 {
+		t.Fatalf("no kanban parsed")
+	}
+	// Focus the paragraph after the kanban.
+	if idx+1 >= len(m.blocks) || m.blocks[idx+1].Type != block.Paragraph {
+		t.Fatalf("expected empty paragraph after kanban, got blocks: %+v", m.blocks)
+	}
+	m.focusBlock(idx + 1)
+	// Backspace on empty paragraph deletes it.
+	m = pressKey(m, "backspace")
+	if m.active != idx {
+		t.Fatalf("active = %d, want %d (kanban)", m.active, idx)
+	}
+	if m.kanban == nil {
+		t.Fatalf("kanban state should be initialized after delete-and-focus")
+	}
+	if len(m.kanban.cols) == 0 {
+		t.Errorf("kanban should have columns after re-focus")
+	}
+	// Ensure block content is intact.
+	if !strings.Contains(m.blocks[idx].Content, "## Todo") {
+		t.Errorf("kanban content corrupted: %q", m.blocks[idx].Content)
+	}
+}
+
+func TestKanbanParagraphBelowDoesNotMergeIntoBoard(t *testing.T) {
+	// Non-empty paragraph below the kanban: backspace at column 0 should
+	// NOT merge the paragraph text into the kanban content.
+	md := sampleKanbanMD + "\n\nhello"
+	m := New(Config{Title: "k", Content: md, Save: func(string) error { return nil }})
+	out, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = out.(Model)
+	idx := firstKanban(m)
+	if idx < 0 {
+		t.Fatalf("no kanban parsed")
+	}
+	// Find the "hello" paragraph after the kanban.
+	helloIdx := -1
+	for i := idx + 1; i < len(m.blocks); i++ {
+		if m.blocks[i].Type == block.Paragraph && m.blocks[i].Content == "hello" {
+			helloIdx = i
+			break
+		}
+	}
+	if helloIdx < 0 {
+		t.Fatalf("hello paragraph not found, blocks: %+v", m.blocks)
+	}
+	m.focusBlock(helloIdx)
+	// Move cursor to column 0 so backspace triggers the merge path.
+	m.textareas[m.active].SetCursorColumn(0)
+	beforeBlocks := len(m.blocks)
+	m = pressKey(m, "backspace")
+	// Block count should be unchanged — backspace at col 0 of a paragraph
+	// preceding a Kanban should be a no-op (not merge into kanban).
+	if len(m.blocks) > beforeBlocks {
+		t.Errorf("blocks count grew: %d → %d", beforeBlocks, len(m.blocks))
+	}
+	// Kanban content must remain intact (no merged paragraph text).
+	for _, b := range m.blocks {
+		if b.Type == block.Kanban {
+			if !strings.Contains(b.Content, "## Todo") {
+				t.Errorf("kanban content corrupted: %q", b.Content)
+			}
+			if strings.Contains(b.Content, "hello") {
+				t.Errorf("paragraph text leaked into kanban: %q", b.Content)
+			}
+		}
+	}
+}
+
+func TestKanbanBackspaceOnEmptyDeletesBlock(t *testing.T) {
+	// Build an editor where a paragraph precedes an empty kanban so
+	// that deleting the kanban has somewhere to focus back to.
+	md := "para text\n\n```kanban\n## Todo\n## Doing\n## Done\n```"
+	m := New(Config{Title: "k", Content: md, Save: func(string) error { return nil }})
+	out, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = out.(Model)
+	idx := firstKanban(m)
+	if idx < 0 {
+		t.Fatalf("no kanban parsed")
+	}
+	// Focus the kanban block.
+	m.active = idx
+	if m.kanban == nil {
+		// focusBlock initializes kanban; simulate by re-init.
+		m.kanban = newKanbanState(m.blocks[idx].Content)
+	}
+	if !m.kanban.isEmpty() {
+		t.Fatalf("expected empty board, got cards in some column")
+	}
+	before := len(m.blocks)
+	m = pressKey(m, "backspace")
+	if len(m.blocks) != before-1 {
+		t.Errorf("blocks count: %d → %d, want -1", before, len(m.blocks))
+	}
+	if m.kanban != nil {
+		t.Errorf("kanban state should be cleared after delete")
+	}
+}
+
+func TestKanbanRoundTripThroughEditor(t *testing.T) {
+	m := newKanbanEditor(t)
+	got := m.Content()
+	if !strings.Contains(got, "```kanban") || !strings.Contains(got, "## Todo") {
+		t.Errorf("Content() lost kanban structure:\n%s", got)
+	}
+}
+
+func TestKanbanContentReflectsMutation(t *testing.T) {
+	m := newKanbanEditor(t)
+	// Move A across to "Doing" and verify Content() shows the move.
+	m = pressKey(m, "shift+right")
+	out := m.Content()
+	doingSection := strings.SplitN(strings.SplitN(out, "## Doing\n", 2)[1], "## Done", 2)[0]
+	if !strings.Contains(doingSection, "- A") {
+		t.Errorf("Content() missing moved A in Doing:\n%s", doingSection)
+	}
+}
+
+func TestKanbanHorizontalScrollFollowsFocus(t *testing.T) {
+	// 4 columns, narrow terminal — only some columns should be visible
+	// at a time and the offset should slide as we navigate right.
+	mdLines := []string{"```kanban"}
+	for _, t := range []string{"Backlog", "Todo", "In Progress", "Done"} {
+		mdLines = append(mdLines, "## "+t, "- card")
+	}
+	mdLines = append(mdLines, "```")
+	md := strings.Join(mdLines, "\n")
+
+	m := New(Config{Title: "k", Content: md})
+	out, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 30})
+	m = out.(Model)
+
+	// Force a render so colOffset is computed.
+	idx := firstKanban(m)
+	_ = m.renderBlock(idx)
+
+	startOffset := m.kanban.colOffset
+
+	// Navigate right several times.
+	m = pressKey(m, "right")
+	m = pressKey(m, "right")
+	m = pressKey(m, "right") // last column
+	_ = m.renderBlock(idx)
+
+	if m.kanban.col != 3 {
+		t.Fatalf("col should be 3 after 3 rights, got %d", m.kanban.col)
+	}
+	if m.kanban.colOffset <= startOffset {
+		t.Errorf("colOffset should advance to keep focus visible: start=%d after=%d",
+			startOffset, m.kanban.colOffset)
+	}
+
+	// Navigate back to first.
+	m = pressKey(m, "left")
+	m = pressKey(m, "left")
+	m = pressKey(m, "left")
+	_ = m.renderBlock(idx)
+	if m.kanban.colOffset != 0 {
+		t.Errorf("colOffset should be 0 after returning to first column, got %d", m.kanban.colOffset)
+	}
+}
+
+func TestKanbanSortByPriority(t *testing.T) {
+	md := "```kanban\n## Todo\n- !! mid one\n- urgent later\n- !!! urgent first\n- ! low\n```"
+	m := New(Config{Title: "k", Content: md})
+	out, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = out.(Model)
+	if m.kanban == nil {
+		t.Fatalf("kanban not initialized")
+	}
+	// Toggle the sort.
+	m = pressKey(m, "s")
+	if !m.kanbanSortByPrio {
+		t.Fatalf("toggle should enable sort")
+	}
+	cards := m.kanban.cols[0].Cards
+	wantOrder := []block.Priority{block.PriorityHigh, block.PriorityMed, block.PriorityLow, block.PriorityNone}
+	for i, want := range wantOrder {
+		if cards[i].Priority != want {
+			t.Errorf("card %d priority = %v, want %v (texts: %q)", i, cards[i].Priority, want, cards[i].Text)
+		}
+	}
+}
+
+// TestKanbanRenderDoesNotPanic exercises the active and inactive render
+// paths to catch obvious layout / nil-deref bugs.
+func TestKanbanRenderDoesNotPanic(t *testing.T) {
+	m := newKanbanEditor(t)
+	idx := firstKanban(m)
+	_ = m.renderBlock(idx)
+	// Force inactive render of the same block by switching the active
+	// pointer somewhere else (simulate it).
+	m.active = -1
+	_ = m.renderBlock(idx)
+}

--- a/internal/editor/palette.go
+++ b/internal/editor/palette.go
@@ -79,6 +79,7 @@ var paletteItemDefs = []struct {
 	{"\u2610", "Checklist", block.Checklist},
 	{"``", "Code Block", block.CodeBlock},
 	{"\u229e", "Table", block.Table},
+	{"\u25a6", "Kanban", block.Kanban},
 	{">", "Quote", block.Quote},
 	{":", "Definition", block.DefinitionList},
 	{"!", "Callout", block.Callout},

--- a/internal/editor/render.go
+++ b/internal/editor/render.go
@@ -52,6 +52,36 @@ func resolveColor(color, fallback string) string {
 	return color
 }
 
+// priorityColor returns the theme color for a priority level.
+// HIGH → Error (red), MED → Warning (yellow), LOW → Muted (gray).
+func priorityColor(p block.Priority, th theme.Theme) string {
+	switch p {
+	case block.PriorityHigh:
+		return th.Error
+	case block.PriorityMed:
+		return th.Warning
+	case block.PriorityLow:
+		return th.Muted
+	default:
+		return ""
+	}
+}
+
+// renderPriorityBadge returns the colored priority badge, or "" for None.
+// Format: "[!!!] " (HIGH bold red), "[!!] " (MED yellow), "[!] " (LOW dim).
+// Trailing space included so it can be appended to a prefix directly.
+func renderPriorityBadge(p block.Priority, th theme.Theme) string {
+	if p == block.PriorityNone {
+		return ""
+	}
+	color := priorityColor(p, th)
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color(color))
+	if p == block.PriorityHigh {
+		style = style.Bold(true)
+	}
+	return style.Render(p.Marker()) + " "
+}
+
 // renderHeader builds the header bar displayed at the top of the editor.
 // It shows the title on the left and file path + size on the right.
 func (m Model) renderHeader() string {
@@ -134,7 +164,7 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 	th := theme.Current()
 
 	// Content width for this block type.
-	contentWidth := m.width - gutterWidth - blockPrefixWidth(b.Type, b.Indent)
+	contentWidth := m.width - gutterWidth - blockPrefixWidth(b)
 	if contentWidth < 1 {
 		contentWidth = 1
 	}
@@ -253,13 +283,14 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 	case block.Checklist:
 		bs := th.Blocks.Checklist
 		indent := listIndent(b)
+		badge := renderPriorityBadge(b.Priority, th)
 		if b.Checked {
 			checkedColor := resolveColor(bs.CheckedColor, th.Accent)
 			style := lipgloss.NewStyle().Foreground(lipgloss.Color(checkedColor))
 			if bs.CheckedBold {
 				style = style.Bold(true)
 			}
-			prefix := indent + style.Render(bs.Checked)
+			prefix := indent + style.Render(bs.Checked) + badge
 			text := taView
 			if bs.CheckedTextFaint {
 				text = styleAroundCursor(taView, lipgloss.NewStyle().Faint(true), cursorByteOffset, cursorLen, cursorVisIdx)
@@ -267,7 +298,7 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 			rendered = prefixFirstLine(prefix, text)
 		} else {
 			uncheckedColor := resolveColor(bs.UncheckedColor, th.Muted)
-			prefix := indent + lipgloss.NewStyle().Foreground(lipgloss.Color(uncheckedColor)).Render(bs.Unchecked)
+			prefix := indent + lipgloss.NewStyle().Foreground(lipgloss.Color(uncheckedColor)).Render(bs.Unchecked) + badge
 			rendered = prefixFirstLine(prefix, taView)
 		}
 
@@ -277,7 +308,7 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 		if !m.wordWrap {
 			// In no-wrap mode contentWidth is 1000; size the box border to
 			// the terminal instead so it doesn't overflow every line.
-			boxWidth = m.width - gutterWidth - blockPrefixWidth(b.Type, b.Indent)
+			boxWidth = m.width - gutterWidth - blockPrefixWidth(b)
 			if boxWidth < 10 {
 				boxWidth = 10
 			}
@@ -417,6 +448,9 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 		// Table rendering is handled entirely by renderActiveTableFull.
 		return m.renderActiveTableFull(idx, b)
 
+	case block.Kanban:
+		return m.renderActiveKanban(idx, b)
+
 	default:
 		rendered = taView
 	}
@@ -459,7 +493,7 @@ func (m Model) renderActiveBlock(idx int, b block.Block, _ string) string {
 			lines[i] = scrollOrTruncate(l, m.width, cursorCol, i == adjustedCursor)
 		}
 	} else {
-		cursorCol := gutterWidth + blockPrefixWidth(b.Type, b.Indent) + cursorColInWrap
+		cursorCol := gutterWidth + blockPrefixWidth(b) + cursorColInWrap
 		for i, l := range lines {
 			lines[i] = scrollOrTruncate(l, m.width, cursorCol, i == cursorVisIdx)
 		}
@@ -673,7 +707,7 @@ func highlightCode(code, language string) string {
 // renderInactiveBlock renders a block as styled static text (no cursor).
 func renderInactiveBlock(b block.Block, content string, width int, wordWrap bool, blocks []block.Block, idx int) string {
 	// Compute the available content width, matching the active block's calculation.
-	contentWidth := width - gutterWidth - blockPrefixWidth(b.Type, b.Indent)
+	contentWidth := width - gutterWidth - blockPrefixWidth(b)
 	if contentWidth < 1 {
 		contentWidth = 1
 	}
@@ -725,13 +759,14 @@ func renderInactiveBlock(b block.Block, content string, width int, wordWrap bool
 	case block.Checklist:
 		bs := th.Blocks.Checklist
 		indent := listIndent(b)
+		badge := renderPriorityBadge(b.Priority, th)
 		if b.Checked {
 			checkedColor := resolveColor(bs.CheckedColor, th.Accent)
 			style := lipgloss.NewStyle().Foreground(lipgloss.Color(checkedColor))
 			if bs.CheckedBold {
 				style = style.Bold(true)
 			}
-			prefix := indent + style.Render(bs.Checked)
+			prefix := indent + style.Render(bs.Checked) + badge
 			text := wrapped
 			if bs.CheckedTextFaint {
 				text = lipgloss.NewStyle().Faint(true).Render(wrapped)
@@ -739,7 +774,7 @@ func renderInactiveBlock(b block.Block, content string, width int, wordWrap bool
 			rendered = prefixFirstLine(prefix, text)
 		} else {
 			uncheckedColor := resolveColor(bs.UncheckedColor, th.Muted)
-			prefix := indent + lipgloss.NewStyle().Foreground(lipgloss.Color(uncheckedColor)).Render(bs.Unchecked)
+			prefix := indent + lipgloss.NewStyle().Foreground(lipgloss.Color(uncheckedColor)).Render(bs.Unchecked) + badge
 			rendered = prefixFirstLine(prefix, wrapped)
 		}
 
@@ -868,6 +903,13 @@ func renderInactiveBlock(b block.Block, content string, width int, wordWrap bool
 		}
 		rendered = renderTableGrid(content, tableWidth, th.Border, th.Blocks.Table.HeaderBold, wordWrap)
 
+	case block.Kanban:
+		boardWidth := width - gutterWidth
+		if boardWidth < 30 {
+			boardWidth = 30
+		}
+		rendered = renderInactiveKanbanBoard(content, boardWidth, 0, th)
+
 	default:
 		rendered = wrapped
 	}
@@ -900,9 +942,9 @@ func renderInactiveBlock(b block.Block, content string, width int, wordWrap bool
 
 // renderViewBlock renders a block for view mode: styled static text without
 // the gutter, centered in a constrained content column for clean reading.
-func renderViewBlock(b block.Block, content string, width int, wordWrap bool, blocks []block.Block, idx int, hovered bool) string {
+func renderViewBlock(b block.Block, content string, width int, wordWrap bool, blocks []block.Block, idx int, hovered bool, kanbanOffset int) string {
 	// Width here is the content column width (already constrained to viewMaxWidth).
-	contentWidth := width - blockPrefixWidth(b.Type, b.Indent)
+	contentWidth := width - blockPrefixWidth(b)
 	if contentWidth < 1 {
 		contentWidth = 1
 	}
@@ -951,13 +993,14 @@ func renderViewBlock(b block.Block, content string, width int, wordWrap bool, bl
 	case block.Checklist:
 		bs := th.Blocks.Checklist
 		indent := listIndent(b)
+		badge := renderPriorityBadge(b.Priority, th)
 		if b.Checked {
 			checkedColor := resolveColor(bs.CheckedColor, th.Accent)
 			style := lipgloss.NewStyle().Foreground(lipgloss.Color(checkedColor))
 			if bs.CheckedBold {
 				style = style.Bold(true)
 			}
-			prefix := indent + style.Render(bs.Checked)
+			prefix := indent + style.Render(bs.Checked) + badge
 			text := wrapped
 			if bs.CheckedTextFaint {
 				text = lipgloss.NewStyle().Faint(true).Render(wrapped)
@@ -968,7 +1011,7 @@ func renderViewBlock(b block.Block, content string, width int, wordWrap bool, bl
 			if hovered {
 				uncheckedColor = th.Accent
 			}
-			prefix := indent + lipgloss.NewStyle().Foreground(lipgloss.Color(uncheckedColor)).Render(bs.Unchecked)
+			prefix := indent + lipgloss.NewStyle().Foreground(lipgloss.Color(uncheckedColor)).Render(bs.Unchecked) + badge
 			rendered = prefixFirstLine(prefix, wrapped)
 		}
 
@@ -1079,6 +1122,9 @@ func renderViewBlock(b block.Block, content string, width int, wordWrap bool, bl
 
 	case block.Table:
 		rendered = renderTableGrid(content, contentWidth, th.Border, th.Blocks.Table.HeaderBold, true)
+
+	case block.Kanban:
+		rendered = renderInactiveKanbanBoard(content, contentWidth, kanbanOffset, th)
 
 	default:
 		rendered = wrapped

--- a/internal/editor/undo.go
+++ b/internal/editor/undo.go
@@ -58,6 +58,8 @@ func (m *Model) captureState() editorState {
 			ts := *m.table
 			ts.syncCell(m.textareas[m.active])
 			blocks[m.active].Content = ts.serialize()
+		} else if m.kanban != nil && m.blocks[m.active].Type == block.Kanban {
+			blocks[m.active].Content = m.kanban.serialize()
 		} else {
 			blocks[m.active].Content = m.textareas[m.active].Value()
 		}
@@ -107,6 +109,7 @@ func (m *Model) restoreState(state editorState) {
 	m.palette.close()
 	m.undoDirty = false
 	m.table = nil
+	m.kanban = nil
 	m.resizeTextareas()
 
 	// If active block is a Table, init table state.
@@ -115,6 +118,17 @@ func (m *Model) restoreState(state editorState) {
 		cw := m.tableCellTAWidth()
 		m.table.loadCell(&m.textareas[active], cw, false)
 		m.cursorCmd = m.textareas[active].Focus()
+	}
+	// If active block is a Kanban, init kanban state.
+	if active < len(m.blocks) && m.blocks[active].Type == block.Kanban {
+		m.kanban = newKanbanState(m.blocks[active].Content)
+		if m.kanbanOffsets != nil {
+			m.kanban.colOffset = m.kanbanOffsets[active]
+		}
+		if m.kanbanSortByPrio {
+			m.kanban.sortByPriority()
+		}
+		m.textareas[active].Blur()
 	}
 }
 
@@ -128,6 +142,8 @@ func (m *Model) performUndo() bool {
 		if m.table != nil && m.blocks[m.active].Type == block.Table {
 			m.table.syncCell(m.textareas[m.active])
 			m.blocks[m.active].Content = m.table.serialize()
+		} else if m.kanban != nil && m.blocks[m.active].Type == block.Kanban {
+			m.blocks[m.active].Content = m.kanban.serialize()
 		} else {
 			m.blocks[m.active].Content = m.textareas[m.active].Value()
 		}
@@ -147,6 +163,8 @@ func (m *Model) performRedo() bool {
 		if m.table != nil && m.blocks[m.active].Type == block.Table {
 			m.table.syncCell(m.textareas[m.active])
 			m.blocks[m.active].Content = m.table.serialize()
+		} else if m.kanban != nil && m.blocks[m.active].Type == block.Kanban {
+			m.blocks[m.active].Content = m.kanban.serialize()
 		} else {
 			m.blocks[m.active].Content = m.textareas[m.active].Value()
 		}

--- a/internal/format/inline.go
+++ b/internal/format/inline.go
@@ -17,13 +17,59 @@ const (
 	strikethroughOff = "\x1b[29m"
 )
 
+// StripControlChars removes C0 (0x00–0x1F except \n \r \t) and DEL (0x7F)
+// from the input. This defangs terminal escape injection (OSC title
+// rewrites, DCS, palette resets, hyperlinks) — all of which start with
+// ESC (0x1B) on modern terminals — coming from untrusted markdown
+// bodies before the renderer composes its own SGR codes around the text.
+//
+// Operates byte-by-byte so 0x80–0xBF UTF-8 continuation bytes pass through
+// untouched. Bare 8-bit C1 controls are not stripped.
+func StripControlChars(s string) string {
+	if !needsStrip(s) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c == '\n' || c == '\r' || c == '\t':
+			b.WriteByte(c)
+		case c < 0x20 || c == 0x7F:
+			// drop C0 + DEL
+		default:
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
+}
+
+func needsStrip(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '\n' || c == '\r' || c == '\t' {
+			continue
+		}
+		if c < 0x20 || c == 0x7F {
+			return true
+		}
+	}
+	return false
+}
+
 // RenderInlineMarkdown applies inline markdown formatting to plain text.
 // Supports **bold**, *italic*, ~~strikethrough~~, and __underline__ with
 // correct nesting. Uses targeted ANSI SGR codes (not full resets) so that
 // outer block-level styles (e.g. heading bold) are preserved. Delimiter
 // pairs may span newlines — useful when the caller has already
 // word-wrapped text, which can split a **foo bar** marker across lines.
+//
+// Control characters (C0/C1) in the input are stripped first to defang
+// terminal escape injection from untrusted markdown content (e.g. a
+// pasted card body containing OSC sequences that retitle the terminal).
 func RenderInlineMarkdown(text string) string {
+	text = StripControlChars(text)
 	runes := []rune(text)
 	n := len(runes)
 	if n == 0 {
@@ -101,7 +147,7 @@ func RenderInlineMarkdown(text string) string {
 type delimKind int
 
 const (
-	delimBold          delimKind = iota
+	delimBold delimKind = iota
 	delimItalic
 	delimStrikethrough
 	delimUnderline

--- a/internal/format/inline_test.go
+++ b/internal/format/inline_test.go
@@ -200,6 +200,40 @@ func TestRenderInlineMarkdown_ItalicWithStrikethrough(t *testing.T) {
 	}
 }
 
+func TestStripControlChars(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "hello world", "hello world"},
+		{"keeps newline tab CR", "a\nb\tc\rd", "a\nb\tc\rd"},
+		{"strips ESC and BEL", "title\x1b]0;EVIL\x07rest", "title]0;EVILrest"},
+		{"strips C0", "\x01\x02hello\x03", "hello"},
+		{"strips DEL", "abc\x7fdef", "abcdef"},
+		{"keeps utf8 multibyte", "héllo", "héllo"},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		got := StripControlChars(tc.in)
+		if got != tc.want {
+			t.Errorf("%s: StripControlChars(%q) = %q, want %q", tc.name, tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRenderInlineMarkdown_StripsControlChars(t *testing.T) {
+	// An OSC sequence in untrusted card text must not pass through.
+	in := "card\x1b]0;EVIL\x07text"
+	got := RenderInlineMarkdown(in)
+	if strings.Contains(got, "\x1b]") {
+		t.Errorf("output should not contain OSC introducer: %q", got)
+	}
+	if strings.Contains(got, "\x07") {
+		t.Errorf("output should not contain BEL: %q", got)
+	}
+}
+
 func TestRenderInlineMarkdown_NoFullReset(t *testing.T) {
 	// The key property: output must never contain \x1b[0m (full reset)
 	// which would kill outer block-level styles like heading bold.


### PR DESCRIPTION
## Summary

- Adds a visual kanban board block type to the markdown editor.
- Round-trips as a `` ```kanban`` ` fenced block so notes stay portable.
- Four default columns (Backlog / Todo / In Progress / Done); "Done" derives from column title.
- Per-card priority cycle (`p`), auto-sort toggle (`s`), inline markdown in cards.
- Symmetric top/bottom entry into the board (leftmost non-empty column, like tables).
- Enter on a card → edit; Enter on empty column → escape to a paragraph below the board.
- Backspace deletes a card; on an empty column it deletes the whole board.
- Horizontal sliding-window column scroll with ◀ / ▶ indicators in both edit and view mode.
- Sanitizes column titles + card text against ANSI/OSC injection from untrusted markdown.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` — all 10 packages green (23 kanban tests)
- [x] Round-trip `Parse(Serialize(x)) == x` for sample boards including multi-line and priority-tagged cards
- [x] Block-deletion / insertion adjacent to a kanban does not corrupt content (regression tests)
- [x] Up at first card / first block inserts an empty paragraph before (does not leak serialized kanban into it)
- [x] Down at last card / last block inserts a paragraph after
- [x] Stray printable keystrokes in selection mode do not mutate the underlying textarea (undo stack stays clean)
- [x] `kanbanOffsets` map keys remap on insert/delete so saved scroll positions stay attached
- [x] `cancelEdit` after `addCard` restores prior selection
- [x] Empty cards drop on save (no `- !!` round-trip data loss)
- [x] `format.StripControlChars` strips ESC / BEL / DEL while preserving \\n \\r \\t and UTF-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)