### PR TITLE
docs: sync README/AGENTS with kanban block + test count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # notebook-cli
 
-Terminal-native note manager with a block-based editor supporting 14 block types, interactive browser, 16 themes, and search. Notes are plain markdown files on disk.
+Terminal-native note manager with a block-based editor supporting 15 block types, interactive browser, 16 themes, and search. Notes are plain markdown files on disk.
 
 ## Tech Stack
 
@@ -16,7 +16,7 @@ Terminal-native note manager with a block-based editor supporting 14 block types
 ```bash
 go install ./cmd/notebook/    # Install as "notebook" binary
 go run ./cmd/notebook/        # Run from source
-go test ./...                 # Test (649 tests across 13 packages)
+go test ./...                 # Test (711 tests across 13 packages)
 go vet ./...                  # Lint
 ```
 
@@ -48,7 +48,7 @@ assets/        Icons and media for README
 - **CLI pattern**: `notebook [book] [note] [verb]` — bare commands do useful things (`notebook` opens TUI, `notebook ideas` scopes to a book, `notebook ideas "My Note"` opens the editor)
 - **Auto-creation**: targeting a non-existent notebook creates it silently
 - **Plain markdown**: notes are `.md` files, no proprietary format, readable outside the app
-- **Block editor**: 14 block types (paragraph, h1-h3, bullet, numbered, checklist, code, table, quote, definition, callout, divider, embed). `/` at start of block opens command palette
+- **Block editor**: 15 block types (paragraph, h1-h3, bullet, numbered, checklist, code, table, quote, definition, callout, divider, embed, kanban). `/` at start of block opens command palette
 - **Search**: `/` in browser searches notebook names (L0) and note titles (L0 Notes section, L1). Title-only, synchronous, lazy-loaded note name cache
 - **Themes**: 16 built-in, selectable via `t` in browser or `notebook theme <name>` CLI
 - **Settings**: `,` in browser opens settings screen for storage, theme, date format, word wrap, etc.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
   <sub><i>Recorded on v1.0.0</i></sub>
 </p>
 
-Notebook is a TUI note manager that organizes markdown notes into notebooks. It comes with a block editor supporting 14 block types, an interactive browser with search, 16 themes, inline markdown formatting, undo/redo, and a view mode for reading.
+Notebook is a TUI note manager that organizes markdown notes into notebooks. It comes with a block editor supporting 15 block types, an interactive browser with search, 16 themes, inline markdown formatting, undo/redo, and a view mode for reading.
 
 Everything runs in your terminal. No account, no sync, no config required.
 
@@ -72,8 +72,9 @@ notebook path/to/file.md
 
 ## Features
 
-- **Block editor** — 14 block types: paragraphs, headings (3 levels), bullet lists, numbered lists, checklists, code blocks, tables, quotes, definitions, callouts, dividers, and embeds. Press **/** to switch types.
+- **Block editor** — 15 block types: paragraphs, headings (3 levels), bullet lists, numbered lists, checklists, code blocks, tables, quotes, definitions, callouts, dividers, embeds, and kanban boards. Press **/** to switch types.
 - **Tables** — Pipe-delimited GFM tables with per-column widths. Alt+R/C to add rows/columns, Alt+Shift+Backspace/Alt+Shift+D to delete. Press Enter on an empty row to exit the table and drop the row.
+- **Kanban boards** — Visual boards with priority cards. Arrows navigate, Shift+arrows move cards, **n** new card, **p** cycle priority, **s** toggle auto-sort. Round-trips as a `kanban` fenced block.
 - **Callouts** — Five admonition variants (Note, Tip, Important, Warning, Caution). Ctrl+T to cycle.
 - **Definitions** — Term/definition pairs. Press **:** to search and jump to definitions.
 - **Embeds** — Reference other notes inline with `![[notebook/note]]`. Click in view mode to expand.


### PR DESCRIPTION
## Summary
- Bump documented block-type count from 14 → 15 (kanban added in #224)
- Add a kanban feature line to README with the navigation/edit shortcuts
- Update AGENTS.md test count 649 → 711 to match `go test ./... -v`

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)