### PR TITLE
docs: move hero gif above intro paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,15 @@
 
 ---
 
-Notebook is a TUI note manager that organizes markdown notes into notebooks. It comes with a block editor supporting 14 block types, an interactive browser with search, 16 themes, inline markdown formatting, undo/redo, and a view mode for reading.
-
-Everything runs in your terminal. No account, no sync, no config required.
 <p align="center">
   <img src="assets/hero.gif" alt="notebook demo" width="1010">
   <br>
   <sub><i>Recorded on v1.0.0</i></sub>
 </p>
+
+Notebook is a TUI note manager that organizes markdown notes into notebooks. It comes with a block editor supporting 14 block types, an interactive browser with search, 16 themes, inline markdown formatting, undo/redo, and a view mode for reading.
+
+Everything runs in your terminal. No account, no sync, no config required.
 
 ## Install
 


### PR DESCRIPTION
## Summary

- Lead with the hero gif so readers see the demo before the prose.

## Test plan

- [x] README renders with the gif appearing immediately under the divider, intro paragraph below it

🤖 Generated with [Claude Code](https://claude.com/claude-code)