### PR TITLE
fix: block manual reorder while kanban auto-sort is on

### DIFF
--- a/internal/editor/kanban.go
+++ b/internal/editor/kanban.go
@@ -880,19 +880,43 @@ func (m *Model) handleKanbanKey(msg tea.KeyPressMsg) (handled bool, cmd tea.Cmd)
 	case "shift+left":
 		m.pushUndo()
 		m.kanban.moveCard(-1, 0)
+		// Cross-column move: the destination column may need re-sorting
+		// when auto-sort is on. Within-column moves don't reorder via
+		// this branch (dCol != 0), but we sort defensively for parity
+		// with shift+up/down so the post-state is always consistent.
+		if m.kanbanSortByPrio {
+			m.kanban.sortByPriority()
+		}
 		m.kanbanAnchorTop = true
 		return true, nil
 	case "shift+right":
 		m.pushUndo()
 		m.kanban.moveCard(1, 0)
+		if m.kanbanSortByPrio {
+			m.kanban.sortByPriority()
+		}
 		m.kanbanAnchorTop = true
 		return true, nil
 	case "shift+up":
+		// Within-column reorder. When auto-sort is on, manual reordering
+		// is meaningless — the sort will run after and undo the move.
+		// Block the move with a status hint so the list doesn't appear
+		// to "snap back" mysteriously.
+		if m.kanbanSortByPrio {
+			m.status = "Manual reorder disabled while sort by priority is on (s to toggle)"
+			m.statusStyle = statusWarning
+			return true, m.scheduleStatusDismiss()
+		}
 		m.pushUndo()
 		m.kanban.moveCard(0, -1)
 		m.kanbanAnchorTop = true
 		return true, nil
 	case "shift+down":
+		if m.kanbanSortByPrio {
+			m.status = "Manual reorder disabled while sort by priority is on (s to toggle)"
+			m.statusStyle = statusWarning
+			return true, m.scheduleStatusDismiss()
+		}
 		m.pushUndo()
 		m.kanban.moveCard(0, 1)
 		m.kanbanAnchorTop = true

--- a/internal/editor/kanban_test.go
+++ b/internal/editor/kanban_test.go
@@ -358,6 +358,42 @@ func TestKanbanCancelEditAfterAddRestoresSelection(t *testing.T) {
 	}
 }
 
+func TestKanbanShiftUpDownBlockedWhileAutoSort(t *testing.T) {
+	// When auto-sort is on, manual within-column reorder is blocked
+	// so the list doesn't appear to snap back mysteriously after the
+	// next sort runs.
+	md := "```kanban\n## Todo\n- !!! high\n- ! low\n- !! mid\n```"
+	m := New(Config{Title: "k", Content: md, Save: func(string) error { return nil }})
+	out, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = out.(Model)
+	if m.kanban == nil {
+		t.Fatalf("kanban not initialized")
+	}
+	// Turn on sort.
+	m = pressKey(m, "s")
+	if !m.kanbanSortByPrio {
+		t.Fatalf("s should enable sort")
+	}
+	// After sort, order is high, mid, low. Select first card (high).
+	if c := m.kanban.cols[0].Cards[0]; c.Priority != block.PriorityHigh {
+		t.Fatalf("first card should be high after sort, got %v", c.Priority)
+	}
+	beforeOrder := []block.Priority{}
+	for _, c := range m.kanban.cols[0].Cards {
+		beforeOrder = append(beforeOrder, c.Priority)
+	}
+	// Try shift+down — should be a no-op (status hint set instead).
+	m = pressKey(m, "shift+down")
+	for i, c := range m.kanban.cols[0].Cards {
+		if c.Priority != beforeOrder[i] {
+			t.Errorf("shift+down should be blocked while sort on; order changed at %d", i)
+		}
+	}
+	if m.status == "" {
+		t.Errorf("expected a status hint explaining the block")
+	}
+}
+
 func TestKanbanPasteIntoCardEdit(t *testing.T) {
 	// Bracketed-paste arrives as tea.PasteMsg. While editing a card,
 	// the pasted content must land in the card's editTA, not be dropped.


### PR DESCRIPTION
## Summary

- When auto-sort by priority is on, manual within-column reorder (`shift+up` / `shift+down`) was happening transiently and then getting silently undone by the next sort pass triggered by `n`/`p`. From the user's POV, the list "snapped" at unpredictable times.
- Now: while sort is on, `shift+up` / `shift+down` are blocked with a status hint pointing at `s` to toggle. Cross-column moves still work and re-run the sort on the destination column.

## Test plan

- [x] New `TestKanbanShiftUpDownBlockedWhileAutoSort` asserts within-column moves are no-ops while sort is on
- [x] Existing tests for sort and move still pass (25 kanban tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)