### PR TITLE
fix: route bracketed-paste to active text widget

### DIFF
--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -1816,6 +1816,32 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case tea.PasteMsg:
+		// Bracketed-paste content. Route to whatever text widget is
+		// currently accepting input so multi-line clipboards land in
+		// one shot instead of being swallowed.
+		if m.viewMode || m.showHelp || m.quitPrompt || m.palette.Visible ||
+			m.embedPicker.Visible || m.embedModal.visible || m.defLookup.Visible ||
+			m.defPreview.visible {
+			return m, nil
+		}
+		if m.kanban != nil && m.kanban.edit {
+			var c tea.Cmd
+			m.kanban.editTA, c = m.kanban.editTA.Update(msg)
+			m.kanban.editTA.SetHeight(m.kanban.editTA.VisualLineCount())
+			m.updateViewport()
+			return m, c
+		}
+		if m.active >= 0 && m.active < len(m.textareas) {
+			m.pushUndo()
+			var c tea.Cmd
+			m.textareas[m.active], c = m.textareas[m.active].Update(msg)
+			m.textareas[m.active].SetHeight(m.textareas[m.active].VisualLineCount())
+			m.updateViewport()
+			return m, c
+		}
+		return m, nil
+
 	case tea.KeyPressMsg:
 		// When help overlay is showing, Ctrl+G/Esc close it, Ctrl+C quits.
 		if m.showHelp {

--- a/internal/editor/kanban_test.go
+++ b/internal/editor/kanban_test.go
@@ -358,6 +358,30 @@ func TestKanbanCancelEditAfterAddRestoresSelection(t *testing.T) {
 	}
 }
 
+func TestKanbanPasteIntoCardEdit(t *testing.T) {
+	// Bracketed-paste arrives as tea.PasteMsg. While editing a card,
+	// the pasted content must land in the card's editTA, not be dropped.
+	m := newKanbanEditor(t)
+	m.kanban.col = 0
+	m.kanban.card = 0
+	m = pressKey(m, "enter") // enter edit mode
+	if !m.kanban.edit {
+		t.Fatalf("enter should put us in edit mode")
+	}
+	// Send a paste message.
+	out, _ := m.Update(tea.PasteMsg{Content: "PASTED"})
+	m = out.(Model)
+	got := m.kanban.editTA.Value()
+	if !strings.Contains(got, "PASTED") {
+		t.Errorf("paste content not in editTA: %q", got)
+	}
+	// Commit and verify the card text picked up the paste.
+	m = pressKey(m, "enter")
+	if c := m.kanban.selectedCard(); c == nil || !strings.Contains(c.Text, "PASTED") {
+		t.Errorf("after commit, card text = %+v, want it to contain PASTED", c)
+	}
+}
+
 func TestKanbanSwallowsPlainPrintableKeys(t *testing.T) {
 	// In selection mode, typing a plain printable character (one with no
 	// modifier) must NOT mutate the underlying textarea — that would


### PR DESCRIPTION
## Summary

- Pasting inside a kanban card editor silently dropped the content because the editor's update switch only handled `tea.KeyPressMsg` — bracketed paste arrives as `tea.PasteMsg`.
- Add a `tea.PasteMsg` case that routes to the kanban editTA when in card-edit mode, otherwise to the active block's textarea.
- Modal / view-mode / palette states swallow the paste (no accidental text injection into pickers).

## Test plan

- [x] New `TestKanbanPasteIntoCardEdit` asserts pasted content lands in the card on commit
- [x] `go test ./...` — all packages green

🤖 Generated with [Claude Code](https://claude.com/claude-code)