### PR TITLE
docs: note recorded version under hero gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Notebook is a TUI note manager that organizes markdown notes into notebooks. It 
 Everything runs in your terminal. No account, no sync, no config required.
 <p align="center">
   <img src="assets/hero.gif" alt="notebook demo" width="1010">
+  <br>
+  <sub><i>Recorded on v1.0.0</i></sub>
 </p>
 
 ## Install


### PR DESCRIPTION
## Summary

- Adds a small `<sub><i>Recorded on v1.0.0</i></sub>` subtitle under the hero gif so readers know which release the demo was captured against.
- v1.0.0 was the only release tagged on 2026-04-05, the day the gif's most recent rebuild landed.

## Test plan

- [x] README renders with the subtitle directly under the centered hero image

🤖 Generated with [Claude Code](https://claude.com/claude-code)